### PR TITLE
[SES-QC-254] Add pending variants on the transparency page story

### DIFF
--- a/src/core/businessLogic/builders/budgetStatementBuilder.ts
+++ b/src/core/businessLogic/builders/budgetStatementBuilder.ts
@@ -6,6 +6,7 @@ import type {
   BudgetStatementFteDto,
   BudgetStatementWalletDto,
   CommentsBudgetStatementDto,
+  BudgetStatementMKRVestDto,
 } from '../../models/dto/coreUnitDTO';
 
 export class BudgetStatementBuilder {
@@ -17,6 +18,7 @@ export class BudgetStatementBuilder {
       month: '',
       budgetStatementFTEs: [] as BudgetStatementFteDto[],
       budgetStatementWallet: [] as BudgetStatementWalletDto[],
+      budgetStatementMKRVest: [] as BudgetStatementMKRVestDto[],
       comments: [] as CommentsBudgetStatementDto[],
       status: BudgetStatus.Draft,
       publicationUrl: '',
@@ -45,6 +47,17 @@ export class BudgetStatementBuilder {
 
   addBudgetStatementWallet(budgetStatementWallet: BudgetStatementWalletDto): BudgetStatementBuilder {
     this._budgetStatement.budgetStatementWallet.push(budgetStatementWallet);
+    return this;
+  }
+
+  addBudgetStatementMKRVest(
+    budgetStatementMKRVest: BudgetStatementMKRVestDto | BudgetStatementMKRVestDto[]
+  ): BudgetStatementBuilder {
+    if (Array.isArray(budgetStatementMKRVest)) {
+      this._budgetStatement.budgetStatementMKRVest?.push(...budgetStatementMKRVest);
+    } else {
+      this._budgetStatement.budgetStatementMKRVest?.push(budgetStatementMKRVest);
+    }
     return this;
   }
 

--- a/src/core/businessLogic/builders/budgetStatementMKRVestBuilder .ts
+++ b/src/core/businessLogic/builders/budgetStatementMKRVestBuilder .ts
@@ -1,0 +1,38 @@
+import type { BudgetStatementMKRVestDto } from '@ses/core/models/dto/coreUnitDTO';
+
+export class BudgetStatementMKRVestBuilder {
+  private readonly _budgetStatementMKRVest: BudgetStatementMKRVestDto;
+
+  constructor() {
+    this._budgetStatementMKRVest = {
+      mkrAmount: 0,
+      mkrAmountOld: 0,
+      vestingDate: '',
+      comments: '',
+    };
+  }
+
+  withMKRAmount(mkrAmount: number): BudgetStatementMKRVestBuilder {
+    this._budgetStatementMKRVest.mkrAmount = mkrAmount;
+    return this;
+  }
+
+  withMKRAmountOld(mkrAmountOld: number): BudgetStatementMKRVestBuilder {
+    this._budgetStatementMKRVest.mkrAmountOld = mkrAmountOld;
+    return this;
+  }
+
+  withVestingDate(vestingDate: string): BudgetStatementMKRVestBuilder {
+    this._budgetStatementMKRVest.vestingDate = vestingDate;
+    return this;
+  }
+
+  withComments(comments: string): BudgetStatementMKRVestBuilder {
+    this._budgetStatementMKRVest.comments = comments;
+    return this;
+  }
+
+  build(): BudgetStatementMKRVestDto {
+    return this._budgetStatementMKRVest;
+  }
+}

--- a/src/core/businessLogic/builders/budgetStatementWalletBuilder.ts
+++ b/src/core/businessLogic/builders/budgetStatementWalletBuilder.ts
@@ -1,4 +1,8 @@
-import type { BudgetStatementLineItemDto, BudgetStatementWalletDto } from '../../models/dto/coreUnitDTO';
+import type {
+  BudgetStatementLineItemDto,
+  BudgetStatementWalletDto,
+  BudgetStatementWalletTransferRequestDto,
+} from '../../models/dto/coreUnitDTO';
 
 export class BudgetStatementWalletBuilder {
   private readonly _wallet: BudgetStatementWalletDto;
@@ -9,7 +13,8 @@ export class BudgetStatementWalletBuilder {
       address: '',
       currentBalance: 0,
       budgetStatementLineItem: [] as BudgetStatementLineItemDto[],
-    };
+      budgetStatementTransferRequest: [] as BudgetStatementWalletTransferRequestDto[],
+    } as BudgetStatementWalletDto;
   }
 
   withLineItems(actualArray: number[], month: string) {
@@ -26,11 +31,20 @@ export class BudgetStatementWalletBuilder {
     lineItem: BudgetStatementLineItemDto | BudgetStatementLineItemDto[]
   ): BudgetStatementWalletBuilder {
     if (Array.isArray(lineItem)) {
-      lineItem.forEach((item) => {
-        this._wallet.budgetStatementLineItem.push(item);
-      });
+      this._wallet.budgetStatementLineItem.push(...lineItem);
     } else {
       this._wallet.budgetStatementLineItem.push(lineItem);
+    }
+    return this;
+  }
+
+  addBudgetStatementTransferRequest(
+    transferRequest: BudgetStatementWalletTransferRequestDto | BudgetStatementWalletTransferRequestDto[]
+  ): BudgetStatementWalletBuilder {
+    if (Array.isArray(transferRequest)) {
+      this._wallet.budgetStatementTransferRequest?.push(...transferRequest);
+    } else {
+      this._wallet.budgetStatementTransferRequest?.push(transferRequest);
     }
     return this;
   }

--- a/src/core/businessLogic/builders/budgetStatementWalletTransferRequestBuilder.ts
+++ b/src/core/businessLogic/builders/budgetStatementWalletTransferRequestBuilder.ts
@@ -1,0 +1,67 @@
+import type { BudgetStatementWalletTransferRequestDto, SourceDto } from '@ses/core/models/dto/coreUnitDTO';
+
+export class BudgetStatementWalletTransferRequestBuilder {
+  private readonly _budgetStatementWalletTransferRequest: BudgetStatementWalletTransferRequestDto;
+
+  constructor() {
+    this._budgetStatementWalletTransferRequest = {
+      requestAmount: 0,
+      walletBalance: 0,
+      target: {
+        amount: 0,
+        calculation: '',
+        description: '',
+        source: {
+          code: '',
+          url: '',
+          title: '',
+        },
+      },
+      walletBalanceTimeStamp: '',
+    };
+  }
+
+  withRequestAmount(requestAmount: number): BudgetStatementWalletTransferRequestBuilder {
+    this._budgetStatementWalletTransferRequest.requestAmount = requestAmount;
+    return this;
+  }
+
+  withWalletBalance(walletBalance: number): BudgetStatementWalletTransferRequestBuilder {
+    this._budgetStatementWalletTransferRequest.walletBalance = walletBalance;
+    return this;
+  }
+
+  withTargetAmount(amount: number): BudgetStatementWalletTransferRequestBuilder {
+    this._budgetStatementWalletTransferRequest.target.amount = amount;
+    return this;
+  }
+
+  withTargetCalculation(calculation: string): BudgetStatementWalletTransferRequestBuilder {
+    this._budgetStatementWalletTransferRequest.target.calculation = calculation;
+    return this;
+  }
+
+  withTargetDescription(description: string): BudgetStatementWalletTransferRequestBuilder {
+    this._budgetStatementWalletTransferRequest.target.description = description;
+    return this;
+  }
+
+  withTargetSource(code: string, url: string, title: string): BudgetStatementWalletTransferRequestBuilder {
+    const source: SourceDto = {
+      code,
+      url,
+      title,
+    };
+    this._budgetStatementWalletTransferRequest.target.source = source;
+    return this;
+  }
+
+  withWalletBalanceTimeStamp(walletBalanceTimeStamp: string): BudgetStatementWalletTransferRequestBuilder {
+    this._budgetStatementWalletTransferRequest.walletBalanceTimeStamp = walletBalanceTimeStamp;
+    return this;
+  }
+
+  build(): BudgetStatementWalletTransferRequestDto {
+    return this._budgetStatementWalletTransferRequest;
+  }
+}

--- a/src/core/utils/storybook/mocks/coreUnitsMocks.ts
+++ b/src/core/utils/storybook/mocks/coreUnitsMocks.ts
@@ -2,6 +2,7 @@ import { BudgetStatementBuilder } from '@ses/core/businessLogic/builders/budgetS
 import { BudgetStatementLineItemBuilder } from '@ses/core/businessLogic/builders/budgetStatementLineItemBuilder';
 import { BudgetStatementMKRVestBuilder } from '@ses/core/businessLogic/builders/budgetStatementMKRVestBuilder ';
 import { BudgetStatementWalletBuilder } from '@ses/core/businessLogic/builders/budgetStatementWalletBuilder';
+import { BudgetStatementWalletTransferRequestBuilder } from '@ses/core/businessLogic/builders/budgetStatementWalletTransferRequestBuilder';
 import { CoreUnitsBuilder } from '@ses/core/businessLogic/builders/coreUnitsBuilder';
 import { CuMipBuilder } from '@ses/core/businessLogic/builders/cuMIPBuilder';
 import { UserBuilder } from '@ses/core/businessLogic/builders/userBuilder';
@@ -124,6 +125,21 @@ export const SESCoreUnitMocked = new CoreUnitsBuilder()
               .withBudgetCap(965548)
               .build(),
           ])
+          .addBudgetStatementTransferRequest([
+            new BudgetStatementWalletTransferRequestBuilder()
+              .withRequestAmount(332276.72)
+              .withWalletBalance(238253.38)
+              .withWalletBalanceTimeStamp('2022-09-22T18:22:03.856Z')
+              .withTargetAmount(506063.09)
+              .withTargetCalculation('FEB + MAR Budget Cap')
+              .withTargetDescription('Auditor wallets are topped up to 2 times the budget cap')
+              .withTargetSource(
+                'MIP40C3-SP14',
+                'https://mips.makerdao.com/mips/details/MIP40c3SP14',
+                'Modify Core Unit Budget - Collateral Engineering Services (SES-001)'
+              )
+              .build(),
+          ])
           .build()
       )
       .addBudgetStatementWallet(
@@ -143,6 +159,21 @@ export const SESCoreUnitMocked = new CoreUnitsBuilder()
               .withActual(256)
               .withForecast(865)
               .withBudgetCap(7445)
+              .build(),
+          ])
+          .addBudgetStatementTransferRequest([
+            new BudgetStatementWalletTransferRequestBuilder()
+              .withRequestAmount(-18915.2)
+              .withWalletBalance(101478.2)
+              .withWalletBalanceTimeStamp('2022-28-22T18:22:03.856Z')
+              .withTargetAmount(506063.09)
+              .withTargetCalculation('FEB + MAR Budget Cap')
+              .withTargetDescription('Auditor wallets are topped up to 2 times the budget cap')
+              .withTargetSource(
+                'MIP40C3-SP14',
+                'https://mips.makerdao.com/mips/details/MIP40c3SP14',
+                'Modify Core Unit Budget - Collateral Engineering Services (SES-001)'
+              )
               .build(),
           ])
           .build()

