### PR TITLE
Fix dark mode color in remaining section

### DIFF
--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -152,7 +152,7 @@ const TableBody = styled.div({});
 const RemainingContainer = styled.div<WithIsLight>(({ isLight }) => ({
   margin: '24px -16px',
   padding: '24px 16px 16px',
-  background: isLight ? '#F6F8F9' : '#131420',
+  background: isLight ? '#F6F8F9' : '#1D1E34',
   boxShadow: isLight ? '0px -1px 1px #EDEFFF' : '0px -1px 1px #292F5B',
   display: 'flex',
   flexDirection: 'column',


### PR DESCRIPTION
# Ticket
https://trello.com/c/tqmW07KT/246-feature-aggregatedviewlevels-v1

# Description
Fix color

# What solved
- Should be clearly shown the color of the horizontal bar in the CURemaining Core Units and Recognized Delegates (By Budget filter). 