### PR TITLE
[SES-QC-254] Prevent not including items into grouped due empty/null values

### DIFF
--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
@@ -723,7 +723,7 @@ export const useTransparencyForecast = (currentMonth: DateTime, propBudgetStatem
 
     const groupedNonHeadCount = _.groupBy(
       ungrouped.filter((x) => !x.headcountExpense),
-      (item) => item.group
+      (item) => item.group?.trim() || ''
     );
 
     result.push(...getBreakdownItemsForGroup(groupedNonHeadCount, 'subTotal'));


### PR DESCRIPTION
# Ticket
https://trello.com/c/NaQQSUtv/254-qc-round-v-80-r

# Description
- Prevented not including breakdown items of the wallets lines budget statement on the breakdown section of the forecast tab on the transparency reports page

# What solved
-There are duplicated breakdown items in the forecast tab on the transparency report page