### PR TITLE
Limit global activity feed to 500 items

### DIFF
--- a/pages/activity-feed/index.tsx
+++ b/pages/activity-feed/index.tsx
@@ -1,21 +1,27 @@
 import React from 'react';
-import { fetchCoreUnitsWithActivities } from '../../src/stories/containers/GlobalActivity/GlobalActivityAPI';
+import { fetchGlobalActivityFeedData } from '../../src/stories/containers/GlobalActivity/GlobalActivityAPI';
 import GlobalActivity from '../../src/stories/containers/GlobalActivity/GlobalActivityFeedContainer';
-import type { CoreUnitDto } from '../../src/core/models/dto/coreUnitDTO';
+import type { ActivityFeedDto, CoreUnitDto } from '../../src/core/models/dto/coreUnitDTO';
 import type { GetServerSideProps, NextPage } from 'next';
 
-const GlobalActivityPage: NextPage<{ coreUnits: CoreUnitDto[] }> = ({ coreUnits }) => (
-  <GlobalActivity coreUnits={coreUnits} />
+interface GlobalActivityPageProps {
+  coreUnits: CoreUnitDto[];
+  activityFeed: ActivityFeedDto[];
+}
+
+const GlobalActivityPage: NextPage<GlobalActivityPageProps> = ({ coreUnits, activityFeed }) => (
+  <GlobalActivity coreUnits={coreUnits} activityFeed={activityFeed} />
 );
 
 export default GlobalActivityPage;
 
 export const getServerSideProps: GetServerSideProps = async () => {
-  const coreUnits = await fetchCoreUnitsWithActivities();
+  const { activityFeed, coreUnits } = await fetchGlobalActivityFeedData();
 
   return {
     props: {
       coreUnits,
+      activityFeed,
     },
   };
 };

--- a/pages/core-unit/[code]/activity-feed.tsx
+++ b/pages/core-unit/[code]/activity-feed.tsx
@@ -1,19 +1,18 @@
-import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import { fetchCoreUnits } from '../../../src/stories/components/CoreUnitSummary/CoreUnitSummaryApi';
 import CUActivityContainer from '../../../src/stories/containers/CUActivity/CUActivityFeedContainer';
-import { fetchCoreUnitWithActivitiesByCode } from '../../../src/stories/containers/CUActivity/cuActivityAPI';
+import { fetchCoreUnitActivityFeedData } from '../../../src/stories/containers/CUActivity/cuActivityAPI';
 import type { ActivityFeedDto, CoreUnitDto } from '../../../src/core/models/dto/coreUnitDTO';
 import type { NextPage, GetServerSideProps, GetServerSidePropsContext } from 'next';
 
 interface CUActivityProps {
   coreUnits: CoreUnitDto[];
   coreUnit: CoreUnitDto;
-  activity: ActivityFeedDto[];
+  activities: ActivityFeedDto[];
 }
 
-const CoreUnitActivityPage: NextPage<CUActivityProps> = ({ coreUnit, coreUnits }) => (
-  <CUActivityContainer coreUnit={coreUnit} coreUnits={coreUnits} />
+const CoreUnitActivityPage: NextPage<CUActivityProps> = ({ coreUnit, coreUnits, activities }) => (
+  <CUActivityContainer coreUnit={coreUnit} coreUnits={coreUnits} activities={activities} />
 );
 
 export default CoreUnitActivityPage;
@@ -22,18 +21,22 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
   const { query } = context;
   const code = query.code as string;
 
-  const [coreUnit, coreUnits] = await Promise.all([fetchCoreUnitWithActivitiesByCode(code), fetchCoreUnits()]);
-
-  if (isEmpty(coreUnit)) {
+  const coreUnits = await fetchCoreUnits();
+  const coreUnitFiltered = coreUnits.filter((cu) => cu.shortCode === code);
+  if (coreUnitFiltered.length === 0 || code === 'DEL') {
     return {
       notFound: true,
     };
   }
 
+  const coreUnitId = coreUnitFiltered[0].id;
+  const activities = await fetchCoreUnitActivityFeedData(coreUnitId);
+
   return {
     props: {
       coreUnits,
-      coreUnit,
+      coreUnit: coreUnitFiltered[0],
+      activities,
     },
   };
 };

--- a/src/stories/containers/CUActivity/CUActivityFeedContainer.stories.tsx
+++ b/src/stories/containers/CUActivity/CUActivityFeedContainer.stories.tsx
@@ -31,47 +31,46 @@ export default {
 
 const variantsArgs = [
   {
+    activities: [],
     coreUnit: SESCoreUnitMocked,
     coreUnits: [SESCoreUnitMocked],
   },
   {
-    coreUnit: {
-      ...SESCoreUnitMocked,
-      activityFeed: [
-        new ActivityBuilder()
-          .withCreatedAt('2022-09-21T12:23:00Z')
-          .withDescription(
-            'Signal your support or opposition to prioritising onboarding GUNIV3-BUSD-DAI (Gelato Uniswap v3 BUSD-DAI).'
-          )
-          .withParams({
-            coreUnit: {
-              shortCode: 'SES',
-            },
-            month: '2022-09',
-          })
-          .build(),
-        new ActivityBuilder()
-          .withCreatedAt('2022-09-10T12:23:00Z')
-          .withDescription('Increase Headcount Expense Forecast Lorem Ipsum test some text.')
-          .withParams({
-            coreUnit: {
-              shortCode: 'SES',
-            },
-            month: '2022-09',
-          })
-          .build(),
-        new ActivityBuilder()
-          .withCreatedAt('2022-08-20T12:23:00Z')
-          .withDescription('Increase Headcount Expense Forecast Lorem Ipsum test some text.')
-          .withParams({
-            coreUnit: {
-              shortCode: 'SES',
-            },
-            month: '2022-08',
-          })
-          .build(),
-      ],
-    },
+    activities: [
+      new ActivityBuilder()
+        .withCreatedAt('2022-09-21T12:23:00Z')
+        .withDescription(
+          'Signal your support or opposition to prioritising onboarding GUNIV3-BUSD-DAI (Gelato Uniswap v3 BUSD-DAI).'
+        )
+        .withParams({
+          coreUnit: {
+            shortCode: 'SES',
+          },
+          month: '2022-09',
+        })
+        .build(),
+      new ActivityBuilder()
+        .withCreatedAt('2022-09-10T12:23:00Z')
+        .withDescription('Increase Headcount Expense Forecast Lorem Ipsum test some text.')
+        .withParams({
+          coreUnit: {
+            shortCode: 'SES',
+          },
+          month: '2022-09',
+        })
+        .build(),
+      new ActivityBuilder()
+        .withCreatedAt('2022-08-20T12:23:00Z')
+        .withDescription('Increase Headcount Expense Forecast Lorem Ipsum test some text.')
+        .withParams({
+          coreUnit: {
+            shortCode: 'SES',
+          },
+          month: '2022-08',
+        })
+        .build(),
+    ],
+    coreUnit: SESCoreUnitMocked,
     coreUnits: [SESCoreUnitMocked],
   },
 ];

--- a/src/stories/containers/CUActivity/CUActivityFeedContainer.tsx
+++ b/src/stories/containers/CUActivity/CUActivityFeedContainer.tsx
@@ -6,14 +6,15 @@ import ActivityTable from '../../components/CUActivityTable/ActivityTable';
 import { CoreUnitSummary } from '../../components/CoreUnitSummary/CoreUnitSummary';
 import { SEOHead } from '../../components/SEOHead/SEOHead';
 import { useCuActivity } from './useCuActivity';
-import type { CoreUnitDto } from '../../../core/models/dto/coreUnitDTO';
+import type { ActivityFeedDto, CoreUnitDto } from '../../../core/models/dto/coreUnitDTO';
 
 interface CUActivityContainerProps {
   coreUnits: CoreUnitDto[];
   coreUnit: CoreUnitDto;
+  activities: ActivityFeedDto[];
 }
 
-const CUActivityFeedContainer: React.FC<CUActivityContainerProps> = ({ coreUnit, coreUnits }) => {
+const CUActivityFeedContainer: React.FC<CUActivityContainerProps> = ({ coreUnit, coreUnits, activities }) => {
   const { isLight, columns, onSortClick } = useCuActivity();
   return (
     <Wrapper>
@@ -30,7 +31,7 @@ const CUActivityFeedContainer: React.FC<CUActivityContainerProps> = ({ coreUnit,
             <ActivityTable
               columns={columns}
               shortCode={coreUnit.shortCode}
-              activityFeed={coreUnit.activityFeed.map((activity) => ({
+              activityFeed={activities.map((activity) => ({
                 activityFeed: activity,
               }))}
               sortClick={onSortClick}

--- a/src/stories/containers/CUActivity/cuActivityAPI.ts
+++ b/src/stories/containers/CUActivity/cuActivityAPI.ts
@@ -1,42 +1,31 @@
 import { request, gql } from 'graphql-request';
 import { GRAPHQL_ENDPOINT } from '../../../config/endpoints';
-import type { CoreUnitDto } from '../../../core/models/dto/coreUnitDTO';
+import type { ActivityFeedDto } from '../../../core/models/dto/coreUnitDTO';
 
-export const GET_CU_ACTIVITY_BY_CODE = gql`
-  query CoreUnits($filter: CoreUnitFilter) {
-    coreUnits(filter: $filter) {
-      id
-      shortCode
-      code
-      name
-      image
-      category
-      sentenceDescription
-      activityFeed {
-        id
+export const getCoreUnitActivityFeedQuery = (coreUnitId: string) => ({
+  query: gql`
+    query CUActivityFeed($limit: Int, $offset: Int, $filter: ActivityFeedFilter) {
+      activityFeed(limit: $limit, offset: $offset, filter: $filter) {
         created_at
-        event
-        params
         description
-      }
-      socialMediaChannels {
-        discord
-        forumTag
-        linkedIn
-        twitter
-        website
-        youtube
-        github
+        event
+        id
+        params
       }
     }
-  }
-`;
-
-export const fetchCoreUnitWithActivitiesByCode = async (shortCode: string) => {
-  const res = (await request(GRAPHQL_ENDPOINT, GET_CU_ACTIVITY_BY_CODE, {
+  `,
+  filter: {
+    limit: 500,
+    offset: 0,
     filter: {
-      shortCode,
+      objectId: coreUnitId,
+      objectType: 'CoreUnit',
     },
-  })) as { coreUnits: CoreUnitDto[] };
-  return res.coreUnits[0];
+  },
+});
+
+export const fetchCoreUnitActivityFeedData = async (coreUnitId: string): Promise<ActivityFeedDto[]> => {
+  const { query, filter } = getCoreUnitActivityFeedQuery(coreUnitId);
+  const res = (await request(GRAPHQL_ENDPOINT, query, filter)) as { activityFeed: ActivityFeedDto[] };
+  return res.activityFeed;
 };

--- a/src/stories/containers/GlobalActivity/GlobalActivityAPI.ts
+++ b/src/stories/containers/GlobalActivity/GlobalActivityAPI.ts
@@ -1,38 +1,39 @@
 import { request, gql } from 'graphql-request';
 import { GRAPHQL_ENDPOINT } from '../../../config/endpoints';
-import type { CoreUnitDto } from '../../../core/models/dto/coreUnitDTO';
+import type { ActivityFeedDto, CoreUnitDto } from '../../../core/models/dto/coreUnitDTO';
 
-export const GET_CUS_WITH_ACTIVITY = gql`
-  query CoreUnits {
-    coreUnits {
-      id
-      shortCode
-      code
-      name
-      image
-      category
-      sentenceDescription
-      activityFeed {
-        id
+export const getGlobalActivityFeedQuery = () => ({
+  query: gql`
+    query GlobalActivityFeed($limit: Int, $offset: Int) {
+      activityFeed(limit: $limit, offset: $offset) {
         created_at
-        event
-        params
         description
+        event
+        id
+        params
       }
-      socialMediaChannels {
-        discord
-        forumTag
-        linkedIn
-        twitter
-        website
-        youtube
-        github
+      coreUnits {
+        id
+        shortCode
+        name
+        image
       }
     }
-  }
-`;
+  `,
+  filter: {
+    limit: 500,
+    offset: 0,
+  },
+});
 
-export const fetchCoreUnitsWithActivities = async () => {
-  const res = (await request(GRAPHQL_ENDPOINT, GET_CUS_WITH_ACTIVITY)) as { coreUnits: CoreUnitDto[] };
-  return res.coreUnits;
+interface GlobalActivityFeedResponse {
+  coreUnits: Partial<CoreUnitDto>[];
+  activityFeed: ActivityFeedDto[];
+}
+
+export const fetchGlobalActivityFeedData = async (): Promise<GlobalActivityFeedResponse> => {
+  const { query, filter } = getGlobalActivityFeedQuery();
+  const response = (await request(GRAPHQL_ENDPOINT, query, filter)) as GlobalActivityFeedResponse;
+
+  return response;
 };

--- a/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.stories.tsx
+++ b/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.stories.tsx
@@ -27,57 +27,54 @@ export default {
 
 const variantsArgs = [
   {
+    activityFeed: [],
     coreUnits: [],
   },
   {
+    activityFeed: [
+      new ActivityBuilder()
+        .withCreatedAt('2022-09-21T12:23:00Z')
+        .withDescription(
+          'Signal your support or opposition to prioritising onboarding GUNIV3-BUSD-DAI (Gelato Uniswap v3 BUSD-DAI).'
+        )
+        .withParams({
+          coreUnit: {
+            shortCode: 'SES',
+          },
+          month: '2022-09',
+        })
+        .build(),
+      new ActivityBuilder()
+        .withCreatedAt('2022-09-10T12:23:00Z')
+        .withDescription('Increase Headcount Expense Forecast Lorem Ipsum test some text.')
+        .withParams({
+          coreUnit: {
+            shortCode: 'SES',
+          },
+          month: '2022-09',
+        })
+        .build(),
+      new ActivityBuilder()
+        .withCreatedAt('2022-08-20T12:23:00Z')
+        .withDescription('Increase Headcount Expense Forecast Lorem Ipsum test some text.')
+        .withParams({
+          coreUnit: {
+            shortCode: 'DUX',
+          },
+          month: '2022-08',
+        })
+        .build(),
+    ],
     coreUnits: [
       new CoreUnitsBuilder()
         .withImage('https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ses-001/logo.png')
         .withShortCode('SES')
         .withName('Sustainable Ecosystem Scaling')
-        .addActivity(
-          new ActivityBuilder()
-            .withCreatedAt('2022-09-21T12:23:00Z')
-            .withDescription(
-              'Signal your support or opposition to prioritising onboarding GUNIV3-BUSD-DAI (Gelato Uniswap v3 BUSD-DAI).'
-            )
-            .withParams({
-              coreUnit: {
-                shortCode: 'SES',
-              },
-              month: '2022-09',
-            })
-            .build()
-        )
-        .addActivity(
-          new ActivityBuilder()
-            .withCreatedAt('2022-09-10T12:23:00Z')
-            .withDescription('Increase Headcount Expense Forecast Lorem Ipsum test some text.')
-            .withParams({
-              coreUnit: {
-                shortCode: 'SES',
-              },
-              month: '2022-09',
-            })
-            .build()
-        )
         .build(),
       new CoreUnitsBuilder()
         .withImage('https://makerdao-ses.github.io/ecosystem-dashboard/core-units/dux-001/dux_logo.png')
         .withShortCode('DUX')
         .withName('Development & UX')
-        .addActivity(
-          new ActivityBuilder()
-            .withCreatedAt('2022-08-20T12:23:00Z')
-            .withDescription('Increase Headcount Expense Forecast Lorem Ipsum test some text.')
-            .withParams({
-              coreUnit: {
-                shortCode: 'DUX',
-              },
-              month: '2022-08',
-            })
-            .build()
-        )
         .build(),
     ],
   },

--- a/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.tsx
+++ b/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.tsx
@@ -13,18 +13,19 @@ import Filter from '../../components/svg/filter';
 import { Paragraph, Title } from '../CUActivity/CUActivityFeedContainer';
 import { ButtonFilter, SmallSeparator } from '../CUTable/cuTableFilters';
 import { useGlobalActivity } from './useGlobalActivity';
-import type { CoreUnitDto } from '../../../core/models/dto/coreUnitDTO';
+import type { ActivityFeedDto, CoreUnitDto } from '../../../core/models/dto/coreUnitDTO';
 import type { SelectItemProps } from '../../components/CustomMultiSelect/CustomMultiSelect';
 
 interface Props {
   coreUnits: CoreUnitDto[];
+  activityFeed: ActivityFeedDto[];
 }
 
-const GlobalActivityFeedContainer: React.FC<Props> = ({ coreUnits }) => {
+const GlobalActivityFeedContainer: React.FC<Props> = ({ coreUnits, activityFeed }) => {
   const { isLight } = useThemeContext();
   const {
     columns,
-    activityFeed,
+    extendedActivityFeed,
     clearFilters,
     filtersActive,
     inputRef,
@@ -36,7 +37,8 @@ const GlobalActivityFeedContainer: React.FC<Props> = ({ coreUnits }) => {
     handleSelectChange,
     filtersVisible,
     toggleFiltersVisible,
-  } = useGlobalActivity(coreUnits);
+  } = useGlobalActivity(coreUnits, activityFeed);
+
   return (
     <Wrapper>
       <SEOHead
@@ -105,7 +107,7 @@ const GlobalActivityFeedContainer: React.FC<Props> = ({ coreUnits }) => {
             <ActivityTable
               columns={columns}
               shortCode={'global'}
-              activityFeed={activityFeed}
+              activityFeed={extendedActivityFeed}
               hasFilter={filtersActive}
               clearAction={clearFilters}
               isGlobal


### PR DESCRIPTION
# Ticket
https://trello.com/c/NaQQSUtv/254-qc-round-v-80-r

# Description
Due to the global activity feed not being paginated, the result is too heavy so this page is outperforming. Now the page is going to show the last 500 activities only

# What solve
- Limit the activity feed item numbers to 500 on the Global and the Core Units Activity Feeds