### PR TITLE
[SES-233] Dedicated Finances section as homepage

### DIFF
--- a/pages/core-units.tsx
+++ b/pages/core-units.tsx
@@ -1,0 +1,16 @@
+import { CuTable } from '@ses/containers/cu-table/cu-table';
+import { CuTable2 } from '@ses/containers/cu-table/cu-table-2';
+import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
+import React from 'react';
+import type { NextPage } from 'next';
+
+const CuTablePage: NextPage = () => {
+  const [isEnabled] = useFlagsActive();
+
+  return isEnabled('FEATURE_CU_INDEX_NEW_TABLE') ? <CuTable2 /> : <CuTable />;
+};
+export async function getServerSideProps() {
+  return { props: {} };
+}
+
+export default CuTablePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,16 +1,9 @@
 import React from 'react';
-import { useFlagsActive } from '../src/core/hooks/useFlagsActive';
-import { CuTable } from '../src/stories/containers/cu-table/cu-table';
-import { CuTable2 } from '../src/stories/containers/cu-table/cu-table-2';
 import type { NextPage } from 'next';
 
-const CuTablePage: NextPage = () => {
-  const [isEnabled] = useFlagsActive();
-
-  return isEnabled('FEATURE_CU_INDEX_NEW_TABLE') ? <CuTable2 /> : <CuTable />;
+const FinanceOverviewPage: NextPage = () => {
+  console.log('finances');
+  return <div style={{ marginTop: 70 }}>Finance Overview Page</div>;
 };
-export async function getServerSideProps() {
-  return { props: {} };
-}
 
-export default CuTablePage;
+export default FinanceOverviewPage;

--- a/src/stories/components/core-unit-summary/core-unit-summary.tsx
+++ b/src/stories/components/core-unit-summary/core-unit-summary.tsx
@@ -104,7 +104,7 @@ export const CoreUnitSummary: React.FC<CoreUnitSummaryProps> = ({
                     Core Units <b>({filteredData.length})</b>
                   </CoreUnitStyle>
                 ),
-                url: `/${queryStrings}`,
+                url: `/core-units/${queryStrings}`,
               },
               {
                 label: buildCULabel(),
@@ -148,7 +148,7 @@ export const CoreUnitSummary: React.FC<CoreUnitSummaryProps> = ({
                       Core Units <Value isLight={isLight}>({filteredData.length})</Value>
                     </span>
                   ),
-                  url: `/${queryStrings}`,
+                  url: `/core-units/${queryStrings}`,
                 },
               ]}
               title={breadcrumbTitle || buildCULabel()}

--- a/src/stories/components/header/header.tsx
+++ b/src/stories/components/header/header.tsx
@@ -50,20 +50,15 @@ const Header = ({ links }: Props) => {
   }, [router]);
 
   const activeMenuItem = useMemo(() => {
-    for (const item of menuItems) {
-      if (item.link === '/') {
-        if (router.pathname === '/' || router.pathname.includes('core-unit')) {
-          return item;
-        }
-      } else {
-        if (router.pathname.includes(item.link)) {
-          return item;
-        }
-      }
+    if (router.pathname.startsWith('/core-unit')) {
+      return menuItems[1];
+    } else if (router.pathname.startsWith('/activity-feed')) {
+      return menuItems[2];
+    } else {
+      return menuItems[0];
     }
-
-    return menuItems[0];
   }, [router.pathname]);
+
   const hrefAccountManager = useMemo(() => `/auth/${isAdmin ? 'manage/my-profile' : 'user-profile'}/`, [isAdmin]);
   const hrefProfile = '/auth/manage/accounts';
 

--- a/src/stories/components/header/menu-items.ts
+++ b/src/stories/components/header/menu-items.ts
@@ -9,8 +9,13 @@ export interface MenuType {
 
 const menuItems = [
   {
-    title: 'Core Units',
+    title: 'Finances',
     link: '/',
+    marginRight: '32px',
+  },
+  {
+    title: 'Core Units',
+    link: '/core-units',
     marginRight: '32px',
   },
   ...(featureFlags[CURRENT_ENVIRONMENT].FEATURE_GLOBAL_ACTIVITIES

--- a/src/stories/components/top-bar-select/top-bar-select.tsx
+++ b/src/stories/components/top-bar-select/top-bar-select.tsx
@@ -44,8 +44,8 @@ export const TopBarSelect = (props: TopBarSelectProps) => {
             />
           </CloseWrapper>
           {menuItems.map((item) => (
-            <Link href={item.link} passHref>
-              <LinkWrapper isLight={isLight} isActive={item.title === props.selectedOption} key={item.title}>
+            <Link href={item.link} passHref key={item.title}>
+              <LinkWrapper isLight={isLight} isActive={item.title === props.selectedOption}>
                 {item.title}
               </LinkWrapper>
             </Link>

--- a/src/stories/containers/cu-table/cu-table-2.mvvm.ts
+++ b/src/stories/containers/cu-table/cu-table-2.mvvm.ts
@@ -93,7 +93,7 @@ export const useCoreUnitsTableMvvm = () => {
 
   const clearFilters = () => {
     router.push({
-      pathname: '/',
+      pathname: '/core-units',
       search: '',
     });
 

--- a/src/stories/containers/cu-table/cu-table-filters.tsx
+++ b/src/stories/containers/cu-table/cu-table-filters.tsx
@@ -52,7 +52,7 @@ export const Filters = (props: FilterProps) => {
       const search = router.query;
       search[key] = Array.isArray(value) ? value.join(',') : value || '';
       router.push({
-        pathname: '/',
+        pathname: '/core-units',
         search: stringify(search),
       });
     },
@@ -63,7 +63,7 @@ export const Filters = (props: FilterProps) => {
     const search = router.query;
     delete search.searchText;
     router.push({
-      pathname: '/',
+      pathname: '/core-units',
       search: stringify(search),
     });
     if (inputRef.current !== null) {

--- a/src/stories/containers/cu-table/cu-table.tsx
+++ b/src/stories/containers/cu-table/cu-table.tsx
@@ -131,7 +131,7 @@ export const CuTable = () => {
 
   const clearFilters = useCallback(() => {
     router.push({
-      pathname: '/',
+      pathname: '/core-units',
       search: '',
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
+      "@ses/containers/*": ["src/stories/containers/*"],
       "@ses/components/*": ["src/stories/components/*"],
       "@ses/core/*": ["src/core/*"],
       "@ses/config/*": ["src/config/*"]


### PR DESCRIPTION
## Ticket
https://trello.com/c/KHEsSLd9/233-feature-coreunittransparencyreporting-v5

## Description
- Create a new Finances section and make it accessible as the top menu’s first page: Finances, Core Units, Activity Feed.
- Make this new overview page the homepage at [https://expenses.makerdao.network/](https://expenses.makerdao.network/).
- Ensure that the old homepage with the Core Units overview table is correctly moved to [https://expenses.makerdao.network/core-units/](https://expenses.makerdao.network/core-units/) as its new location and that all links are updated throughout the application.