### PR TITLE
Add more padding in bigger resolution

### DIFF
--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: FinancesOverviewContainer,
   decorators: [withoutSBPadding],
   chromatic: {
-    viewports: [375, 834, 1194],
+    viewports: [375, 834, 1194, 1440],
     pauseAnimationAtEnd: true,
   },
   parameters: {
@@ -146,7 +146,8 @@ LightMode.parameters = {
         },
       },
       1440: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=15343%3A199079',
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=15343:199079&t=u7vF8lSvHCDE6Xof-4',
         options: {
           componentStyle: {
             width: 1440,
@@ -155,7 +156,8 @@ LightMode.parameters = {
         },
       },
       1920: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=13399%3A142663',
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=13399:142663&t=u7vF8lSvHCDE6Xof-4',
         options: {
           componentStyle: {
             width: 1920,

--- a/src/stories/containers/FinancesOverview/components/QuarterCard/QuarterCard.stories.tsx
+++ b/src/stories/containers/FinancesOverview/components/QuarterCard/QuarterCard.stories.tsx
@@ -34,8 +34,9 @@ export const [[LightMode, DarkMode]] = createThemeModeVariants(QuarterCard, args
 LightMode.parameters = {
   figma: {
     component: {
-      0: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=13399%3A147644',
+      375: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=15491:166053&t=0uzloS94rCOJjOj1-4',
         options: {
           componentStyle: {
             width: 164,

--- a/src/stories/containers/FinancesOverview/components/QuarterCard/QuarterCard.stories.tsx
+++ b/src/stories/containers/FinancesOverview/components/QuarterCard/QuarterCard.stories.tsx
@@ -8,14 +8,14 @@ export default {
   component: QuarterCard,
   decorators: [
     (Story: Story) => (
-      <div style={{ maxWidth: 270.5 }}>
+      <div style={{ maxWidth: 310 }}>
         <Story />
       </div>
     ),
   ],
   parameters: {
     chromatic: {
-      viewports: [375, 834, 1194],
+      viewports: [375, 834, 1194, 1440],
       pauseAnimationAtEnd: true,
     },
   },
@@ -63,6 +63,19 @@ LightMode.parameters = {
         options: {
           componentStyle: {
             width: 270.5,
+          },
+          style: {
+            top: -1,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=15343:199281&t=u7vF8lSvHCDE6Xof-4',
+        options: {
+          componentStyle: {
+            width: 310,
           },
           style: {
             top: -1,

--- a/src/stories/containers/FinancesOverview/components/QuarterCard/QuarterCard.tsx
+++ b/src/stories/containers/FinancesOverview/components/QuarterCard/QuarterCard.tsx
@@ -104,6 +104,7 @@ const Prediction = styled.div<WithIsLight>(({ isLight }) => ({
   marginLeft: 'auto',
   marginRight: 'auto',
   color: isLight ? '#231536' : '#EDEFFF',
+  fontFeatureSettings: "'tnum' on, 'lnum' on",
 }));
 
 const PredictionNumber = styled.div({
@@ -195,6 +196,7 @@ const LegendNumber = styled.div({
   fontWeight: 700,
   fontSize: 10,
   lineHeight: '12px',
+  fontFeatureSettings: "'tnum' on, 'lnum' on",
 
   [lightTheme.breakpoints.up('table_834')]: {
     fontSize: 14,

--- a/src/stories/containers/FinancesOverview/components/QuarterCard/QuarterCard.tsx
+++ b/src/stories/containers/FinancesOverview/components/QuarterCard/QuarterCard.tsx
@@ -87,6 +87,9 @@ const Card = styled.div<WithIsLight>(({ isLight }) => ({
   [lightTheme.breakpoints.up('table_834')]: {
     padding: 16,
   },
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    padding: '16px 24px',
+  },
 }));
 
 const PredictionWrapper = styled.div({

--- a/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.stories.tsx
+++ b/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: QuarterCarousel,
   parameters: {
     chromatic: {
-      viewports: [375, 834, 1194],
+      viewports: [375, 834, 1194, 1440],
       pauseAnimationAtEnd: true,
     },
   },
@@ -97,6 +97,19 @@ LightMode.parameters = {
         options: {
           componentStyle: {
             width: 1130,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=15343:199190&t=1jQcjZZk6fFlTwlR-4',
+        options: {
+          componentStyle: {
+            width: 1312,
           },
           style: {
             top: 0,

--- a/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.stories.tsx
+++ b/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.stories.tsx
@@ -68,8 +68,9 @@ export const [[LightMode, DarkMode]] = createThemeModeVariants(QuarterCarousel, 
 LightMode.parameters = {
   figma: {
     component: {
-      0: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=13399%3A147553',
+      375: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=15491:165961&t=0uzloS94rCOJjOj1-4',
         options: {
           componentStyle: {
             maxWidth: 348,

--- a/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.tsx
+++ b/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.tsx
@@ -35,7 +35,9 @@ export default QuarterCarousel;
 
 const SwiperWrapper = styled.div({
   margin: '0 -8px',
-
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    margin: '0 -12px',
+  },
   [lightTheme.breakpoints.up('table_834')]: {
     marginBottom: 32,
   },

--- a/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.tsx
+++ b/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.tsx
@@ -63,6 +63,10 @@ const CardWrapper = styled.div({
   marginRight: 8,
   marginBottom: 40,
   width: '100%',
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    marginLeft: 12,
+    marginRight: 12,
+  },
 });
 
 const Divider = styled.div({


### PR DESCRIPTION
# Ticket
https://trello.com/c/4OEItwNA/256-qa-bug-findings-v-80

#What solved
The spacing of quarterly expenses card sub-data (eg. ‘actuals’ and ‘cap’) is off.

# Actions
Add more padding in bigger resolution
