### PR TITLE
Add new layout in column target balance

### DIFF
--- a/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/useTransparencyTransferRequest.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/useTransparencyTransferRequest.tsx
@@ -1,7 +1,7 @@
 import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
 import { formatNumber } from '@ses/core/utils/string';
 import { useMemo } from 'react';
-import { renderLinks, RenderNumberWithIcon, renderWallet } from '../../transparencyReportUtils';
+import { renderLinks, RenderNumberWithIcon, renderWallet, TotalTargetBalance } from '../../transparencyReportUtils';
 import { useTransparencyForecast } from '../TransparencyForecast/useTransparencyForecast';
 import type { InnerTableColumn, InnerTableRow } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
 import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
@@ -102,7 +102,7 @@ export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetSta
       {
         header: 'Target Balance',
         type: 'custom',
-        align: 'left',
+        align: 'right',
 
         cellRender: RenderNumberWithIcon,
       },
@@ -182,11 +182,11 @@ export const useTransparencyTransferRequest = (currentMonth: DateTime, budgetSta
             column: mainTableColumns[1],
 
             value: (
-              <b>
+              <TotalTargetBalance>
                 {formatNumber(
                   getForecastSumForMonths(budgetStatements, currentMonth, [firstMonth, secondMonth, thirdMonth])
                 )}
-              </b>
+              </TotalTargetBalance>
             ),
           },
           {

--- a/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
+++ b/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
@@ -249,7 +249,6 @@ const PopoverContainer = styled.div({
   flex: 1,
 });
 const Container = styled.div({
-  flex: 1,
   width: '100%',
   display: 'flex',
   flexDirection: 'row',
@@ -260,6 +259,7 @@ const Container = styled.div({
     width: '100%',
     flexDirection: 'row-reverse',
     marginLeft: 0,
+
     marginTop: 0,
   },
 });
@@ -268,12 +268,20 @@ export const ContainerInfoIcon = styled.div({
   paddingRight: 0,
   marginTop: -10,
   display: 'flex',
-
   flexDirection: 'row',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
     height: 32,
     display: 'flex',
     alignItems: 'center',
+    marginTop: 0,
+    marginRight: 12.5,
+  },
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    height: 32,
+    alignItems: 'center',
+
+    marginRight: 20,
     marginTop: 0,
   },
 });
@@ -283,8 +291,14 @@ const ContainerInformation = styled.div({
   flex: 1,
   flexDirection: 'column',
   alignItems: 'flex-end',
-  [lightTheme.breakpoints.up('table_834')]: {
-    alignItems: 'flex-start',
+
+  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
+    alignItems: 'flex-end',
+    marginRight: 4.5,
+  },
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    alignItems: 'flex-end',
+    marginRight: 14,
   },
 });
 
@@ -292,6 +306,8 @@ const ContainerNumberCell = styled(NumberCell)({
   paddingBottom: 2,
   '@media (min-width: 834px)': {
     paddingBottom: 0,
+    paddingRight: 0,
+    paddingTop: 0,
   },
 });
 
@@ -300,5 +316,19 @@ const ContainerStyleMonths = styled.div({
   fontSize: '11px',
   lineHeight: '13px',
   color: '#546978',
-  marginLeft: 16,
+  [lightTheme.breakpoints.up('table_834')]: {
+    whiteSpace: 'nowrap',
+  },
+});
+
+export const TotalTargetBalance = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  flex: 1,
+  justifyContent: 'flex-end',
+  textAlign: 'center',
+  fontWeight: 700,
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    marginRight: 32,
+  },
 });

--- a/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
+++ b/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
@@ -113,7 +113,7 @@ export const RenderNumberWithIcon = (data: TargetBalanceTooltipInformation) => {
                   overflowX: 'unset',
                   overflowY: 'unset',
                 },
-                marginLeft: -5.5,
+                marginLeft: -6.7,
                 marginTop: 0.6,
               }}
               id="information"


### PR DESCRIPTION
# Ticket

https://trello.com/c/tixH6IkI/245-feature-coreunittransparencyreporting-v6

#What solved
Should align the target balance value to the left In the Transfer Requests tab
Should display in a line the months (Month + Month Budget Cap) in the target balance (834 resolution). 

# Actions
Add new layout in column target balance