### PR TITLE
[SES-QC-254] Create stories for CU about and transparency pages

### DIFF
--- a/src/core/businessLogic/builders/budgetStatementBuilder.ts
+++ b/src/core/businessLogic/builders/budgetStatementBuilder.ts
@@ -13,6 +13,7 @@ export class BudgetStatementBuilder {
 
   constructor() {
     this._budgetStatement = {
+      id: '',
       month: '',
       budgetStatementFTEs: [] as BudgetStatementFteDto[],
       budgetStatementWallet: [] as BudgetStatementWalletDto[],
@@ -20,6 +21,11 @@ export class BudgetStatementBuilder {
       status: BudgetStatus.Draft,
       publicationUrl: '',
     } as BudgetStatementDto;
+  }
+
+  withId(id: string): BudgetStatementBuilder {
+    this._budgetStatement.id = id;
+    return this;
   }
 
   withMonth(month: string): BudgetStatementBuilder {

--- a/src/core/businessLogic/builders/budgetStatementLineItemBuilder.ts
+++ b/src/core/businessLogic/builders/budgetStatementLineItemBuilder.ts
@@ -1,0 +1,68 @@
+import type { BudgetStatementLineItemDto } from '../../models/dto/coreUnitDTO';
+
+export class BudgetStatementLineItemBuilder {
+  private readonly _lineItem: BudgetStatementLineItemDto;
+
+  constructor() {
+    this._lineItem = {
+      actual: 0,
+      forecast: 0,
+      payment: 0,
+      budgetCategory: '',
+      headcountExpense: false,
+      comments: '',
+      month: '',
+      budgetCap: 0,
+      group: '',
+    };
+  }
+
+  withActual(actual: number): BudgetStatementLineItemBuilder {
+    this._lineItem.actual = actual;
+    return this;
+  }
+
+  withForecast(forecast: number): BudgetStatementLineItemBuilder {
+    this._lineItem.forecast = forecast;
+    return this;
+  }
+
+  withPayment(payment: number): BudgetStatementLineItemBuilder {
+    this._lineItem.payment = payment;
+    return this;
+  }
+
+  withBudgetCategory(budgetCategory: string): BudgetStatementLineItemBuilder {
+    this._lineItem.budgetCategory = budgetCategory;
+    return this;
+  }
+
+  withHeadcountExpense(headcountExpense: boolean): BudgetStatementLineItemBuilder {
+    this._lineItem.headcountExpense = headcountExpense;
+    return this;
+  }
+
+  withComments(comments: string): BudgetStatementLineItemBuilder {
+    this._lineItem.comments = comments;
+    return this;
+  }
+
+  withMonth(month: string): BudgetStatementLineItemBuilder {
+    this._lineItem.month = month;
+    return this;
+  }
+
+  withBudgetCap(budgetCap: number): BudgetStatementLineItemBuilder {
+    this._lineItem.budgetCap = budgetCap;
+    return this;
+  }
+
+  withGroup(group: string): BudgetStatementLineItemBuilder {
+    this._lineItem.group = group;
+    return this;
+  }
+
+  build(): BudgetStatementLineItemDto {
+    return this._lineItem;
+  }
+}

--- a/src/core/businessLogic/builders/budgetStatementWalletBuilder.ts
+++ b/src/core/businessLogic/builders/budgetStatementWalletBuilder.ts
@@ -6,6 +6,8 @@ export class BudgetStatementWalletBuilder {
   constructor() {
     this._wallet = {
       name: '',
+      address: '',
+      currentBalance: 0,
       budgetStatementLineItem: [] as BudgetStatementLineItemDto[],
     };
   }
@@ -17,6 +19,29 @@ export class BudgetStatementWalletBuilder {
         month,
       });
     });
+    return this;
+  }
+
+  addBudgetStatementLineItem(
+    lineItem: BudgetStatementLineItemDto | BudgetStatementLineItemDto[]
+  ): BudgetStatementWalletBuilder {
+    if (Array.isArray(lineItem)) {
+      lineItem.forEach((item) => {
+        this._wallet.budgetStatementLineItem.push(item);
+      });
+    } else {
+      this._wallet.budgetStatementLineItem.push(lineItem);
+    }
+    return this;
+  }
+
+  withName(name: string): BudgetStatementWalletBuilder {
+    this._wallet.name = name;
+    return this;
+  }
+
+  withAddress(address: string): BudgetStatementWalletBuilder {
+    this._wallet.address = address;
     return this;
   }
 

