### PR TITLE
[SES-QA-256] Remove duplicate DEL on Cost Breakdown table

### DIFF
--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
@@ -155,6 +155,13 @@ const variantsArgs = [
         .withAnnualPeriod(2023)
         .extend('TEST', 'Testing')
         .build(),
+      new TotalExpenseReportsBuilder()
+        .withBudget('delegates')
+        .withPrediction(415631)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('DEL', 'Recognized Delegates')
+        .build(),
     ],
     byCategoryBreakdownExpenses: [
       new TotalExpenseReportsBuilder()

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -74,15 +74,17 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
                   )}
                   rowType={'remaining'}
                 />
-                <ByBudgetTableRow
-                  expense={remainingBudgetDelegates}
-                  total={total}
-                  relativePercentage={percentageRespectTo(
-                    remainingBudgetDelegates?.prediction,
-                    byBudgetExpenses[0]?.prediction
-                  )}
-                  rowType={'remaining'}
-                />
+                {remainingBudgetDelegates?.prediction > 0 && (
+                  <ByBudgetTableRow
+                    expense={remainingBudgetDelegates}
+                    total={total}
+                    relativePercentage={percentageRespectTo(
+                      remainingBudgetDelegates?.prediction,
+                      byBudgetExpenses[0]?.prediction
+                    )}
+                    rowType={'remaining'}
+                  />
+                )}
               </RemainingContainer>
             </>
           ) : (


### PR DESCRIPTION
# Ticket
https://trello.com/c/4OEItwNA/256-qa-bug-findings-v-80

# Description
Remove recognized delegates from the bottom remaining core units row when the Delegate is in the top 10

# What solved
- The core units breakdown list for 2021, duplicates Recognized Delegates. Impacting the integrity of displayed data