### PR TITLE
fix link cu core-units

### DIFF
--- a/src/stories/components/CustomTable/ItemCoreUnit/ItemCoreUnit.tsx
+++ b/src/stories/components/CustomTable/ItemCoreUnit/ItemCoreUnit.tsx
@@ -16,20 +16,20 @@ interface Props {
 export const ItemCoreUnit = ({ queryStrings, isLoading, columns, cu }: Props) => {
   const { isLight } = useThemeContext();
   return (
-    <Link href={`/core-unit/${cu?.shortCode}/${queryStrings}`} passHref>
-      <>
-        <TableWrapper>
+    <>
+      <TableWrapper>
+        <Link href={`/core-unit/${cu?.shortCode}/${queryStrings}`} passHref legacyBehavior>
           <TableRow isLight={isLight} isLoading={isLoading} columns={columns}>
             {columns?.map((column) => (
               <TableCell key={column?.header}>{column.cellRender?.(cu)}</TableCell>
             ))}
           </TableRow>
-        </TableWrapper>
-        <ListWrapper>
-          <CardItemCoreUnitMobile coreUnit={cu} />
-        </ListWrapper>
-      </>
-    </Link>
+        </Link>
+      </TableWrapper>
+      <ListWrapper>
+        <CardItemCoreUnitMobile coreUnit={cu} />
+      </ListWrapper>
+    </>
   );
 };
 


### PR DESCRIPTION
# Ticket

https://trello.com/c/tixH6IkI/245-feature-coreunittransparencyreporting-v6

#What solved
Should redirect to the CU About view of the core unit when clicking on the row. 

# Actions
fix link CU-core-units