### PR TITLE
Prevent scroll bouncing on apple devices

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -111,6 +111,10 @@
   font-style: normal;
 }
 
+body {
+  overscroll-behavior: none;
+}
+
 html,
 body {
   padding: 0;


### PR DESCRIPTION
## Ticket
https://trello.com/c/4OEItwNA/256-qa-bug-findings-v-80

## Issue
- When pulling the page down on mobile in dark mode, a white area appears. [image.png](https://trello.com/1/cards/63c573b095f58802270f7e2b/attachments/63da3cfa7029e31482f41b1c/download/image.png)