--- a/src/core/utils/storybook/mocks/coreUnitsMocks.ts
+++ b/src/core/utils/storybook/mocks/coreUnitsMocks.ts
@@ -1,5 +1,6 @@
 import { BudgetStatementBuilder } from '@ses/core/businessLogic/builders/budgetStatementBuilder';
 import { BudgetStatementLineItemBuilder } from '@ses/core/businessLogic/builders/budgetStatementLineItemBuilder';
+import { BudgetStatementMKRVestBuilder } from '@ses/core/businessLogic/builders/budgetStatementMKRVestBuilder ';
 import { BudgetStatementWalletBuilder } from '@ses/core/businessLogic/builders/budgetStatementWalletBuilder';
 import { CoreUnitsBuilder } from '@ses/core/businessLogic/builders/coreUnitsBuilder';
 import { CuMipBuilder } from '@ses/core/businessLogic/builders/cuMIPBuilder';
@@ -146,6 +147,30 @@ export const SESCoreUnitMocked = new CoreUnitsBuilder()
           ])
           .build()
       )
+      .addBudgetStatementMKRVest([
+        new BudgetStatementMKRVestBuilder()
+          .withComments('Vesting for the SES-001 Core Unit')
+          .withMKRAmount(10)
+          .withMKRAmountOld(10)
+          .withVestingDate('1021-09-01')
+          .build(),
+        new BudgetStatementMKRVestBuilder()
+          .withMKRAmount(2.47)
+          .withMKRAmountOld(2.47)
+          .withVestingDate('1021-08-24')
+          .build(),
+        new BudgetStatementMKRVestBuilder()
+          .withComments('Vesting testing')
+          .withMKRAmount(9.04)
+          .withMKRAmountOld(9.04)
+          .withVestingDate('1021-08-01')
+          .build(),
+        new BudgetStatementMKRVestBuilder()
+          .withMKRAmount(5.36)
+          .withMKRAmountOld(5.36)
+          .withVestingDate('1021-07-16')
+          .build(),
+      ])
       .build()
   )
   .build();

