### PR TITLE
[SES-QC-243] Fix breadcrumbs alignment

### DIFF
--- a/src/stories/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/stories/components/breadcrumbs/breadcrumbs.tsx
@@ -12,7 +12,6 @@ interface BreadcrumbsProps {
   height?: number;
   width?: number;
   paddingBreadcrumbs?: string;
-  heightBreadcrumbs?: string;
   fontSize?: string;
   borderRadius?: string;
   marginLeft?: string;
@@ -27,7 +26,6 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
       className={props.className}
       isLight={isLight}
       padding={props.paddingBreadcrumbs}
-      height={props.heightBreadcrumbs}
       borderRadius={props.borderRadius}
     >
       {props.items.map((item, i) => (
@@ -63,15 +61,14 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
 
 const Container = styled.div<{
   padding?: string;
-  height?: string;
   borderRadius?: string;
   isLight: boolean;
-}>(({ height = '47px', padding = '27px 0', borderRadius }) => ({
+}>(({ padding = '27px 0', borderRadius }) => ({
   display: 'flex',
   flex: 1,
   padding,
   boxSizing: 'border-box',
-  height,
+  height: '100%',
   alignSelf: 'flex-start',
   borderRadius,
 }));


### PR DESCRIPTION
## Ticket
https://trello.com/c/nHLbSsUd/243-qc-round-v-70-r

## Issue
- **NC** **Environment:** DEV. **Browser:** All. **Resolution:** All. **Steps to Reproduce:** CUAbout and Expense Reports views. **Expected Output:** The breadcrumb and the elements (number of the core units and navigation icons) displayed on the left side should be aligned. **Current Output:** The breadcrumb and the elements on the left side are misaligned. **Visual Proof:**  [image.png](https://trello.com/1/cards/63dbc95c19102cb39f3e5692/attachments/63fdfd432e13542cb7763962/download/image.png)