### PR TITLE
[SES-225] Activity feed linking

### DIFF
--- a/src/stories/components/cu-activity-table/cu-activity-item.tsx
+++ b/src/stories/components/cu-activity-table/cu-activity-item.tsx
@@ -26,7 +26,7 @@ export default function CUActivityItem({ activity, isNew }: CUActivityItemProps)
 
   const detailsUrl = useMemo(() => {
     let anchor = '';
-    if (['CU_BUDGET_STATEMENT_COMMENT', 'CU_BUDGET_STATEMENT_CREATED'].includes(activity.activityFeed.event)) {
+    if (activity.activityFeed.event === 'CU_BUDGET_STATEMENT_COMMENT') {
       anchor = '#comments';
     }
     return `/core-unit/${


### PR DESCRIPTION
## Ticket
https://trello.com/c/fnTy5yik/225-feature-coreunitfinancestransparencyreporting-v5

## Description
In the Activity Feed, only the commenting and auditing-related activities should link to the commenting tab.
Technical names:
- CU_BUDGET_STATEMENT_CREATED and CU_BUDGET_STATEMENT_UPDATED
  - should navigate to the Actuals tab of the correct month's expense report
- CU_BUDGET_STATEMENT_COMMENT
  - should navigate to the Comments tab of the correct month's expense report
