### PR TITLE
[SES-254] Fix space transparency report and delegate

### DIFF
--- a/src/stories/containers/transparency-report/transparency-actuals/transparency-actuals-2.tsx
+++ b/src/stories/containers/transparency-report/transparency-actuals/transparency-actuals-2.tsx
@@ -82,9 +82,6 @@ export const TransparencyActuals2 = (props: Props) => {
             id: headerIds[i],
           }))}
           currentIndex={thirdIndex}
-          style={{
-            marginBottom: '32px',
-          }}
         />
       )}
 

--- a/src/stories/containers/transparency-report/transparency-actuals/transparency-actuals-2.tsx
+++ b/src/stories/containers/transparency-report/transparency-actuals/transparency-actuals-2.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { useThemeContext } from '../../../../core/context/ThemeContext';
 import { MAKER_BURN_LINK } from '../../../../core/utils/const';
@@ -21,6 +23,7 @@ interface Props {
 
 export const TransparencyActuals2 = (props: Props) => {
   const { isLight } = useThemeContext();
+  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
 
   const {
     headerIds,
@@ -44,7 +47,7 @@ export const TransparencyActuals2 = (props: Props) => {
             color: '#447AFB',
             letterSpacing: '0.3px',
             lineHeight: '18px',
-            marginBottom: '16px',
+            marginBottom: isMobile ? '0px' : '32px',
             marginLeft: 0,
             whiteSpace: 'break-spaces',
             display: 'inline-block',
@@ -58,9 +61,7 @@ export const TransparencyActuals2 = (props: Props) => {
           {`view the ${getShortCode(props.code)} Core Unit on-chain transaction history`}
         </CustomLink>
       </LinkDescription>
-      <Title isLight={isLight} responsiveMarginBottom={16}>
-        {props.currentMonth.toFormat('MMM yyyy')} Totals
-      </Title>
+      <Title isLight={isLight}>{props.currentMonth.toFormat('MMM yyyy')} Totals</Title>
       <AdvancedInnerTable
         columns={mainTableColumns}
         items={mainTableItems}
@@ -112,7 +113,6 @@ export const LinkDescription = styled.div<{ isLight: boolean }>(({ isLight }) =>
   fontSize: '16px',
   lineHeight: '22px',
   color: isLight ? '#231536' : '#D2D4EF',
-  marginBottom: '32px',
   span: {
     marginRight: 4,
   },

--- a/src/stories/containers/transparency-report/transparency-forecast/transparency-forecast-2.tsx
+++ b/src/stories/containers/transparency-report/transparency-forecast/transparency-forecast-2.tsx
@@ -82,7 +82,6 @@ export const TransparencyForecast2 = (props: Props) => {
             item: header,
             id: headerIds[i],
           }))}
-          style={{ marginBottom: '64px' }}
           currentIndex={thirdIndex}
         />
       )}

--- a/src/stories/containers/transparency-report/transparency-forecast/transparency-forecast-2.tsx
+++ b/src/stories/containers/transparency-report/transparency-forecast/transparency-forecast-2.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { useThemeContext } from '../../../../core/context/ThemeContext';
 import { MAKER_BURN_LINK } from '../../../../core/utils/const';
@@ -22,6 +24,7 @@ interface Props {
 
 export const TransparencyForecast2 = (props: Props) => {
   const { isLight } = useThemeContext();
+  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
 
   const {
     thirdIndex,
@@ -45,7 +48,7 @@ export const TransparencyForecast2 = (props: Props) => {
             color: '#447AFB',
             letterSpacing: '0.3px',
             lineHeight: '18px',
-            marginBottom: '16px',
+            marginBottom: isMobile ? '0px' : '32px',
             whiteSpace: 'break-spaces',
             display: 'inline-block',
             marginLeft: 0,
@@ -59,9 +62,7 @@ export const TransparencyForecast2 = (props: Props) => {
           {`view the ${getShortCode(props.code)} Core Unit on-chain transaction history`}
         </CustomLink>
       </LinkDescription>
-      <Title isLight={isLight} marginBottom={16}>
-        {props.currentMonth.toFormat('MMM yyyy')} Totals
-      </Title>
+      <Title isLight={isLight}>{props.currentMonth.toFormat('MMM yyyy')} Totals</Title>
       <AdvancedInnerTable
         longCode={props.longCode}
         columns={mainTableColumns}

--- a/src/stories/containers/transparency-report/transparency-mkr-vesting/transparency-mkr-vesting-2.tsx
+++ b/src/stories/containers/transparency-report/transparency-mkr-vesting/transparency-mkr-vesting-2.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { useThemeContext } from '../../../../core/context/ThemeContext';
 import { MAKER_BURN_LINK } from '../../../../core/utils/const';
@@ -24,6 +26,7 @@ export const TransparencyMkrVesting2 = (props: TransparencyMkrVestingProps) => {
     props.currentMonth,
     props.budgetStatements
   );
+  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
   const { isLight } = useThemeContext();
 
   return (
@@ -37,7 +40,7 @@ export const TransparencyMkrVesting2 = (props: TransparencyMkrVestingProps) => {
             color: '#447AFB',
             letterSpacing: '0.3px',
             lineHeight: '18px',
-            marginBottom: '16px',
+            marginBottom: isMobile ? '0px' : '32px',
             whiteSpace: 'break-spaces',
             display: 'inline-block',
             marginLeft: 0,

--- a/src/stories/containers/transparency-report/transparency-report.tsx
+++ b/src/stories/containers/transparency-report/transparency-report.tsx
@@ -231,7 +231,7 @@ const Container = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   flexDirection: 'column',
   alignItems: 'center',
   marginTop: '64px',
-  paddingBottom: '128px',
+  paddingBottom: '64px',
   flex: 1,
   backgroundColor: isLight ? '#FFFFFF' : '#000000',
   backgroundImage: isLight ? 'url(/assets/img/bg-page.png)' : 'url(/assets/img/bg-page-dark.png)',
@@ -253,7 +253,16 @@ const InnerPage = styled.div({
   margin: '0 auto',
   paddingRight: '64px',
   paddingLeft: '64px',
+  marginTop: 32,
+  [lightTheme.breakpoints.up('table_834')]: {
+    paddingTop: 32,
+    marginTop: 0,
+  },
 
+  [lightTheme.breakpoints.between('table_834', 'desktop_1280')]: {
+    paddingRight: '32px',
+    paddingLeft: '32px',
+  },
   [lightTheme.breakpoints.up('desktop_1920')]: {
     maxWidth: '1312px',
     paddingRight: '0px',
@@ -263,13 +272,7 @@ const InnerPage = styled.div({
     paddingRight: '48px',
     paddingLeft: '48px',
   },
-  [lightTheme.breakpoints.between('table_834', 'desktop_1280')]: {
-    paddingRight: '32px',
-    paddingLeft: '32px',
-  },
-  [lightTheme.breakpoints.up('table_834')]: {
-    paddingTop: 32,
-  },
+
   [lightTheme.breakpoints.down('table_834')]: {
     paddingRight: '16px',
     paddingLeft: '16px',
@@ -297,7 +300,7 @@ export const Title = styled.div<{
     marginBottom: `${responsiveMarginBottom || marginBottom}px`,
   },
   [lightTheme.breakpoints.between('table_375', 'table_834')]: {
-    marginTop: '40px',
+    marginTop: '32px',
     fontWeight: 700,
   },
 }));
@@ -399,7 +402,7 @@ export const ParenthesisNumber = styled.label({
 });
 
 const AdditionalNotesSection = styled.div({
-  paddingBottom: 113,
+  paddingBottom: 0,
 
   [lightTheme.breakpoints.up('table_834')]: {
     paddingBottom: 0,

--- a/src/stories/containers/transparency-report/transparency-transfer-request/transparency-transfer-request-2.tsx
+++ b/src/stories/containers/transparency-report/transparency-transfer-request/transparency-transfer-request-2.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { useThemeContext } from '../../../../core/context/ThemeContext';
 import { MAKER_BURN_LINK } from '../../../../core/utils/const';
@@ -19,6 +21,7 @@ interface Props {
 
 export const TransparencyTransferRequest2 = (props: Props) => {
   const { isLight } = useThemeContext();
+  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
   const { mainTableColumns, mainTableItems } = useTransparencyTransferRequestMvvm2(
     props.currentMonth,
     props.budgetStatements
@@ -35,7 +38,7 @@ export const TransparencyTransferRequest2 = (props: Props) => {
             color: '#447AFB',
             letterSpacing: '0.3px',
             lineHeight: '18px',
-            marginBottom: '16px',
+            marginBottom: isMobile ? '0px' : '32px',
             whiteSpace: 'break-spaces',
             display: 'inline-block',
             marginLeft: 0,
@@ -49,13 +52,15 @@ export const TransparencyTransferRequest2 = (props: Props) => {
           {`view the ${getShortCode(props.code)} Core Unit on-chain transaction history`}
         </CustomLink>
       </LinkDescription>
-      <AdvancedInnerTable
-        columns={mainTableColumns}
-        items={mainTableItems}
-        style={{ marginBottom: '64px' }}
-        cardsTotalPosition={'top'}
-        longCode={props.longCode}
-      />
+      <div style={{ marginTop: 32 }}>
+        <AdvancedInnerTable
+          columns={mainTableColumns}
+          items={mainTableItems}
+          style={{ marginBottom: '64px' }}
+          cardsTotalPosition={'top'}
+          longCode={props.longCode}
+        />
+      </div>
     </Container>
   );
 };


### PR DESCRIPTION
# Ticket
https://trello.com/c/NaQQSUtv/254-qc-round-v-80-r

#What solved
  The months area is too closer to the header bottom 
  A big space is displayed between the makerburn link and the section below.
  The space between the footer and the section above should be the same defined in the design. 
  A big space is displayed between the tab and the data below. 
# Actions
Fix-space-additional-notes