### PR TITLE
[SES-246] Connect cost breakdown with API

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,38 +1,55 @@
 import { CURRENT_ENVIRONMENT } from '@ses/config/endpoints';
 import { CuTable } from '@ses/containers/CUTable/CuTable';
 import FinancesOverviewContainer from '@ses/containers/FinancesOverview/FinancesOverviewContainer';
-import { fetchExpenses } from '@ses/containers/FinancesOverview/api/queries';
+import { fetchCostBreakdownExpenses, fetchExpenses } from '@ses/containers/FinancesOverview/api/queries';
 import { ExpenseGranularity } from '@ses/core/models/dto/expensesDTO';
 import React from 'react';
 import { featureFlags } from '../feature-flags/feature-flags';
+import type { ExtendedExpense } from '@ses/containers/FinancesOverview/financesOverviewTypes';
 import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
 import type { NextPage } from 'next';
 
-type FinanceOverviewPageProps = {
+interface FinanceOverviewPageProps {
   quarterExpenses: ExpenseDto[];
   monthlyExpenses: Partial<ExpenseDto>[];
-};
+  breakdownExpenses: ExtendedExpense[];
+}
 
-const FinanceOverviewPage: NextPage<FinanceOverviewPageProps> = ({ quarterExpenses, monthlyExpenses }) => {
+const FinanceOverviewPage: NextPage<FinanceOverviewPageProps> = ({
+  quarterExpenses,
+  monthlyExpenses,
+  breakdownExpenses,
+}) => {
   if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_FINANCES_OVERVIEW) {
     // core unit overview would be the home page if the finances overview is disabled
     return <CuTable />;
   }
 
-  return <FinancesOverviewContainer quarterExpenses={quarterExpenses} monthlyExpenses={monthlyExpenses || []} />;
+  return (
+    <FinancesOverviewContainer
+      quarterExpenses={quarterExpenses}
+      monthlyExpenses={monthlyExpenses || []}
+      breakdownExpenses={breakdownExpenses}
+    />
+  );
 };
 
 export default FinanceOverviewPage;
 
 export async function getServerSideProps() {
   if (featureFlags[CURRENT_ENVIRONMENT].FEATURE_FINANCES_OVERVIEW) {
-    const quarterExpenses = await fetchExpenses(ExpenseGranularity.quarterly);
-    const monthlyExpenses = await fetchExpenses(ExpenseGranularity.monthly);
+    const [quarterExpenses, monthlyExpenses, breakdownExpenses] = await Promise.all([
+      fetchExpenses(ExpenseGranularity.quarterly),
+      fetchExpenses(ExpenseGranularity.monthly),
+      // fetchExpenses(ExpenseGranularity.annual, 'makerdao/*:*/*:*'),
+      fetchCostBreakdownExpenses(),
+    ]);
 
     return {
       props: {
         quarterExpenses,
         monthlyExpenses,
+        breakdownExpenses,
       },
     };
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -41,7 +41,6 @@ export async function getServerSideProps() {
     const [quarterExpenses, monthlyExpenses, breakdownExpenses] = await Promise.all([
       fetchExpenses(ExpenseGranularity.quarterly),
       fetchExpenses(ExpenseGranularity.monthly),
-      // fetchExpenses(ExpenseGranularity.annual, 'makerdao/*:*/*:*'),
       fetchCostBreakdownExpenses(),
     ]);
 

--- a/src/core/businessLogic/builders/totalExpenseReportsBuilder.ts
+++ b/src/core/businessLogic/builders/totalExpenseReportsBuilder.ts
@@ -1,3 +1,4 @@
+import type { ExtendedExpense } from '@ses/containers/FinancesOverview/financesOverviewTypes';
 import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
 
 export class TotalExpenseReportsBuilder {
@@ -51,6 +52,18 @@ export class TotalExpenseReportsBuilder {
 
   withMonthlyPeriod(year: number, month: number): TotalExpenseReportsBuilder {
     this._expense.period = `${year}-${month < 10 ? `0${month}` : month}`;
+    return this;
+  }
+
+  withAnnualPeriod(year: number): TotalExpenseReportsBuilder {
+    this._expense.period = `${year}`;
+    return this;
+  }
+
+  extend(shortCode: string, name: string): TotalExpenseReportsBuilder {
+    const ref = this._expense as ExtendedExpense;
+    ref.shortCode = shortCode;
+    ref.name = name;
     return this;
   }
 

--- a/src/core/models/dto/expensesDTO.ts
+++ b/src/core/models/dto/expensesDTO.ts
@@ -10,4 +10,5 @@ export interface ExpenseDto {
 export enum ExpenseGranularity {
   monthly = 'monthly',
   quarterly = 'quarterly',
+  annual = 'annual',
 }

--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -116,6 +116,7 @@ const dictionary = [
   'lnum',
   'touchstart',
   'scrollable',
+  'deco',
 ];
 
 module.exports = dictionary;

--- a/src/core/utils/math.ts
+++ b/src/core/utils/math.ts
@@ -1,0 +1,1 @@
+export const percentageRespectTo = (a: number, b: number): number => (a / b) * 100;

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
@@ -11,12 +11,12 @@ export default {
   title: 'Pages/Finances Overview',
   component: FinancesOverviewContainer,
   decorators: [withoutSBPadding],
-  chromatic: {
-    viewports: [375, 834, 1194],
-    pauseAnimationAtEnd: true,
-  },
   parameters: {
     date: new Date('2023-02-14T04:14:00.000Z'),
+    chromatic: {
+      viewports: [375, 834, 1194, 1280, 1440, 1920],
+      pauseAnimationAtEnd: true,
+    },
   },
 } as ComponentMeta<typeof FinancesOverviewContainer>;
 

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
@@ -88,6 +88,74 @@ const variantsArgs = [
       new TotalExpenseReportsBuilder().withPrediction(231563).withActuals(632531).withMonthlyPeriod(2023, 11).build(),
       new TotalExpenseReportsBuilder().withPrediction(231563).withActuals(1242156).withMonthlyPeriod(2023, 12).build(),
     ] as Partial<ExpenseDto>[],
+    breakdownExpenses: [
+      new TotalExpenseReportsBuilder()
+        .withPrediction(5827878)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('PE', 'Protocol Engineering')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(3433400)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('GRO', 'Growth')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(3112752)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('CES', 'Collateral Engineering Services')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(2633200)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('RISK', 'Risk')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(2539612)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('ORA', 'Oracles')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(2364780)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('DECO', 'Deco Protocol')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(2364780)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('TECH', 'TechOps')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(1739908)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('SF', 'Strategic Happiness')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(1573652)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('DEL', 'Feedback Loops LLC')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(1240280)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('DUX', 'Development & UX')
+        .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(425631)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('TEST', 'Testing')
+        .build(),
+    ],
   },
 ];
 

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
@@ -9,15 +9,21 @@ import NavigationButtons from './components/NavigationButtons/NavigationButtons'
 import QuarterCarousel from './components/QuarterCarousel/QuarterCarousel';
 import YearPicker from './components/YearPicker/YearPicker';
 import useFinancesOverview from './useFinancesOverview';
+import type { ExtendedExpense } from './financesOverviewTypes';
 import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
-type FinancesOverviewContainerProps = {
+interface FinancesOverviewContainerProps {
   monthlyExpenses: Partial<ExpenseDto>[];
   quarterExpenses: ExpenseDto[];
-};
+  breakdownExpenses: ExtendedExpense[];
+}
 
-const FinancesOverviewContainer: React.FC<FinancesOverviewContainerProps> = ({ monthlyExpenses, quarterExpenses }) => {
+const FinancesOverviewContainer: React.FC<FinancesOverviewContainerProps> = ({
+  monthlyExpenses,
+  quarterExpenses,
+  breakdownExpenses,
+}) => {
   const {
     isLight,
     selectedYear,
@@ -31,7 +37,11 @@ const FinancesOverviewContainer: React.FC<FinancesOverviewContainerProps> = ({ m
     isDownTable,
     selectedFilter,
     setSelectedFilter,
-  } = useFinancesOverview(quarterExpenses, monthlyExpenses);
+    byBudgetExpenses,
+    remainingBudgetCU,
+    remainingBudgetDelegates,
+    costBreakdownTotal,
+  } = useFinancesOverview(quarterExpenses, monthlyExpenses, breakdownExpenses);
 
   return (
     <Container isLight={isLight}>
@@ -67,7 +77,14 @@ const FinancesOverviewContainer: React.FC<FinancesOverviewContainerProps> = ({ m
             {!isDownTable && <NavigationButtons />}
           </ExpensesChartColumn>
           <BreakdownTableColumn>
-            <CostBreakdownTable selectedFilter={selectedFilter} setSelectedFilter={setSelectedFilter} />
+            <CostBreakdownTable
+              selectedFilter={selectedFilter}
+              setSelectedFilter={setSelectedFilter}
+              byBudgetExpenses={byBudgetExpenses}
+              remainingBudgetCU={remainingBudgetCU}
+              remainingBudgetDelegates={remainingBudgetDelegates}
+              total={costBreakdownTotal}
+            />
           </BreakdownTableColumn>
           {isDownTable && <NavigationButtons />}
         </BreakdownSectionContainer>

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
@@ -220,7 +220,7 @@ const TotalDescription = styled.label<WithIsLight>(({ isLight }) => ({
 const BreakdownSectionContainer = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  gap: 38,
+  gap: 39,
 
   [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
     gap: 18,

--- a/src/stories/containers/FinancesOverview/api/queries.ts
+++ b/src/stories/containers/FinancesOverview/api/queries.ts
@@ -1,8 +1,13 @@
 import { GRAPHQL_ENDPOINT } from '@ses/config/endpoints';
+import { ExpenseGranularity } from '@ses/core/models/dto/expensesDTO';
+import { getShortCode } from '@ses/core/utils/string';
 import request, { gql } from 'graphql-request';
-import type { ExpenseDto, ExpenseGranularity } from '@ses/core/models/dto/expensesDTO';
+import { isCoreUnitExpense } from '../utils/costBreakdown';
+import type { ExtendedExpense } from '../financesOverviewTypes';
+import type { CoreUnitDto } from '@ses/core/models/dto/coreUnitDTO';
+import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
 
-export const totalExpensesAPI = (granularity: ExpenseGranularity) => ({
+export const totalExpensesQuery = (granularity: ExpenseGranularity, budgets: string) => ({
   query: gql`
     query TotalExpenses($filter: AggregateExpensesFilter) {
       totalQuarterlyExpenses(filter: $filter) {
@@ -21,16 +26,74 @@ export const totalExpensesAPI = (granularity: ExpenseGranularity) => ({
   `,
   filter: {
     filter: {
-      budgets: 'makerdao/*',
+      budgets,
       granularity,
     },
   },
 });
 
-export const fetchExpenses = async (granularity: ExpenseGranularity): Promise<ExpenseDto[]> => {
-  const { query, filter } = totalExpensesAPI(granularity);
+export const costBreakdownExpensesQuery = () => ({
+  query: gql`
+    query CostBreakdownExpenses($filter: AggregateExpensesFilter) {
+      totalQuarterlyExpenses(filter: $filter) {
+        reports {
+          expenses {
+            actuals
+            budget
+            budgetCap
+            discontinued
+            period
+            prediction
+          }
+        }
+      }
+      coreUnits {
+        shortCode
+        name
+      }
+    }
+  `,
+  filter: {
+    filter: {
+      budgets: 'makerdao/*:*/*:*',
+      granularity: ExpenseGranularity.annual,
+    },
+  },
+});
+
+export const fetchExpenses = async (granularity: ExpenseGranularity, budgets = 'makerdao/*'): Promise<ExpenseDto[]> => {
+  const { query, filter } = totalExpensesQuery(granularity, budgets);
   const res = (await request(GRAPHQL_ENDPOINT, query, filter)) as {
     totalQuarterlyExpenses: { reports: { expenses: ExpenseDto[] } };
   };
   return res.totalQuarterlyExpenses.reports.expenses;
+};
+
+export const fetchCostBreakdownExpenses = async (): Promise<ExtendedExpense[]> => {
+  const { query, filter } = costBreakdownExpensesQuery();
+  const res = (await request(GRAPHQL_ENDPOINT, query, filter)) as {
+    totalQuarterlyExpenses: { reports: { expenses: ExpenseDto[] } };
+    coreUnits: CoreUnitDto[];
+  };
+
+  const expenses = res.totalQuarterlyExpenses.reports.expenses;
+  const coreUnitsMap = new Map<string, CoreUnitDto>();
+  res.coreUnits.forEach((cu) => coreUnitsMap.set(cu.shortCode, cu));
+
+  const extendedExpenses = expenses.map((expense) => {
+    if (isCoreUnitExpense(expense)) {
+      const shortCode = getShortCode(expense.budget.replace('makerdao/core-units/', ''));
+      return {
+        ...expense,
+        shortCode,
+        name: coreUnitsMap.get(shortCode)?.name,
+      } as ExtendedExpense;
+    } else {
+      // it is a delegate expense
+      // TODO: extend with the delegate name
+      return expense as ExtendedExpense;
+    }
+  });
+
+  return extendedExpenses;
 };

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
@@ -136,6 +136,10 @@ const NameColumn = styled.div({
     paddingRight: 4,
     marginBottom: 0,
   },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    lineHeight: '23px',
+  },
 });
 
 const TotalPercentageColumn = styled.div({

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
@@ -100,7 +100,7 @@ const Row = styled.div<WithIsLight>(({ isLight }) => ({
   alignItems: 'center',
   padding: 8,
   background: isLight ? '#FFFFFF' : '#1E2C37',
-  marginBottom: 8,
+  marginBottom: 9,
   boxShadow: isLight
     ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
     : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
@@ -128,7 +128,7 @@ const MobileColumn = styled.div({
 const NameColumn = styled.div({
   width: '100%',
   marginBottom: 9.2,
-  lineHeight: '15px',
+  lineHeight: '14px',
   fontSize: 14,
 
   [lightTheme.breakpoints.up('table_834')]: {
@@ -211,7 +211,7 @@ const ViewColumn = styled.div({
 const ShortCode = styled.span<WithIsLight>(({ isLight }) => ({
   fontSize: 12,
   fontWeight: 800,
-  lineHeight: '15px',
+  lineHeight: '14px',
   letterSpacing: 0.3,
   textTransform: 'uppercase',
   color: isLight ? '#9FAFB9' : '#546978',
@@ -227,7 +227,7 @@ const ShortCode = styled.span<WithIsLight>(({ isLight }) => ({
 const Name = styled.span<WithIsLight>(({ isLight }) => ({
   fontSize: 12,
   fontWeight: 400,
-  lineHeight: '15px',
+  lineHeight: '14px',
   color: isLight ? '#231536' : '#D2D4EF ',
 
   [lightTheme.breakpoints.up('table_834')]: {

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableRow.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableRow.tsx
@@ -72,7 +72,7 @@ const NameColumnComponent: React.FC<WithIsLight & { name: string }> = ({ isLight
 const TotalPercentageColumnComponent: React.FC<WithIsLight> = ({ isLight }) => (
   <TotalPercentageColumn>
     <TotalBarContainer>
-      <RelativeBudgetBar budgetCap={20} actuals={14} prediction={16} />
+      <RelativeBudgetBar discontinued={20} actuals={14} prediction={16} maxPercentage={100} />
       <TotalPercentage isLight={isLight}>32%</TotalPercentage>
     </TotalBarContainer>
   </TotalPercentageColumn>

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -112,13 +112,14 @@ const Table = styled.div<WithIsLight>(({ isLight }) => ({
   [lightTheme.breakpoints.up('table_834')]: {
     background: isLight ? '#FFFFFF' : '#1E2C37',
     borderRadius: 6,
+    marginTop: 26,
     boxShadow: isLight
       ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
       : '10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
   },
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    marginTop: 16,
+    marginTop: 17,
   },
 }));
 

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -112,14 +112,14 @@ const Table = styled.div<WithIsLight>(({ isLight }) => ({
   [lightTheme.breakpoints.up('table_834')]: {
     background: isLight ? '#FFFFFF' : '#1E2C37',
     borderRadius: 6,
-    marginTop: 26,
+    marginTop: 25,
     boxShadow: isLight
       ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
       : '10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
   },
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    marginTop: 17,
+    marginTop: 15,
   },
 }));
 

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/TableFooter.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/TableFooter.tsx
@@ -18,7 +18,7 @@ const TableFooter: React.FC<TableFooterProps> = ({ mode, total = 0 }) => {
     <TableFooterContainer isLight={isLight}>
       <Total isLight={isLight}>Total </Total>
       <TotalNumber isLight={isLight} extraPadding={mode === 'By budget'}>
-        {usLocalizedNumber(total)} <DAISpan isLight={isLight}>DAI</DAISpan>
+        {usLocalizedNumber(Math.round(total))} <DAISpan isLight={isLight}>DAI</DAISpan>
       </TotalNumber>
     </TableFooterContainer>
   );

--- a/src/stories/containers/FinancesOverview/components/NavigationButtons/NavigationButtons.tsx
+++ b/src/stories/containers/FinancesOverview/components/NavigationButtons/NavigationButtons.tsx
@@ -19,7 +19,7 @@ const NavigationButtonsContainer = styled.div({
   flexDirection: 'column',
   gap: 16,
   width: '100%',
-  margin: '6px auto 0',
+  margin: '8px auto 0',
   padding: '0 22px',
 
   [lightTheme.breakpoints.up('table_834')]: {

--- a/src/stories/containers/FinancesOverview/components/NavigationButtons/NavigationButtons.tsx
+++ b/src/stories/containers/FinancesOverview/components/NavigationButtons/NavigationButtons.tsx
@@ -19,7 +19,7 @@ const NavigationButtonsContainer = styled.div({
   flexDirection: 'column',
   gap: 16,
   width: '100%',
-  margin: '8px auto 0',
+  margin: '10px auto 0',
   padding: '0 22px',
 
   [lightTheme.breakpoints.up('table_834')]: {

--- a/src/stories/containers/FinancesOverview/components/RelativeBudgetBar/RelativeBudgetBar.tsx
+++ b/src/stories/containers/FinancesOverview/components/RelativeBudgetBar/RelativeBudgetBar.tsx
@@ -5,27 +5,34 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface RelativeBudgetBarProps {
-  budgetCap: number;
+  discontinued: number;
   actuals: number;
   prediction: number;
+  maxPercentage?: number;
 }
 
-const RelativeBudgetBar: React.FC<RelativeBudgetBarProps> = ({ budgetCap, actuals, prediction }) => {
+const RelativeBudgetBar: React.FC<RelativeBudgetBarProps> = ({
+  discontinued,
+  actuals,
+  prediction,
+  maxPercentage = 100,
+}) => {
   const { isLight } = useThemeContext();
   const barRef = useRef<HTMLDivElement>(null);
+  const [discontinuedWidth, setDiscontinuedWidth] = useState<number>(0);
   const [actualsWidth, setActualsWidth] = useState<number>(0);
   const [predictionWidth, setPredictionWidth] = useState<number>(0);
 
   const updateBars = useCallback(() => {
     if (!barRef) return;
     const barWidth = barRef.current?.offsetWidth || 1;
-    const maxPercentage = 87;
     const max = (barWidth * maxPercentage) / 100;
-    const maxValue = Math.max(actuals, prediction, budgetCap) || 1;
+    const maxValue = Math.max(actuals, prediction, discontinued) || 1;
 
     setActualsWidth(((actuals / maxValue) * max * maxPercentage) / max);
     setPredictionWidth(((prediction / maxValue) * max * maxPercentage) / max);
-  }, [actuals, budgetCap, prediction]);
+    setDiscontinuedWidth(((discontinued / maxValue) * max * maxPercentage) / max);
+  }, [actuals, discontinued, prediction, maxPercentage]);
 
   useEffect(() => {
     updateBars();
@@ -35,6 +42,7 @@ const RelativeBudgetBar: React.FC<RelativeBudgetBarProps> = ({ budgetCap, actual
     <BudgetBar isLight={isLight} ref={barRef}>
       {prediction > 0 && <Prediction isLight={isLight} width={predictionWidth} />}
       {actuals > 0 && <Actuals isLight={isLight} width={actualsWidth} />}
+      {discontinued > 0 && <Discontinued isLight={isLight} width={discontinuedWidth} />}
     </BudgetBar>
   );
 };
@@ -60,10 +68,10 @@ const Actuals = styled.div<WithIsLight & { width: number }>(({ isLight, width })
   top: 0,
   left: 0,
   background: isLight ? '#0EB19F' : '#027265',
-  borderRadius: 4,
+  borderRadius: 6,
   width: `${width}%`,
   height: '100%',
-  transition: 'width 0.85s ease-in-out',
+  transition: 'width 0.5s ease-in-out',
 }));
 
 const Prediction = styled.div<WithIsLight & { width: number }>(({ isLight, width }) => ({
@@ -71,8 +79,19 @@ const Prediction = styled.div<WithIsLight & { width: number }>(({ isLight, width
   top: 0,
   left: 0,
   background: isLight ? '#68FEE3' : '#1AAB9B',
-  borderRadius: 4,
+  borderRadius: 6,
   width: `${width}%`,
   height: '100%',
-  transition: 'width 0.85s ease-in-out',
+  transition: 'width 0.5s ease-in-out',
+}));
+
+const Discontinued = styled.div<WithIsLight & { width: number }>(({ isLight, width }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  background: isLight ? '#027265' : '#2C3F3B',
+  borderRadius: 6,
+  width: `${width}%`,
+  height: '100%',
+  transition: 'width 0.5s ease-in-out',
 }));

--- a/src/stories/containers/FinancesOverview/financesOverviewTypes.ts
+++ b/src/stories/containers/FinancesOverview/financesOverviewTypes.ts
@@ -1,1 +1,8 @@
+import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
+
 export type CostBreakdownFilterValue = 'By budget' | 'By Category';
+
+export interface ExtendedExpense extends ExpenseDto {
+  shortCode?: string;
+  name: string;
+}

--- a/src/stories/containers/FinancesOverview/useFinancesOverview.ts
+++ b/src/stories/containers/FinancesOverview/useFinancesOverview.ts
@@ -143,7 +143,6 @@ const useFinancesOverview = (
   const { byBudgetExpenses, costBreakdownTotal, remainingBudgetCU, remainingBudgetDelegates } = useMemo(() => {
     let costBreakdownTotal = 0;
     const byBudgetExpenses: ExtendedExpense[] = [];
-    // const byCategory: ExtendedExpense[] = [];
     const remainingBudgetCU = {
       shortCode: 'CU',
       name: 'Remaining Core Units',
@@ -202,7 +201,6 @@ const useFinancesOverview = (
     selectedFilter,
     setSelectedFilter,
     byBudgetExpenses,
-    // byCategoryExpenses,
     remainingBudgetCU,
     remainingBudgetDelegates,
     costBreakdownTotal,

--- a/src/stories/containers/FinancesOverview/utils/costBreakdown.ts
+++ b/src/stories/containers/FinancesOverview/utils/costBreakdown.ts
@@ -1,0 +1,12 @@
+import type { ExtendedExpense } from '../financesOverviewTypes';
+import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
+
+export const isCoreUnitExpense = (expense: ExpenseDto): boolean => expense.budget.includes('makerdao/core-unit');
+
+export const mutableCombinationExpenseByAdding = (expenseA: ExtendedExpense, expenseB: ExtendedExpense): void => {
+  expenseA.actuals += expenseB.actuals;
+  expenseA.budget += expenseB.budget;
+  expenseA.budgetCap += expenseB.budgetCap;
+  expenseA.discontinued = (expenseA.discontinued ?? 0) + (expenseB.discontinued ?? 0);
+  expenseA.prediction += expenseB.prediction;
+};


### PR DESCRIPTION
# Ticket
https://trello.com/c/tqmW07KT/246-feature-aggregatedviewlevels-v1

# Description
Connect the UI of the Cost Breakdown table on the Finance's page with the API

# What solve
- Should get the required data from the API on Server Side
- Should have the Budget column: The core unit column will list core units and recognized delegates by name.
- Should add column “% of Total”
- Should be displayed 12 row, when the “By Budget” category is select
- Should order the entries of the table by absolute amount regardless of their source
- Should on the "By budget" the top 10 expenses be by absolute amount regardless of their source, either by individual core units, Individual recognized delegates , “remaining core units” and  “remaining recognized delegates”
- The "View" CTA should go to the right place
- Should have "Total Spend” with the absolute number that the line item is, expressed in DAI