--- a/src/stories/containers/TransparencyReport/TransparencyReport.stories.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.stories.tsx
@@ -47,12 +47,17 @@ const variantsArgs = [
     coreUnit: SESCoreUnitMocked,
     coreUnits: [SESCoreUnitMocked],
   },
+  {
+    coreUnit: SESCoreUnitMocked,
+    coreUnits: [SESCoreUnitMocked],
+  },
 ];
 
 export const [
   [ActualsWithDataLightMode, ActualsWithDataDarkMode],
   [ActualsWithoutDataLightMode, ActualsWithoutDataDarkMode],
   [ForecastTabLightMode, ForecastTabDarkMode],
+  [MKRVestingLightMode, MKRVestingDarkMode],
 ] = createThemeModeVariants(
   (props) => (
     <FeatureFlagsProvider enabledFeatures={featureFlags[CURRENT_ENVIRONMENT]}>
@@ -73,3 +78,12 @@ const forecastParams = {
 };
 ForecastTabLightMode.parameters = forecastParams;
 ForecastTabDarkMode.parameters = forecastParams;
+
+const mkrVestingParams = {
+  nextRouter: {
+    path: '/core-unit/[code]/finances/reports#mkr-vesting',
+    asPath: '/core-unit/SES/finances/reports#mkr-vesting',
+  },
+};
+MKRVestingLightMode.parameters = mkrVestingParams;
+MKRVestingDarkMode.parameters = mkrVestingParams;

--- a/src/stories/containers/TransparencyReport/TransparencyReport.stories.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.stories.tsx
@@ -32,10 +32,12 @@ export default {
 } as ComponentMeta<typeof TransparencyReport>;
 
 const variantsArgs = [
+  // actuals
   {
     coreUnit: SESCoreUnitMocked,
     coreUnits: [SESCoreUnitMocked],
   },
+  // actuals without data (empty)
   {
     coreUnit: {
       ...SESCoreUnitMocked,
@@ -43,10 +45,17 @@ const variantsArgs = [
     },
     coreUnits: [SESCoreUnitMocked],
   },
+  // forecast
   {
     coreUnit: SESCoreUnitMocked,
     coreUnits: [SESCoreUnitMocked],
   },
+  // mkr vesting
+  {
+    coreUnit: SESCoreUnitMocked,
+    coreUnits: [SESCoreUnitMocked],
+  },
+  // transfer requests
   {
     coreUnit: SESCoreUnitMocked,
     coreUnits: [SESCoreUnitMocked],
@@ -58,6 +67,7 @@ export const [
   [ActualsWithoutDataLightMode, ActualsWithoutDataDarkMode],
   [ForecastTabLightMode, ForecastTabDarkMode],
   [MKRVestingLightMode, MKRVestingDarkMode],
+  [TransferRequestsLightMode, TransferRequestsDarkMode],
 ] = createThemeModeVariants(
   (props) => (
     <FeatureFlagsProvider enabledFeatures={featureFlags[CURRENT_ENVIRONMENT]}>
@@ -87,3 +97,12 @@ const mkrVestingParams = {
 };
 MKRVestingLightMode.parameters = mkrVestingParams;
 MKRVestingDarkMode.parameters = mkrVestingParams;
+
+const transferRequestsParams = {
+  nextRouter: {
+    path: '/core-unit/[code]/finances/reports#transfer-requests',
+    asPath: '/core-unit/SES/finances/reports#transfer-requests',
+  },
+};
+TransferRequestsLightMode.parameters = transferRequestsParams;
+TransferRequestsDarkMode.parameters = transferRequestsParams;


### PR DESCRIPTION
# Ticket
https://trello.com/c/NaQQSUtv/254-qc-round-v-80-r

# Description
Add pending stories variants of the transparency reports page.
Added:
- mkr vesting variant
- transfer request variant

# What solve
- Add pending variants on the transparency page story