### PR TITLE
[SES-245] : Add dark mode and other parameter necessary

### DIFF
--- a/src/core/utils/typesHelpers.ts
+++ b/src/core/utils/typesHelpers.ts
@@ -22,6 +22,10 @@ export function isActivity(activity: CommentsBudgetStatementDto | ActivityFeedDt
 
 export type TargetBalanceTooltipInformation = {
   balance: number;
-  targetBalanceFirstMonth: DateTime;
-  targetBalanceSecondMonth: DateTime;
+  months: string;
+  description: string;
+  mipNumber: string;
+  link: string;
+  longCode: string;
+  name: string;
 };

--- a/src/stories/components/CustomPopover/CustomPopover.tsx
+++ b/src/stories/components/CustomPopover/CustomPopover.tsx
@@ -4,6 +4,7 @@ import { getPageWrapper } from '@ses/core/utils/dom';
 import React from 'react';
 import { useThemeContext } from '../../../core/context/ThemeContext';
 import type { SxProps } from '@mui/material/styles';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { CSSProperties } from 'react';
 interface CustomPopoverProps {
   title?: JSX.Element | string;
@@ -109,7 +110,7 @@ export const CustomPopover = ({
         >
           {props.title}
         </Container>
-        {widthArrow && <ContainerTriangle alignArrow={alignArrow} />}
+        {widthArrow && <ContainerTriangle alignArrow={alignArrow} isLight={isLight} />}
       </Popover>
     </React.Fragment>
   );
@@ -123,8 +124,8 @@ const Container = styled.div({
   fontWeight: 400,
 });
 
-const ContainerTriangle = styled.div<{ alignArrow?: 'center' | 'right' }>(({ alignArrow }) => ({
-  backgroundColor: 'white',
+const ContainerTriangle = styled.div<WithIsLight & { alignArrow?: 'center' | 'right' }>(({ alignArrow, isLight }) => ({
+  backgroundColor: isLight ? 'white' : '#000A13',
   borderRadius: '6px',
   '&:after , &:before': {
     content: '""',
@@ -136,11 +137,11 @@ const ContainerTriangle = styled.div<{ alignArrow?: 'center' | 'right' }>(({ ali
     left: alignArrow === 'center' ? 135 : alignArrow === 'right' ? 257 : 35,
     borderColor: 'transparent',
     borderWidth: '0 8px  16px  8px',
-    borderBottomColor: 'white',
+    borderBottomColor: isLight ? 'white' : '#000A13',
     top: -14,
   },
   ':before': {
     top: -16,
-    borderBottomColor: '#D4D9E1',
+    borderBottomColor: isLight ? '#D4D9E1' : '#231536',
   },
 }));

--- a/src/stories/containers/TransparencyReport/components/ArrowPopoverTargetValue/ArrowPopoverTargetValueComponent.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/ArrowPopoverTargetValue/ArrowPopoverTargetValueComponent.stories.tsx
@@ -1,5 +1,6 @@
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import ArrowPopoverTargetValueComponent from './ArrowPopoverTargetValueComponent';
+import type { TargetBalanceTooltipInformation } from '@ses/core/utils/typesHelpers';
 import type { ComponentMeta } from '@storybook/react';
 
 export default {
@@ -15,28 +16,14 @@ export default {
 
 const variantsArgs = [
   {
-    align: 'center',
-    name: 'Collateral Engineering Services',
+    months: 'FEB + MAR Budget Cap',
     longCode: 'SES-001',
-    description: '2 Month Budget Cap',
-    mipNumber: 'MIP40c3-SP14:',
-    link: '#',
-    style: {
-      padding: 10,
-      width: '305px',
-      background: 'white',
-      border: '1px solid #D4D9E1',
-      boxShadow: '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)',
-      borderRadius: '6px',
-    },
-  },
-  {
-    align: 'left',
-    name: 'Collateral Engineering Services',
-    longCode: 'SES-01',
-    description: '2 Month Budget Cap',
-    mipNumber: 'MIP40c3-SP14:',
-    link: '#',
+    name: 'Sustainable Ecosystem Scaling',
+    toolTipData: {
+      description: '2 Month Budget Cap',
+      link: '#',
+      mipNumber: 'MIP40c3-SP14:',
+    } as Pick<TargetBalanceTooltipInformation, 'description' | 'mipNumber' | 'link'>,
     style: {
       padding: 10,
       width: '305px',
@@ -48,12 +35,12 @@ const variantsArgs = [
   },
 ];
 
-export const [[LightCenter, DarkCenter], [LightLeft, DarkLeft]] = createThemeModeVariants(
+export const [[PopoverContainerWithoutArrow, PopoverContainerWithoutArrowDark]] = createThemeModeVariants(
   ArrowPopoverTargetValueComponent,
   variantsArgs
 );
 
-LightCenter.parameters = {
+PopoverContainerWithoutArrow.parameters = {
   figma: {
     component: {
       375: {
@@ -69,12 +56,6 @@ LightCenter.parameters = {
           },
         },
       },
-    },
-  },
-};
-LightLeft.parameters = {
-  figma: {
-    component: {
       834: {
         component:
           'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=14723%3A160960&t=GfCJNnX1UcXL4afU-4',

--- a/src/stories/containers/TransparencyReport/components/ArrowPopoverTargetValue/ArrowPopoverTargetValueComponent.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/ArrowPopoverTargetValue/ArrowPopoverTargetValueComponent.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: ArrowPopoverTargetValueComponent,
   parameters: {
     chromatic: {
-      viewports: [375, 834],
+      viewports: [375],
       pauseAnimationAtEnd: true,
     },
   },
@@ -53,19 +53,6 @@ PopoverContainerWithoutArrow.parameters = {
           style: {
             top: -32,
             left: -40,
-          },
-        },
-      },
-      834: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=14723%3A160960&t=GfCJNnX1UcXL4afU-4',
-        options: {
-          componentStyle: {
-            width: 305,
-          },
-          style: {
-            top: -16,
-            left: 0,
           },
         },
       },

--- a/src/stories/containers/TransparencyReport/components/ArrowPopoverTargetValue/ArrowPopoverTargetValueComponent.tsx
+++ b/src/stories/containers/TransparencyReport/components/ArrowPopoverTargetValue/ArrowPopoverTargetValueComponent.tsx
@@ -1,35 +1,21 @@
 import styled from '@emotion/styled';
+import ArrowPopover from '@ses/components/ArrowPopover/ArrowPopover';
 import React from 'react';
-import ArrowPopover from '../../../../components/ArrowPopover/ArrowPopover';
 import ArrowPopoverTargetValueContent from './ArrowPopoverTargetValueContent';
+import type { TargetBalanceTooltipInformation } from '@ses/core/utils/typesHelpers';
 import type { CSSProperties } from 'react';
 
 interface Props {
   name: string;
   longCode: string;
-  description: string;
-  mipNumber: string;
-  link?: string;
   style?: CSSProperties;
+  toolTipData: Pick<TargetBalanceTooltipInformation, 'description' | 'mipNumber' | 'link'>;
 }
 
-const ArrowPopoverTargetValueComponent: React.FC<Props> = ({
-  description,
-  longCode,
-  mipNumber,
-  name,
-  link,
-  style = {},
-}) => (
+const ArrowPopoverTargetValueComponent: React.FC<Props> = ({ toolTipData, longCode, name, style = {} }) => (
   <Container style={style}>
     <ArrowPopover>
-      <ArrowPopoverTargetValueContent
-        longCode={longCode}
-        name={name}
-        description={description}
-        mipNumber={mipNumber}
-        link={link}
-      />
+      <ArrowPopoverTargetValueContent longCode={longCode} name={name} toolTipData={toolTipData} />
     </ArrowPopover>
   </Container>
 );

--- a/src/stories/containers/TransparencyReport/components/ArrowPopoverTargetValue/ArrowPopoverTargetValueContent.tsx
+++ b/src/stories/containers/TransparencyReport/components/ArrowPopoverTargetValue/ArrowPopoverTargetValueContent.tsx
@@ -1,46 +1,49 @@
 import styled from '@emotion/styled';
 import { CustomLink } from '@ses/components/CustomLink/CustomLink';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
 import React from 'react';
+import type { TargetBalanceTooltipInformation, WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
-  description?: string;
-  mipNumber?: string;
-  link?: string;
+  toolTipData: Pick<TargetBalanceTooltipInformation, 'description' | 'mipNumber' | 'link'>;
   name: string;
   longCode: string;
 }
 
-const ArrowPopoverTargetValueContent: React.FC<Props> = ({ description, link, name, mipNumber, longCode }) => (
-  <Container>
-    <Description>{description}</Description>
-    <Source>Source</Source>
-    <ContainerLinkWithMip>
-      <MipNumber>{mipNumber}</MipNumber>
-      <ContainerLink>
-        <CustomLink
-          children={`Modify Core Unit Budget -
+const ArrowPopoverTargetValueContent: React.FC<Props> = ({ toolTipData, name, longCode }) => {
+  const { isLight } = useThemeContext();
+  return (
+    <Container>
+      <Description isLight={isLight}>{toolTipData.description}</Description>
+      <Source isLight={isLight}>Source</Source>
+      <ContainerLinkWithMip isLight={isLight}>
+        <MipNumber>{toolTipData.mipNumber}</MipNumber>
+        <ContainerLink>
+          <CustomLink
+            children={`Modify Core Unit Budget -
            ${name} (${longCode})`}
-          withArrow
-          marginLeft="7px"
-          href={link}
-          iconWidth={10}
-          fontWeight={400}
-          iconHeight={10}
-          style={{
-            lineHeight: '15px',
-            fontSize: '12px',
-            letterSpacing: '0px',
-            marginLeft: 0,
-            paddingRight: 0,
-            whiteSpace: 'pre-line',
-            overflowWrap: 'break-word',
-            width: '259px',
-          }}
-        />
-      </ContainerLink>
-    </ContainerLinkWithMip>
-  </Container>
-);
+            withArrow
+            marginLeft="7px"
+            href={toolTipData.link}
+            iconWidth={10}
+            fontWeight={400}
+            iconHeight={10}
+            style={{
+              lineHeight: '15px',
+              fontSize: '12px',
+              letterSpacing: '0px',
+              marginLeft: 0,
+              paddingRight: 0,
+              whiteSpace: 'pre-line',
+              overflowWrap: 'break-word',
+              width: '259px',
+            }}
+          />
+        </ContainerLink>
+      </ContainerLinkWithMip>
+    </Container>
+  );
+};
 
 export default ArrowPopoverTargetValueContent;
 
@@ -49,33 +52,33 @@ const Container = styled.div({
   flexDirection: 'column',
   justifyContent: 'flex-start',
 });
-const Description = styled.div({
+const Description = styled.div<WithIsLight>(({ isLight }) => ({
   marginBottom: 16,
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
   fontWeight: 400,
   fontSize: 14,
   lineHeight: '17px',
-  color: '#231536',
-});
-const Source = styled.div({
+  color: isLight ? '#231536' : '#ADAFD4',
+}));
+const Source = styled.div<WithIsLight>(({ isLight }) => ({
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
   fontWeight: 600,
   fontSize: 11,
   lineHeight: '13px',
-  color: '#231536',
+  color: isLight ? '#231536' : '#ADAFD4',
   marginBottom: 4,
-});
+}));
 
-const ContainerLinkWithMip = styled.div({
+const ContainerLinkWithMip = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'flex',
   flexDirection: 'column',
-  background: '#EDEFFF',
+  background: isLight ? '#EDEFFF' : '#25273D',
   borderRadius: 6,
   padding: 6,
   height: '64px',
-});
+}));
 
 const ContainerLink = styled.div({
   display: 'flex',

--- a/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/useTransparencyTransferRequest.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/useTransparencyTransferRequest.tsx
@@ -1,12 +1,12 @@
 import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
 import { formatNumber } from '@ses/core/utils/string';
-import { DateTime } from 'luxon';
 import { useMemo } from 'react';
 import { renderLinks, renderNumberWithIcon, renderWallet } from '../../transparencyReportUtils';
 import { useTransparencyForecast } from '../TransparencyForecast/useTransparencyForecast';
 import type { InnerTableColumn, InnerTableRow } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
 import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
 import type { TargetBalanceTooltipInformation } from '@ses/core/utils/typesHelpers';
+import type { DateTime } from 'luxon';
 
 export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetStatements: BudgetStatementDto[]) => {
   const { firstMonth, secondMonth, thirdMonth, getForecastSumOfMonthsOnWallet, getForecastSumForMonths, wallets } =
@@ -145,8 +145,12 @@ export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetSta
                 secondMonth,
                 thirdMonth,
               ]),
-              targetBalanceFirstMonth: DateTime.now(),
-              targetBalanceSecondMonth: DateTime.now(),
+              months: 'FEB + MAR Budget Cap',
+              mipNumber: 'MIP40c3-SP14:',
+              link: '#',
+              description: '2 Month Budget Cap',
+              longCode: 'SES-001',
+              name: 'Sustainable Ecosystem Scaling',
             } as TargetBalanceTooltipInformation,
           },
           {

--- a/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
+++ b/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
@@ -84,11 +84,13 @@ export const renderNumberWithIcon = (data: TargetBalanceTooltipInformation) => (
         }}
         title={
           <ArrowPopoverTargetValueComponent
-            link="#"
-            description="2 Month Budget Cap"
-            longCode="SES-001"
-            mipNumber="MIP40c3-SP14:"
-            name="Collateral Engineering Services"
+            toolTipData={{
+              link: data.link,
+              description: data.description,
+              mipNumber: data.mipNumber,
+            }}
+            longCode={data.longCode}
+            name={data.name}
           />
         }
         leaveOnChildrenMouseOut
@@ -99,11 +101,7 @@ export const renderNumberWithIcon = (data: TargetBalanceTooltipInformation) => (
       </CustomPopover>
       <ContainerInformation>
         <ContainerNumberCell value={data.balance} />
-        <ContainerStyleMonths style={{}}>{`${data.targetBalanceFirstMonth
-          .toFormat('LLL')
-          .toLocaleUpperCase()} + ${data.targetBalanceSecondMonth
-          .toFormat('LLL')
-          .toLocaleUpperCase()}  Budget Cap`}</ContainerStyleMonths>
+        <ContainerStyleMonths>{data.months}</ContainerStyleMonths>
       </ContainerInformation>
     </Container>
   </PopoverContainer>


### PR DESCRIPTION
# Ticket

https://trello.com/c/tixH6IkI/245-feature-coreunittransparencyreporting-v6

#What solved
Should switch the styles of the icon/tooltip to dark on dark mode  Desk
Should add an information tooltip on the "Target balance" column

# Actions
Add dark mode and other parameter necessary
