### PR TITLE
Increase the container width of the CU pages

### DIFF
--- a/pages/core-unit/[code]/finances/index.tsx
+++ b/pages/core-unit/[code]/finances/index.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const Finances = () => {
-  return <h1>Here go finances overview</h1>;
-};
-
-export default Finances;

--- a/src/stories/components/core-unit-summary/core-unit-summary.tsx
+++ b/src/stories/components/core-unit-summary/core-unit-summary.tsx
@@ -207,18 +207,14 @@ const ContainerTitle = styled.div<{ hiddenTextDescription: boolean }>(({ hiddenT
   flexDirection: 'column',
   width: '100%',
   height: 'fit-content',
-
   transition: 'all .3s ease',
   paddingTop: '8px',
+
   [lightTheme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
     paddingLeft: '48px',
     paddingRight: '48px',
   },
-  [lightTheme.breakpoints.between('desktop_1194', 'desktop_1280')]: {
-    paddingLeft: '27px',
-    paddingRight: '27px',
-  },
-  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
+  [lightTheme.breakpoints.between('table_834', 'desktop_1280')]: {
     paddingLeft: '32px',
     paddingRight: '32px',
   },
@@ -243,10 +239,10 @@ const Wrapper = styled.div({
   flexDirection: 'column',
   alignItems: 'center',
   width: '100%',
-  maxWidth: '1184px',
+  maxWidth: '100%',
   margin: '0 auto',
-  [lightTheme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
-    maxWidth: '100%',
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    maxWidth: '1312px',
   },
 });
 

--- a/src/stories/containers/cu-about-2/cu-about-container-2.tsx
+++ b/src/stories/containers/cu-about-2/cu-about-container-2.tsx
@@ -364,8 +364,8 @@ const ContainerAllData = styled.div({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
-  marginRight: '128px',
-  marginLeft: '128px',
+  marginRight: '64px',
+  marginLeft: '64px',
   [lightTheme.breakpoints.up('desktop_1920')]: {
     marginRight: '0px',
     marginLeft: '0px',
@@ -374,19 +374,11 @@ const ContainerAllData = styled.div({
     marginRight: '48px',
     marginLeft: '48px',
   },
-  [lightTheme.breakpoints.between('desktop_1194', 'desktop_1280')]: {
+  [lightTheme.breakpoints.between('table_834', 'desktop_1280')]: {
     marginRight: '32px',
     marginLeft: '32px',
   },
-  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    marginRight: '32px',
-    marginLeft: '32px',
-  },
-  [lightTheme.breakpoints.between('table_375', 'table_834')]: {
-    marginRight: '16px',
-    marginLeft: '16px',
-  },
-  [lightTheme.breakpoints.down('table_375')]: {
+  [lightTheme.breakpoints.down('table_834')]: {
     marginRight: '16px',
     marginLeft: '16px',
   },
@@ -412,8 +404,9 @@ const Wrapper = styled.div({
   width: '100%',
   maxWidth: '1440px',
   margin: '0 auto',
+
   [lightTheme.breakpoints.up('desktop_1920')]: {
-    maxWidth: '1184px',
+    maxWidth: '1312px',
     marginLeft: '0px',
     marginRight: '0px',
     margin: '0 auto',
@@ -431,13 +424,7 @@ const ContainerResponsive = styled.div({
   width: '60.39%',
   display: 'flex',
   flexDirection: 'column',
-  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    width: '100%',
-  },
-  [lightTheme.breakpoints.between('table_375', 'table_834')]: {
-    width: '100%',
-  },
-  [lightTheme.breakpoints.down('table_375')]: {
+  [lightTheme.breakpoints.down('desktop_1194')]: {
     width: '100%',
   },
 });

--- a/src/stories/containers/cu-activity/cu-activity.tsx
+++ b/src/stories/containers/cu-activity/cu-activity.tsx
@@ -78,22 +78,42 @@ const Container = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   backgroundImage: isLight ? 'url(/assets/img/bg-page.png)' : 'url(/assets/img/bg-page-dark.png)',
   backgroundAttachment: 'fixed',
   backgroundSize: 'cover',
-  padding: '0 16px 79px',
+  paddingBottom: '79px',
 
   [lightTheme.breakpoints.up('table_834')]: {
-    padding: '0 32px 128px',
+    paddingBottom: '128px',
   },
 }));
 
 const InnerPage = styled.div({
   display: 'block',
-  margin: '24px auto 0',
-  width: '100%',
-  maxWidth: '1184px',
   textAlign: 'left',
+  width: '100%',
+  maxWidth: '1440px',
+  margin: '0 auto',
+  paddingTop: 24,
+  paddingRight: '64px',
+  paddingLeft: '64px',
 
+  [lightTheme.breakpoints.up('desktop_1920')]: {
+    maxWidth: '1312px',
+    paddingRight: '0px',
+    paddingLeft: '0px',
+  },
+  [lightTheme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
+    paddingRight: '48px',
+    paddingLeft: '48px',
+  },
+  [lightTheme.breakpoints.between('table_834', 'desktop_1280')]: {
+    paddingRight: '32px',
+    paddingLeft: '32px',
+  },
   [lightTheme.breakpoints.up('table_834')]: {
-    marginTop: '32px',
+    paddingTop: 32,
+  },
+  [lightTheme.breakpoints.down('table_834')]: {
+    paddingRight: '16px',
+    paddingLeft: '16px',
   },
 });
 

--- a/src/stories/containers/transparency-report/transparency-report.tsx
+++ b/src/stories/containers/transparency-report/transparency-report.tsx
@@ -238,10 +238,6 @@ const Container = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   backgroundImage: isLight ? 'url(/assets/img/bg-page.png)' : 'url(/assets/img/bg-page-dark.png)',
   backgroundAttachment: 'fixed',
   backgroundSize: 'cover',
-  padding: '0 16px 128px',
-  '@media (min-width: 834px)': {
-    padding: '0 32px 128px',
-  },
 }));
 
 const Wrapper = styled.div({
@@ -252,10 +248,33 @@ const Wrapper = styled.div({
 
 const InnerPage = styled.div({
   display: 'block',
-  margin: '32px auto 0',
-  width: '100%',
-  maxWidth: '1184px',
   textAlign: 'left',
+  width: '100%',
+  maxWidth: '1440px',
+  margin: '0 auto',
+  paddingRight: '64px',
+  paddingLeft: '64px',
+
+  [lightTheme.breakpoints.up('desktop_1920')]: {
+    maxWidth: '1312px',
+    paddingRight: '0px',
+    paddingLeft: '0px',
+  },
+  [lightTheme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
+    paddingRight: '48px',
+    paddingLeft: '48px',
+  },
+  [lightTheme.breakpoints.between('table_834', 'desktop_1280')]: {
+    paddingRight: '32px',
+    paddingLeft: '32px',
+  },
+  [lightTheme.breakpoints.up('table_834')]: {
+    paddingTop: 32,
+  },
+  [lightTheme.breakpoints.down('table_834')]: {
+    paddingRight: '16px',
+    paddingLeft: '16px',
+  },
 });
 
 export const Title = styled.div<{


### PR DESCRIPTION
## Ticket
https://trello.com/c/CrTkQJV6/203-feature-coreunitfinancestransparency-v4

## Description
The container width of the following pages was increased (according to the design):
- CU About
- CU Transparency Report
- CU Activity

Now, the container width is:
Resolution -> width (pixels)
1920 -> 1312
1440 -> 1312
1280 -> 1184
1194 -> 1130
834  -> 770
375  -> 343  