### PR TITLE
Ses 245 feature coreunittransparencyreporting v6 add fiels table

### DIFF
--- a/src/core/utils/typesHelpers.ts
+++ b/src/core/utils/typesHelpers.ts
@@ -19,3 +19,9 @@ export interface CookiesInterface {
 export function isActivity(activity: CommentsBudgetStatementDto | ActivityFeedDto): activity is ActivityFeedDto {
   return (activity as ActivityFeedDto).event !== undefined;
 }
+
+export type TargetBalanceTooltipInformation = {
+  balance: number;
+  targetBalanceFirstMonth: DateTime;
+  targetBalanceSecondMonth: DateTime;
+};

--- a/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -24,7 +24,8 @@ export interface InnerTableColumn {
 
 export interface InnerTableCell {
   column: InnerTableColumn;
-  value: unknown;
+  value: unknown | React.ReactElement;
+  isBold?: boolean;
 }
 
 export type RowType = 'normal' | 'total' | 'section' | 'subTotal';

--- a/src/stories/components/NumberCell/NumberCell.tsx
+++ b/src/stories/components/NumberCell/NumberCell.tsx
@@ -9,12 +9,14 @@ interface NumberCellProps {
   fontFamily?: string;
   value: number;
   bold?: boolean;
+  className?: string;
 }
 
 export const NumberCell = (props: NumberCellProps) => {
   const { isLight } = useThemeContext();
   return (
     <Container
+      className={props.className}
       fontFamily={props.fontFamily}
       isLight={isLight}
       style={{

--- a/src/stories/components/TextCell/TextCell.tsx
+++ b/src/stories/components/TextCell/TextCell.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useThemeContext } from '../../../core/context/ThemeContext';
 import type { CSSProperties } from 'react';
 
-interface TableCellProps {
+export interface TableCellProps {
   negative?: boolean;
   children?: string | JSX.Element | JSX.Element[];
   style?: CSSProperties;
@@ -11,12 +11,14 @@ interface TableCellProps {
   responsivePadding?: string;
   bold?: boolean;
   isHeader?: boolean;
+  className?: string;
 }
 
 export const TextCell = ({ responsivePadding = '10px 16px', ...props }: TableCellProps) => {
   const { isLight } = useThemeContext();
   return (
     <Container
+      className={props.className}
       bold={!!props.bold}
       isLight={isLight}
       fontFamily={props.fontFamily}

--- a/src/stories/components/svg/information.tsx
+++ b/src/stories/components/svg/information.tsx
@@ -36,7 +36,7 @@ const Information: React.FC<Props> = ({ height = 15, width = 15, style, ...props
 export default Information;
 
 const ContainerSVg = styled.svg<{ isLight?: boolean }>(({ isLight }) => ({
-  fill: isLight ? '#9FAFB9' : '#434358',
+  fill: isLight ? '#9FAFB9' : '#787A9B',
   ':hover': {
     fill: '#447AFB',
   },

--- a/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/TransparencyTransferRequest.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/TransparencyTransferRequest.tsx
@@ -8,7 +8,6 @@ import { getShortCode } from '../../../../../core/utils/string';
 import { AdvancedInnerTable } from '../../../../components/AdvancedInnerTable/AdvancedInnerTable';
 import { CustomLink } from '../../../../components/CustomLink/CustomLink';
 import { LinkDescription } from '../TransparencyActuals/TransparencyActuals';
-// import { useTransparencyTransferRequestMvvm } from './useTransparencyTransferRequest';
 import { useTransparencyTransferRequest } from './useTransparencyTransferRequest';
 import type { BudgetStatementDto } from '../../../../../core/models/dto/coreUnitDTO';
 import type { DateTime } from 'luxon';

--- a/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/useTransparencyTransferRequest.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/useTransparencyTransferRequest.tsx
@@ -104,7 +104,7 @@ export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetSta
         cellRender: renderNumberWithIcon,
       },
       {
-        header: 'Current Balance',
+        header: ` ${currentMonth.toFormat('dd-LLL')} Balance`,
         type: 'number',
         align: 'right',
       },
@@ -114,7 +114,7 @@ export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetSta
         align: 'right',
       },
       {
-        header: 'External Links',
+        header: 'multi-sig address',
         type: 'custom',
         width: '240px',
         cellRender: renderLinks,
@@ -122,7 +122,7 @@ export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetSta
       },
     ];
     return mainTableColumns;
-  }, []);
+  }, [currentMonth]);
 
   const mainTableItems: InnerTableRow[] = useMemo(() => {
     const result: InnerTableRow[] = [];

--- a/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/useTransparencyTransferRequest.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/useTransparencyTransferRequest.tsx
@@ -1,10 +1,12 @@
 import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
+import { formatNumber } from '@ses/core/utils/string';
+import { DateTime } from 'luxon';
 import { useMemo } from 'react';
 import { renderLinks, renderNumberWithIcon, renderWallet } from '../../transparencyReportUtils';
 import { useTransparencyForecast } from '../TransparencyForecast/useTransparencyForecast';
 import type { InnerTableColumn, InnerTableRow } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
 import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
-import type { DateTime } from 'luxon';
+import type { TargetBalanceTooltipInformation } from '@ses/core/utils/typesHelpers';
 
 export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetStatements: BudgetStatementDto[]) => {
   const { firstMonth, secondMonth, thirdMonth, getForecastSumOfMonthsOnWallet, getForecastSumForMonths, wallets } =
@@ -104,7 +106,7 @@ export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetSta
         cellRender: renderNumberWithIcon,
       },
       {
-        header: ` ${currentMonth.toFormat('dd-LLL')} Balance`,
+        header: `${currentMonth.toFormat('dd-LLL')} Balance`,
         type: 'number',
         align: 'right',
       },
@@ -137,11 +139,15 @@ export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetSta
           },
           {
             column: mainTableColumns[1],
-            value: getForecastSumOfMonthsOnWallet(budgetStatements, wallet?.address, currentMonth, [
-              firstMonth,
-              secondMonth,
-              thirdMonth,
-            ]),
+            value: {
+              balance: getForecastSumOfMonthsOnWallet(budgetStatements, wallet?.address, currentMonth, [
+                firstMonth,
+                secondMonth,
+                thirdMonth,
+              ]),
+              targetBalanceFirstMonth: DateTime.now(),
+              targetBalanceSecondMonth: DateTime.now(),
+            } as TargetBalanceTooltipInformation,
           },
           {
             column: mainTableColumns[2],
@@ -169,7 +175,14 @@ export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetSta
           },
           {
             column: mainTableColumns[1],
-            value: getForecastSumForMonths(budgetStatements, currentMonth, [firstMonth, secondMonth, thirdMonth]),
+
+            value: (
+              <b>
+                {formatNumber(
+                  getForecastSumForMonths(budgetStatements, currentMonth, [firstMonth, secondMonth, thirdMonth])
+                )}
+              </b>
+            ),
           },
           {
             column: mainTableColumns[2],

--- a/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
+++ b/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { CustomPopover } from '@ses/components/CustomPopover/CustomPopover';
+import { NumberCell } from '@ses/components/NumberCell/NumberCell';
 import Information from '@ses/components/svg/information';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
@@ -57,7 +58,7 @@ export const renderLinksWithToken = (address: string) => (
   </TextCell>
 );
 
-export const renderNumberWithIcon = (number: number) => (
+export const renderNumberWithIcon = (value: number) => (
   <PopoverContainer>
     <Container>
       <CustomPopover
@@ -73,7 +74,7 @@ export const renderNumberWithIcon = (number: number) => (
         </ContainerInfoIcon>
       </CustomPopover>
       <ContainerInformation>
-        <ContainerNumber>{number}</ContainerNumber>
+        <NumberCell value={value} />
         <ContainerMonth>FEB + MAR Budget Cap</ContainerMonth>
       </ContainerInformation>
     </Container>
@@ -121,23 +122,6 @@ const ContainerInformation = styled.div({
   },
 });
 
-const ContainerNumber = styled.div({
-  fontFamily: 'Inter, sans-serif',
-  fontStyle: 'normal',
-  fontWeight: 400,
-  fontSize: '16px',
-  lineHeight: '19px',
-  letterSpacing: '0.3px',
-  fontFeatureSettings: " 'tnum' on, 'lnum' on",
-  color: '#231536',
-  marginBottom: 2,
-  marginTop: 2,
-  [lightTheme.breakpoints.up('table_834')]: {
-    marginBottom: 0,
-    marginTop: 0,
-  },
-});
-
 const ContainerMonth = styled.div({
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
@@ -145,4 +129,5 @@ const ContainerMonth = styled.div({
   fontSize: '11px',
   lineHeight: '13px',
   color: '#546978',
+  marginLeft: 16,
 });

--- a/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
+++ b/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
@@ -9,6 +9,7 @@ import { CustomLink } from '../../components/CustomLink/CustomLink';
 import { TextCell } from '../../components/TextCell/TextCell';
 import { WalletTableCell } from '../../components/WalletTableCell/WalletTableCell';
 import type { BudgetStatementWalletDto } from '../../../core/models/dto/coreUnitDTO';
+import type { TargetBalanceTooltipInformation } from '@ses/core/utils/typesHelpers';
 
 export const renderWallet = (wallet: BudgetStatementWalletDto) => (
   <WalletTableCell
@@ -58,7 +59,7 @@ export const renderLinksWithToken = (address: string) => (
   </TextCell>
 );
 
-export const renderNumberWithIcon = (value: number) => (
+export const renderNumberWithIcon = (data: TargetBalanceTooltipInformation) => (
   <PopoverContainer>
     <Container>
       <CustomPopover
@@ -74,8 +75,12 @@ export const renderNumberWithIcon = (value: number) => (
         </ContainerInfoIcon>
       </CustomPopover>
       <ContainerInformation>
-        <NumberCell value={value} />
-        <ContainerMonth>FEB + MAR Budget Cap</ContainerMonth>
+        <ContainerNumberCell value={data.balance} />
+        <ContainerStyleMonths style={{}}>{`${data.targetBalanceFirstMonth
+          .toFormat('LLL')
+          .toLocaleUpperCase()} + ${data.targetBalanceSecondMonth
+          .toFormat('LLL')
+          .toLocaleUpperCase()}  Budget Cap`}</ContainerStyleMonths>
       </ContainerInformation>
     </Container>
   </PopoverContainer>
@@ -115,6 +120,7 @@ const ContainerInfoIcon = styled.div({
 
 const ContainerInformation = styled.div({
   display: 'flex',
+  flex: 1,
   flexDirection: 'column',
   alignItems: 'flex-end',
   [lightTheme.breakpoints.up('table_834')]: {
@@ -122,9 +128,14 @@ const ContainerInformation = styled.div({
   },
 });
 
-const ContainerMonth = styled.div({
-  fontFamily: 'Inter, sans-serif',
-  fontStyle: 'normal',
+const ContainerNumberCell = styled(NumberCell)({
+  paddingBottom: 2,
+  '@media (min-width: 834px)': {
+    paddingBottom: 0,
+  },
+});
+
+const ContainerStyleMonths = styled.div({
   fontWeight: 400,
   fontSize: '11px',
   lineHeight: '13px',


### PR DESCRIPTION
# Ticket

https://trello.com/c/tixH6IkI/245-feature-coreunittransparencyreporting-v6

#What solved
Under the existing Transfer Requests Tab, change the column text: "Current Balance” → “31-JAN Balance". This is specific to the expense report, and is derived from the specific data that the report was published. 

# Actions
Add headers to table
Add new style for data in the column
