### PR TITLE
[SES-QA-231] Disable comments form when there is not budget statement

### DIFF
--- a/src/stories/containers/transparency-report/transparency-auditor-comments/comment-container/auditor-comments-container.tsx
+++ b/src/stories/containers/transparency-report/transparency-auditor-comments/comment-container/auditor-comments-container.tsx
@@ -26,7 +26,7 @@ const AuditorCommentsContainer: React.FC<AuditorCommentsContainerProps> = ({ bud
   return (
     <Container>
       <CommentsContainer>
-        {comments.length === 0 && !canComment ? (
+        {!budgetStatement || (comments.length === 0 && !canComment) ? (
           <NoComments />
         ) : (
           <>


### PR DESCRIPTION
## Ticket
https://trello.com/c/YANCMcmX/231-qa-bug-findings-v-60

## Description
Disable the option to comment when there are no budget statement available to prevent errors