### PR TITLE
[SES-QA-242] Feature/switch forecast tabs

### DIFF
--- a/src/stories/containers/recognized-delegates/delegates-actuals/useDelegatesActuals.mvvm.ts
+++ b/src/stories/containers/recognized-delegates/delegates-actuals/useDelegatesActuals.mvvm.ts
@@ -240,7 +240,7 @@ export const useDelegatesActuals = (
   const breakdownColumnsActuals = useMemo(() => {
     const breakdownColumns: InnerTableColumn[] = [
       {
-        header: 'Group',
+        header: 'Recognized delegates',
         align: 'left',
         type: 'text',
         hidden: !hasGroups,

--- a/src/stories/containers/recognized-delegates/delegates-forecast/delegates-forecast.tsx
+++ b/src/stories/containers/recognized-delegates/delegates-forecast/delegates-forecast.tsx
@@ -4,7 +4,7 @@ import { TransparencyEmptyTable } from '@ses/containers/transparency-report/plac
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
-import { useDelegatesForecast } from './useDelegatesForecast.mvvm';
+import { useDelegatesForecast } from './useDelegatesForeCast.mvvm';
 
 import type { BudgetStatementDto } from '@ses/core/models/dto/core-unit.dto';
 import type { DateTime } from 'luxon';

--- a/src/stories/containers/recognized-delegates/delegates-forecast/delegates-forecast.tsx
+++ b/src/stories/containers/recognized-delegates/delegates-forecast/delegates-forecast.tsx
@@ -4,7 +4,7 @@ import { TransparencyEmptyTable } from '@ses/containers/transparency-report/plac
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
-import { useDelegatesForecast } from './useDelegatesForeCast.mvvm';
+import { useDelegatesForecast } from './useDelegatesForecast.mvvm';
 
 import type { BudgetStatementDto } from '@ses/core/models/dto/core-unit.dto';
 import type { DateTime } from 'luxon';

--- a/src/stories/containers/recognized-delegates/delegates-forecast/useDelegatesForeCast.mvvm.ts
+++ b/src/stories/containers/recognized-delegates/delegates-forecast/useDelegatesForeCast.mvvm.ts
@@ -286,12 +286,12 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
         align: 'right',
       },
       {
-        header: '3 Months',
+        header: 'Mthly Budget',
         type: 'number',
         align: 'right',
       },
       {
-        header: 'Mthly Budget',
+        header: '3 Months',
         type: 'number',
         align: 'right',
       },
@@ -340,17 +340,18 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
           currentMonth,
           thirdMonthForecast
         ),
-        getForecastSumOfMonthsOnWalletForecast(propBudgetStatements, wallet?.address, currentMonth, [
-          firstMonthForecast,
-          secondMonthForecast,
-          thirdMonthForecast,
-        ]),
+
         getBudgetCapForMonthOnWalletOnBudgetStatement(
           propBudgetStatements,
           wallet?.address,
           currentMonth,
           currentMonth
         ),
+        getForecastSumOfMonthsOnWalletForecast(propBudgetStatements, wallet?.address, currentMonth, [
+          firstMonthForecast,
+          secondMonthForecast,
+          thirdMonthForecast,
+        ]),
         getBudgetCapSumOfMonthsOnWallet(propBudgetStatements, wallet?.address, currentMonth, [
           firstMonthForecast,
           secondMonthForecast,
@@ -424,6 +425,11 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
           column: mainTableColumnsForecast[3],
           value: getForecastSumForMonth(propBudgetStatements, currentMonth, thirdMonthForecast),
         },
+
+        {
+          column: mainTableColumnsForecast[5],
+          value: getBudgetCapForMonthOnBudgetStatement(propBudgetStatements, currentMonth, currentMonth),
+        },
         {
           column: mainTableColumnsForecast[4],
           value: getForecastSumForMonthsForecast(propBudgetStatements, currentMonth, [
@@ -431,10 +437,6 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
             secondMonthForecast,
             thirdMonthForecast,
           ]),
-        },
-        {
-          column: mainTableColumnsForecast[5],
-          value: getBudgetCapForMonthOnBudgetStatement(propBudgetStatements, currentMonth, currentMonth),
         },
         {
           column: mainTableColumnsForecast[6],
@@ -495,12 +497,12 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
         align: 'right',
       },
       {
-        header: '3 Months',
+        header: 'Mthly Budget',
         type: 'number',
         align: 'right',
       },
       {
-        header: 'Mthly Budget',
+        header: '3 Months',
         type: 'number',
         align: 'right',
       },
@@ -563,13 +565,13 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
 
           subTotal[4] += getLineItemForecastSumForMonth(groupedCategory[groupedCatKey], thirdMonthForecast);
 
-          subTotal[5] += getLineItemForecastSumForMonths(groupedCategory[groupedCatKey], [
+          subTotal[5] += getBudgetCapForMonthOnLineItem(groupedCategory[groupedCatKey], currentMonth);
+
+          subTotal[6] += getLineItemForecastSumForMonths(groupedCategory[groupedCatKey], [
             firstMonthForecast,
             secondMonthForecast,
             thirdMonthForecast,
           ]);
-
-          subTotal[6] += getBudgetCapForMonthOnLineItem(groupedCategory[groupedCatKey], currentMonth);
 
           subTotal[7] += getTotalQuarterlyBudgetCapOnLineItem(groupedCategory[groupedCatKey], [
             firstMonthForecast,
@@ -601,16 +603,16 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
                 value: getLineItemForecastSumForMonth(groupedCategory[groupedCatKey], thirdMonthForecast),
               },
               {
+                column: breakdownHeadersForecast[6],
+                value: getBudgetCapForMonthOnLineItem(groupedCategory[groupedCatKey], currentMonth),
+              },
+              {
                 column: breakdownHeadersForecast[5],
                 value: getLineItemForecastSumForMonths(groupedCategory[groupedCatKey], [
                   firstMonthForecast,
                   secondMonthForecast,
                   thirdMonthForecast,
                 ]),
-              },
-              {
-                column: breakdownHeadersForecast[6],
-                value: getBudgetCapForMonthOnLineItem(groupedCategory[groupedCatKey], currentMonth),
               },
               {
                 column: breakdownHeadersForecast[7],
@@ -774,14 +776,6 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
           ),
         },
         {
-          column: breakdownHeadersForecast[5],
-          value: getForecastSumOfMonthsOnWalletForecast(propBudgetStatements, currentWalletAddress, currentMonth, [
-            firstMonthForecast,
-            secondMonthForecast,
-            thirdMonthForecast,
-          ]),
-        },
-        {
           column: breakdownHeadersForecast[6],
           value: getBudgetCapForMonthOnWalletOnBudgetStatement(
             propBudgetStatements,
@@ -789,6 +783,14 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
             currentMonth,
             currentMonth
           ),
+        },
+        {
+          column: breakdownHeadersForecast[5],
+          value: getForecastSumOfMonthsOnWalletForecast(propBudgetStatements, currentWalletAddress, currentMonth, [
+            firstMonthForecast,
+            secondMonthForecast,
+            thirdMonthForecast,
+          ]),
         },
         {
           column: breakdownHeadersForecast[7],

--- a/src/stories/containers/transparency-report/transparency-forecast/transparency-forecast-2.mvvm.ts
+++ b/src/stories/containers/transparency-report/transparency-forecast/transparency-forecast-2.mvvm.ts
@@ -303,12 +303,12 @@ export const useTransparencyForecastMvvm2 = (currentMonth: DateTime, propBudgetS
         align: 'right',
       },
       {
-        header: '3 Months',
+        header: 'Mthly Budget',
         type: 'number',
         align: 'right',
       },
       {
-        header: 'Mthly Budget',
+        header: '3 Months',
         type: 'number',
         align: 'right',
       },
@@ -342,17 +342,18 @@ export const useTransparencyForecastMvvm2 = (currentMonth: DateTime, propBudgetS
         getForecastForMonthOnWalletOnBudgetStatement(propBudgetStatements, wallet?.address, currentMonth, firstMonth),
         getForecastForMonthOnWalletOnBudgetStatement(propBudgetStatements, wallet?.address, currentMonth, secondMonth),
         getForecastForMonthOnWalletOnBudgetStatement(propBudgetStatements, wallet?.address, currentMonth, thirdMonth),
-        getForecastSumOfMonthsOnWallet(propBudgetStatements, wallet?.address, currentMonth, [
-          firstMonth,
-          secondMonth,
-          thirdMonth,
-        ]),
         getBudgetCapForMonthOnWalletOnBudgetStatement(
           propBudgetStatements,
           wallet?.address,
           currentMonth,
           currentMonth
         ),
+        getForecastSumOfMonthsOnWallet(propBudgetStatements, wallet?.address, currentMonth, [
+          firstMonth,
+          secondMonth,
+          thirdMonth,
+        ]),
+
         getBudgetCapSumOfMonthsOnWallet(propBudgetStatements, wallet?.address, currentMonth, [
           firstMonth,
           secondMonth,
@@ -428,11 +429,11 @@ export const useTransparencyForecastMvvm2 = (currentMonth: DateTime, propBudgetS
         },
         {
           column: mainTableColumns[4],
-          value: getForecastSumForMonths(propBudgetStatements, currentMonth, [firstMonth, secondMonth, thirdMonth]),
+          value: getBudgetCapForMonthOnBudgetStatement(propBudgetStatements, currentMonth, currentMonth),
         },
         {
           column: mainTableColumns[5],
-          value: getBudgetCapForMonthOnBudgetStatement(propBudgetStatements, currentMonth, currentMonth),
+          value: getForecastSumForMonths(propBudgetStatements, currentMonth, [firstMonth, secondMonth, thirdMonth]),
         },
         {
           column: mainTableColumns[6],
@@ -492,12 +493,12 @@ export const useTransparencyForecastMvvm2 = (currentMonth: DateTime, propBudgetS
         align: 'right',
       },
       {
-        header: '3 Months',
+        header: 'Mthly Budget',
         type: 'number',
         align: 'right',
       },
       {
-        header: 'Mthly Budget',
+        header: '3 Months',
         type: 'number',
         align: 'right',
       },
@@ -593,6 +594,11 @@ export const useTransparencyForecastMvvm2 = (currentMonth: DateTime, propBudgetS
                 column: breakdownHeaders[4],
                 value: getLineItemForecastSumForMonth(groupedCategory[groupedCatKey], thirdMonth),
               },
+
+              {
+                column: breakdownHeaders[6],
+                value: getBudgetCapForMonthOnLineItem(groupedCategory[groupedCatKey], currentMonth),
+              },
               {
                 column: breakdownHeaders[5],
                 value: getLineItemForecastSumForMonths(groupedCategory[groupedCatKey], [
@@ -600,10 +606,6 @@ export const useTransparencyForecastMvvm2 = (currentMonth: DateTime, propBudgetS
                   secondMonth,
                   thirdMonth,
                 ]),
-              },
-              {
-                column: breakdownHeaders[6],
-                value: getBudgetCapForMonthOnLineItem(groupedCategory[groupedCatKey], currentMonth),
               },
               {
                 column: breakdownHeaders[7],
@@ -644,12 +646,12 @@ export const useTransparencyForecastMvvm2 = (currentMonth: DateTime, propBudgetS
             value: subTotal[4],
           },
           {
-            column: breakdownHeaders[5],
-            value: subTotal[5],
-          },
-          {
             column: breakdownHeaders[6],
             value: subTotal[6],
+          },
+          {
+            column: breakdownHeaders[5],
+            value: subTotal[5],
           },
           {
             column: breakdownHeaders[7],
@@ -767,14 +769,6 @@ export const useTransparencyForecastMvvm2 = (currentMonth: DateTime, propBudgetS
           ),
         },
         {
-          column: breakdownHeaders[5],
-          value: getForecastSumOfMonthsOnWallet(propBudgetStatements, currentWalletAddress, currentMonth, [
-            firstMonth,
-            secondMonth,
-            thirdMonth,
-          ]),
-        },
-        {
           column: breakdownHeaders[6],
           value: getBudgetCapForMonthOnWalletOnBudgetStatement(
             propBudgetStatements,
@@ -782,6 +776,14 @@ export const useTransparencyForecastMvvm2 = (currentMonth: DateTime, propBudgetS
             currentMonth,
             currentMonth
           ),
+        },
+        {
+          column: breakdownHeaders[5],
+          value: getForecastSumOfMonthsOnWallet(propBudgetStatements, currentWalletAddress, currentMonth, [
+            firstMonth,
+            secondMonth,
+            thirdMonth,
+          ]),
         },
         {
           column: breakdownHeaders[7],


### PR DESCRIPTION
## Ticket
https://trello.com/c/HoJdcpkZ/242-qa-bug-findings-v-70

## Issues
- **CoreUnitTransparencyReporting:** Under the expense reports forecast tab- Switch “Monthly Budget” column with “3 Month Forecast”, for all tables. [image.png](https://trello.com/1/cards/63dbc9348e3ca5e5e66b17e5/attachments/63f7322718cb30895efe3745/download/image.png) 

## Description
Switched the columns in the transparency report and the delegates page. Updated some column names on the delegates page