--- a/src/core/businessLogic/builders/coreUnitsBuilder.ts
+++ b/src/core/businessLogic/builders/coreUnitsBuilder.ts
@@ -21,6 +21,8 @@ export class CoreUnitsBuilder {
       id: '',
       legacyBudgetStatementUrl: '',
       sentenceDescription: '',
+      paragraphDescription: '',
+      paragraphImage: '',
       category: [] as string[],
       auditors: [] as AuditorDto[],
       budgetStatements: [] as BudgetStatementDto[],
@@ -63,6 +65,16 @@ export class CoreUnitsBuilder {
 
   withDescription(description: string): CoreUnitsBuilder {
     this._coreUnit.sentenceDescription = description;
+    return this;
+  }
+
+  withParagraphDescription(description: string): CoreUnitsBuilder {
+    this._coreUnit.paragraphDescription = description;
+    return this;
+  }
+
+  withParagraphImage(image: string): CoreUnitsBuilder {
+    this._coreUnit.paragraphImage = image;
     return this;
   }
 

--- a/src/core/businessLogic/builders/cuMIPBuilder.ts
+++ b/src/core/businessLogic/builders/cuMIPBuilder.ts
@@ -7,6 +7,7 @@ export class CuMipBuilder {
 
   constructor() {
     this._cuMip = {
+      mipTitle: '',
       mipStatus: 'Accepted',
       mip40: [] as Mip40Dto[],
       mip41: [] as Mip41Dto[],
@@ -16,6 +17,11 @@ export class CuMipBuilder {
       formalSubmission: '',
       obsolete: '',
     } as CuMipDto;
+  }
+
+  withMipTitle(title: string): CuMipBuilder {
+    this._cuMip.mipTitle = title;
+    return this;
   }
 
   withStatus(status: CuStatusEnum, date: string): CuMipBuilder {

--- a/src/core/hooks/useBudgetStatementComments.ts
+++ b/src/core/hooks/useBudgetStatementComments.ts
@@ -25,7 +25,7 @@ const useBudgetStatementComments = (
 
   const comments = useMemo(() => {
     const comments = getAllCommentsBudgetStatementLine(budgetStatement) as (CommentsBudgetStatementDto & WithDate)[];
-    let activities = budgetStatement?.activityFeed.filter(
+    let activities = budgetStatement?.activityFeed?.filter(
       (activity) => activity.event === 'CU_BUDGET_STATEMENT_CREATED'
     ) as (ActivityFeedDto & WithDate)[];
     activities =

--- a/src/core/utils/storybook/mocks/coreUnitsMocks.ts
+++ b/src/core/utils/storybook/mocks/coreUnitsMocks.ts
@@ -1,20 +1,39 @@
+import { BudgetStatementBuilder } from '@ses/core/businessLogic/builders/budgetStatementBuilder';
+import { BudgetStatementLineItemBuilder } from '@ses/core/businessLogic/builders/budgetStatementLineItemBuilder';
+import { BudgetStatementWalletBuilder } from '@ses/core/businessLogic/builders/budgetStatementWalletBuilder';
 import { CoreUnitsBuilder } from '@ses/core/businessLogic/builders/coreUnitsBuilder';
 import { CuMipBuilder } from '@ses/core/businessLogic/builders/cuMIPBuilder';
+import { UserBuilder } from '@ses/core/businessLogic/builders/userBuilder';
 import { CuCategoryEnum } from '@ses/core/enums/cuCategoryEnum';
 import { CuStatusEnum } from '@ses/core/enums/cuStatusEnum';
 
 export const SESCoreUnitMocked = new CoreUnitsBuilder()
   .withId('1')
+  .withCode('SES-001')
   .withShortCode('SES')
   .withName('Sustainable Ecosystem Scaling')
   .withImage('https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ses-001/logo.png')
   .withDescription(
     "The aim of SES is to sustainably grow the Maker Protocol's moats by systematically removing barriers between the decentralized workforce, capital, and work."
   )
+  .withParagraphDescription(
+    'The SES Core Unit supports a decentralized, effective, and scalable economy on top of the Maker Protocol that continues to push forward its growth in a sustainable manner.\n\nThis decentralized, effective, and scalable economy:  \n\n1. Has the best and most successful **onboarding experience** for new participants, with the highest **retention rate** in the industry.\n1. Allows everyone to **find the capital they need** to work on **the best projects** which (1) optimally drive protocol growth and (2) are most fulfilling for its participants.\n1. Has **resilient safety mechanisms** in place that **prevent protocol failure** while leaving ample space for **rapid innovation and experimentation.**\n\n**Strategy**\n\nThe strategy for growing the Maker Protocol’s moats is structured as a **continuous improvement** cycle with research and development at its core. Iterating through this cycle will systematically **drive the ecosystem closer to the vision** that was outlined.\n\nIn a typical iteration: (1) new scaling bottlenecks are first identified, (2) research is then conducted on how to remove these bottlenecks, and, finally, (3) activities are funded and kick-started to implement practical solutions in line with the research.'
+  )
+  .withParagraphImage('https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ses-001/diagram.png')
+  .addAuditors(new UserBuilder().withName('jhon').build())
   .addCuMip(
     new CuMipBuilder()
+      .withMipTitle('MIP39c2-SP10: Core Unit Budget for Sustainable Ecosystem Scaling (SES-001)')
       .withStatus(CuStatusEnum.Accepted, '2021-05-25')
       .withMipCode('MIP39')
+      .withFormalSubmission('2021-05-25')
+      .build()
+  )
+  .addCuMip(
+    new CuMipBuilder()
+      .withMipTitle('MIP40c3-SP10: Core Unit Facilitator Onboarding (SES-001)')
+      .withStatus(CuStatusEnum.Accepted, '2021-05-25')
+      .withMipCode('MIP40')
       .withFormalSubmission('2021-05-25')
       .build()
   )
@@ -31,4 +50,65 @@ export const SESCoreUnitMocked = new CoreUnitsBuilder()
     github: 'https://github.com/ses-makerdao',
     website: 'https://ses.makerdao.network',
   })
+  .addBudgetStatement(
+    new BudgetStatementBuilder()
+      .withId('1')
+      .withMonth('2022-09-01')
+      .addBudgetStatementWallet(
+        new BudgetStatementWalletBuilder()
+          .withName('Incubation Team')
+          .withAddress('0x7c09ff9b59baaebfd721cbda3676826aa6d7bae8')
+          .addBudgetStatementLineItem([
+            new BudgetStatementLineItemBuilder()
+              .withGroup('Travel & Entertainment')
+              .withHeadcountExpense(true)
+              .withMonth('2022-09-01')
+              .withActual(1000)
+              .withForecast(1500)
+              .build(),
+            new BudgetStatementLineItemBuilder()
+              .withGroup('Compensation & Benefits')
+              .withHeadcountExpense(true)
+              .withMonth('2022-09-01')
+              .withActual(104942.87)
+              .withForecast(110487.03)
+              .build(),
+            new BudgetStatementLineItemBuilder()
+              .withGroup('Gas Expense')
+              .withMonth('2022-09-01')
+              .withActual(450)
+              .withForecast(450)
+              .build(),
+            new BudgetStatementLineItemBuilder()
+              .withGroup('Software Development Expense')
+              .withMonth('2022-09-01')
+              .withActual(0)
+              .withForecast(40000)
+              .build(),
+            new BudgetStatementLineItemBuilder()
+              .withGroup('Professional Service')
+              .withMonth('2022-09-01')
+              .withActual(10500)
+              .withForecast(10500)
+              .build(),
+            new BudgetStatementLineItemBuilder()
+              .withGroup('Marketing Expense')
+              .withMonth('2022-09-01')
+              .withActual(1500)
+              .withForecast(0)
+              .build(),
+          ])
+          .build()
+      )
+      .addBudgetStatementWallet(
+        new BudgetStatementWalletBuilder()
+          .withName('Permanent Team')
+          .withAddress('0xb5eb779ce300024edb3df9b6c007e312584f6f4f')
+          .addBudgetStatementLineItem(
+            new BudgetStatementLineItemBuilder().withMonth('2022-09-01').withActual(1000).withForecast(1500).build()
+          )
+          .build()
+      )
+      .build()
+  )
   .build();

--- a/src/stories/components/RelateMips/RelateMips.stories.tsx
+++ b/src/stories/components/RelateMips/RelateMips.stories.tsx
@@ -1,50 +1,51 @@
-import React from 'react';
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import { CuStatusEnum } from '../../../core/enums/cuStatusEnum';
 import RelateMips from './RelateMips';
 import type { CuMipDto } from '../../../core/models/dto/coreUnitDTO';
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { ComponentMeta } from '@storybook/react';
 
 export default {
   title: 'Components/CUAbout/RelateMips',
   component: RelateMips,
 } as ComponentMeta<typeof RelateMips>;
 
-const Template: ComponentStory<typeof RelateMips> = (args) => <RelateMips {...args} />;
-export const WithData = Template.bind({});
-WithData.args = {
-  relateMips: {
-    mipTitle: 'MIP40c3-SP1:Modify Core Unit Budget - Real-World Finance (RWF-001)',
-    mipUrl: 'https://mips.makerdao.com/mips/details/MIP39c2SP10',
-    mipStatus: CuStatusEnum.Accepted,
-    accepted: '2019-06-11',
-    obsolete: '2019-06-11',
-    rfc: '2019-06-11',
-    cuId: '1',
-    mipCode: 'MIP39c2-SP10',
-    formalSubmission: '2019-06-11',
-    rejected: '2019-06-11',
-    dateMip: new Date(),
-    mip40: [],
-    mip41: [],
-  } as CuMipDto,
-};
+const variantsArgs = [
+  {
+    relateMips: {
+      mipTitle: 'MIP40c3-SP1:Modify Core Unit Budget - Real-World Finance (RWF-001)',
+      mipUrl: 'https://mips.makerdao.com/mips/details/MIP39c2SP10',
+      mipStatus: CuStatusEnum.Accepted,
+      accepted: '2019-06-11',
+      obsolete: '2019-06-11',
+      rfc: '2019-06-11',
+      cuId: '1',
+      mipCode: 'MIP39c2-SP10',
+      formalSubmission: '2019-06-11',
+      rejected: '2019-06-11',
+      dateMip: new Date(),
+      mip40: [],
+      mip41: [],
+    } as CuMipDto,
+  },
+  {
+    relateMips: {
+      mipTitle:
+        'MIP40c3-SP1:Modify Core Unit Budget - Real-World Finance (RWF-001) Other Data Here Real-World Finance (RWF-001) Other Data HereReal-World Finance (RWF-001) Other Data HereReal-World Finance (RWF-001) Other Data HereReal-World Finance (RWF-001) Other Data Here',
+      mipUrl: 'https://mips.makerdao.com/mips/details/MIP39c2SP10 ',
+      mipStatus: CuStatusEnum.Accepted,
+      accepted: '2019-06-11',
+      obsolete: '2019-06-11',
+      rfc: '2019-06-11',
+      cuId: '1',
+      mipCode: 'MIP39c2-SP10',
+      formalSubmission: '2019-06-11',
+      rejected: '2019-06-11',
+      dateMip: new Date(),
+      mip40: [],
+      mip41: [],
+    } as CuMipDto,
+  },
+];
 
-export const DataWithLargeText = Template.bind({});
-DataWithLargeText.args = {
-  relateMips: {
-    mipTitle:
-      'MIP40c3-SP1:Modify Core Unit Budget - Real-World Finance (RWF-001) Other Data Here Real-World Finance (RWF-001) Other Data HereReal-World Finance (RWF-001) Other Data HereReal-World Finance (RWF-001) Other Data HereReal-World Finance (RWF-001) Other Data Here',
-    mipUrl: 'https://mips.makerdao.com/mips/details/MIP39c2SP10 ',
-    mipStatus: CuStatusEnum.Accepted,
-    accepted: '2019-06-11',
-    obsolete: '2019-06-11',
-    rfc: '2019-06-11',
-    cuId: '1',
-    mipCode: 'MIP39c2-SP10',
-    formalSubmission: '2019-06-11',
-    rejected: '2019-06-11',
-    dateMip: new Date(),
-    mip40: [],
-    mip41: [],
-  } as CuMipDto,
-};
+export const [[WithDataLightMode, WithDataDarkMode], [WithLargeTextLightMode, WithLargeTextDarkMode]] =
+  createThemeModeVariants(RelateMips, variantsArgs, false);

--- a/src/stories/containers/CUAbout/CuAboutContainer.stories.tsx
+++ b/src/stories/containers/CUAbout/CuAboutContainer.stories.tsx
@@ -1,0 +1,48 @@
+import { CURRENT_ENVIRONMENT } from '@ses/config/endpoints';
+import { FeatureFlagsProvider } from '@ses/core/context/FeatureFlagsProvider';
+import { withoutSBPadding } from '@ses/core/utils/storybook/decorators';
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import { SESCoreUnitMocked } from '@ses/core/utils/storybook/mocks/coreUnitsMocks';
+import { featureFlags } from 'feature-flags/feature-flags';
+import AppLayout from '../AppLayout/AppLayout';
+import CuAboutContainer from './CuAboutContainer';
+import type { ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Pages/CU About',
+  component: CuAboutContainer,
+  decorators: [withoutSBPadding],
+
+  parameters: {
+    nextRouter: {
+      path: '/core-unit/[code]',
+      asPath: '/core-unit/SES',
+      query: {
+        code: 'SES',
+      },
+    },
+    chromatic: {
+      viewports: [375, 834, 1194],
+      pauseAnimationAtEnd: true,
+    },
+  },
+} as ComponentMeta<typeof CuAboutContainer>;
+
+const variantsArgs = [
+  {
+    cuAbout: SESCoreUnitMocked,
+    coreUnits: [SESCoreUnitMocked],
+    code: 'SES',
+  },
+];
+
+export const [[LightMode, DarkMode]] = createThemeModeVariants(
+  (props) => (
+    <FeatureFlagsProvider enabledFeatures={featureFlags[CURRENT_ENVIRONMENT]}>
+      <AppLayout>
+        <CuAboutContainer {...props} />
+      </AppLayout>
+    </FeatureFlagsProvider>
+  ),
+  variantsArgs
+);

--- a/src/stories/containers/TransparencyReport/TransparencyReport.stories.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.stories.tsx
@@ -1,0 +1,61 @@
+import { CURRENT_ENVIRONMENT } from '@ses/config/endpoints';
+import { FeatureFlagsProvider } from '@ses/core/context/FeatureFlagsProvider';
+import { withoutSBPadding } from '@ses/core/utils/storybook/decorators';
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import { withLocalStorageItem } from '@ses/core/utils/storybook/loaders';
+import { SESCoreUnitMocked } from '@ses/core/utils/storybook/mocks/coreUnitsMocks';
+import { featureFlags } from 'feature-flags/feature-flags';
+import AppLayout from '../AppLayout/AppLayout';
+import { TransparencyReport } from './TransparencyReport';
+import type { ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Pages/CU Transparency Report',
+  component: TransparencyReport,
+  decorators: [withoutSBPadding],
+
+  parameters: {
+    nextRouter: {
+      path: '/core-unit/[code]/finances/reports',
+      asPath: '/core-unit/SES/finances/reports',
+      query: {
+        code: 'SES',
+      },
+    },
+    chromatic: {
+      viewports: [375, 834, 1194],
+      pauseAnimationAtEnd: true,
+    },
+    date: new Date('2022-09-22T12:23:00Z'),
+  },
+  loaders: [withLocalStorageItem('activity-visit-SES', '1662812570000')],
+} as ComponentMeta<typeof TransparencyReport>;
+
+const variantsArgs = [
+  {
+    coreUnit: SESCoreUnitMocked,
+    coreUnits: [SESCoreUnitMocked],
+  },
+  {
+    coreUnit: {
+      ...SESCoreUnitMocked,
+      budgetStatements: [],
+    },
+    coreUnits: [SESCoreUnitMocked],
+  },
+];
+
+export const [
+  [ActualsWithDataLightMode, ActualsWithDataDarkMode],
+  [ActualsWithoutDataLightMode, ActualsWithoutDataDarkMode],
+] = createThemeModeVariants(
+  (props) => (
+    <FeatureFlagsProvider enabledFeatures={featureFlags[CURRENT_ENVIRONMENT]}>
+      <AppLayout>
+        <TransparencyReport {...props} />
+      </AppLayout>
+    </FeatureFlagsProvider>
+  ),
+  variantsArgs,
+  false
+);


### PR DESCRIPTION
# Ticket
https://trello.com/c/NaQQSUtv/254-qc-round-v-80-r

# Description
Added stories for "CU about" and "CU transparency report" pages. Also added missing builders.

# What solve
- Create the storybook related to Related MIPs section
- Create the storybook related to the complete CU About view
- Create the storybook related to the complete Expense Reports view