### PR TITLE
Fix: CU moving back when changing the budget month

### DIFF
--- a/src/stories/containers/transparency-report/transparency-report.mvvm.ts
+++ b/src/stories/containers/transparency-report/transparency-report.mvvm.ts
@@ -128,7 +128,7 @@ export const useTransparencyReportViewModel = (coreUnit: CoreUnitDto) => {
       replaceViewMonthRoute(month.toFormat('LLLyyyy'));
       setCurrentMonth(month);
     }
-  }, [setCurrentMonth, currentMonth]);
+  }, [setCurrentMonth, currentMonth, router]);
 
   const hasNextMonth = () => {
     const limit = getLastMonthWithActualOrForecast(coreUnit?.budgetStatements).plus({
@@ -143,7 +143,7 @@ export const useTransparencyReportViewModel = (coreUnit: CoreUnitDto) => {
       replaceViewMonthRoute(month.toFormat('LLLyyyy'));
       setCurrentMonth(month);
     }
-  }, [setCurrentMonth, currentMonth]);
+  }, [setCurrentMonth, currentMonth, router]);
 
   const prepareWalletsName = (budgetStatement?: BudgetStatementDto) => {
     const walletNames = new Map<string, number>();


### PR DESCRIPTION
## Ticket
[No ticket]

## Description 
Fixed issue in the CU report tabs when changing tabs, the CU was moving to the previous CU