### PR TITLE
[SES-254] Correct color in the line forecast card

### DIFF
--- a/src/stories/components/TransparencyCard/TransparencyCard.tsx
+++ b/src/stories/components/TransparencyCard/TransparencyCard.tsx
@@ -104,7 +104,7 @@ const Label = styled.div<{ hasIcon?: boolean; height?: string }>(({ hasIcon = fa
 const ContainerLine = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   display: 'flex',
   flex: 1,
-  border: isLight ? '1px solid #D4D9E1' : '1px solid #405361',
+  borderTop: isLight ? '1px solid #D4D9E1' : '1px solid #405361',
   marginBottom: 20,
   marginTop: 20,
 }));

--- a/src/stories/components/TransparencyCard/TransparencyCard.tsx
+++ b/src/stories/components/TransparencyCard/TransparencyCard.tsx
@@ -104,7 +104,7 @@ const Label = styled.div<{ hasIcon?: boolean; height?: string }>(({ hasIcon = fa
 const ContainerLine = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   display: 'flex',
   flex: 1,
-  borderTop: isLight ? '1px solid #D4D9E1' : '1px solid #405361',
+  borderTop: `1px solid ${isLight ? '#D4D9E1' : '#405361'}`,
   marginBottom: 20,
   marginTop: 20,
 }));


### PR DESCRIPTION
# Ticket
https://trello.com/c/NaQQSUtv/254-qc-round-v-80-r

#What solved
Should show the correct color in the line for separation in the forecast tab for mobile view

# Actions
Add border-top line instead border