### PR TITLE
[SES-245] Connect Transfer-Request Tab with the API

### DIFF
--- a/src/core/models/dto/coreUnitDTO.ts
+++ b/src/core/models/dto/coreUnitDTO.ts
@@ -75,9 +75,23 @@ export interface BudgetStatementLineItemDto {
   group?: string;
 }
 
+export interface SourceDto {
+  code: string;
+  url: string;
+  title: string;
+}
+export interface TargetDto {
+  amount: number;
+  calculation: string;
+  description: string;
+  source: SourceDto;
+}
+
 export interface BudgetStatementWalletTransferRequestDto {
   requestAmount: number;
   walletBalance: number;
+  target: TargetDto;
+  walletBalanceTimeStamp: string;
 }
 
 export interface BudgetStatementWalletDto {

--- a/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
+++ b/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
@@ -64,8 +64,19 @@ export const CORE_UNIT_REQUEST = (shortCode: string) => ({
               payment
             }
             budgetStatementTransferRequest {
+              target {
+                amount
+                calculation
+                description
+                source {
+                  code
+                  url
+                  title
+                }
+              }
               requestAmount
               walletBalance
+              walletBalanceTimeStamp
             }
           }
           budgetStatementMKRVest {


### PR DESCRIPTION
# Ticket

https://trello.com/c/tixH6IkI/245-feature-onchaindatareconciliation-v1

#What solved
Should display the correct "target" value coming from the API in the "Target account" column
Should display the MIP number and the link coming from the API on the tooltip
Should open (https://mips.makerdao.com/mips/details/MIP40) in a new tab when the user clicks on the tooltip link 

# Actions
Add Dto and parameters to query