### PR TITLE
[SES-265] Add correct color in dark mode card cu-table

### DIFF
--- a/src/stories/components/CoreUnitCard/CoreUnitCard.tsx
+++ b/src/stories/components/CoreUnitCard/CoreUnitCard.tsx
@@ -30,6 +30,7 @@ import { CuTableColumnSummary } from '../CuTableColumnSummary/CuTableColumnSumma
 import { CuTableColumnTeamMember } from '../CuTableColumnTeamMember/CuTableColumnTeamMember';
 import { CategoriesSkeleton } from './CategoriesSkeleton';
 import type { CoreUnitDto } from '../../../core/models/dto/coreUnitDTO';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface CoreUnitCardProps {
   coreUnit: CoreUnitDto;
@@ -91,7 +92,7 @@ const CoreUnitCard = ({ coreUnit, isLoading = false }: CoreUnitCardProps) => {
       <CuCard>
         <Container isLight={isLight}>
           <Summary>
-            <Title hideSmall isCoreUnitTitle>
+            <Title hideSmall isCoreUnitTitle isLight={isLight}>
               Core Unit
             </Title>
             <CuTableColumnSummary
@@ -107,7 +108,9 @@ const CoreUnitCard = ({ coreUnit, isLoading = false }: CoreUnitCardProps) => {
           </Summary>
           <Link href={`/core-unit/${coreUnit.shortCode}/finances/reports${queryStrings}`} passHref>
             <Expenditure>
-              <Title isExpenditure>Expenditure</Title>
+              <Title isExpenditure isLight={isLight}>
+                Expenditure
+              </Title>
               <CuTableColumnExpenditures
                 value={getExpenditureValueFromCoreUnit(coreUnit)}
                 percent={getPercentFromCoreUnit(coreUnit)}
@@ -119,7 +122,7 @@ const CoreUnitCard = ({ coreUnit, isLoading = false }: CoreUnitCardProps) => {
             </Expenditure>
           </Link>
           <Team>
-            <Title>Team Members</Title>
+            <Title isLight={isLight}>Team Members</Title>
             <CuTableColumnTeamMember
               members={getFacilitatorsFromCoreUnit(coreUnit)}
               fte={getFTEsFromCoreUnit(coreUnit)}
@@ -127,7 +130,7 @@ const CoreUnitCard = ({ coreUnit, isLoading = false }: CoreUnitCardProps) => {
           </Team>
           <Link href={`/core-unit/${coreUnit.shortCode}/activity-feed${queryStrings}`} passHref>
             <LastModified>
-              <Title>Last Modified</Title>
+              <Title isLight={isLight}>Last Modified</Title>
               <CuTableColumnLastModified date={getLastMonthWithData(coreUnit)} code={getShortCode(coreUnit.code)} />
             </LastModified>
           </Link>
@@ -316,15 +319,15 @@ const Links = styled.div({
   },
 });
 
-const Title = styled.div<{ hideSmall?: boolean; isCoreUnitTitle?: boolean; isExpenditure?: boolean }>(
-  ({ hideSmall = false, isCoreUnitTitle = false, isExpenditure = false }) => ({
+const Title = styled.div<WithIsLight & { hideSmall?: boolean; isCoreUnitTitle?: boolean; isExpenditure?: boolean }>(
+  ({ hideSmall = false, isCoreUnitTitle = false, isExpenditure = false, isLight }) => ({
     display: hideSmall ? 'none' : 'block',
     fontFamily: 'Inter, sans-serif',
     fontStyle: 'normal',
     fontWeight: 400,
     fontSize: '14px',
     lineHeight: '22px',
-    color: '#9FAFB9',
+    color: isLight ? '#9FAFB9' : '#405361',
     marginLeft: '0px',
     marginBottom: isExpenditure ? '14px' : '8px',
     '@media (min-width: 834px)': {

--- a/src/stories/containers/TransparencyReport/components/TransparencyAuditorComments/AuditorCommentsContainer/AuditorCommentsContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyAuditorComments/AuditorCommentsContainer/AuditorCommentsContainer.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import AuditorCommentList from '../AuditorCommentList';
@@ -7,6 +8,7 @@ import NoComments from '../NoComments';
 import ParticipantRoles from '../ParticipantRoles';
 import useCommentsContainer from './useCommentsContainer';
 import type { ActivityFeedDto, BudgetStatementDto, CommentsBudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 export type CommentMode = 'CoreUnits' | 'Delegates';
 
@@ -21,6 +23,7 @@ const AuditorCommentsContainer: React.FC<AuditorCommentsContainerProps> = ({
   comments,
   mode = 'CoreUnits',
 }) => {
+  const { isLight } = useThemeContext();
   const { cuParticipants, auditors, canComment, currentBudgetStatus, coreUnitCode } = useCommentsContainer(
     comments,
     budgetStatement,
@@ -45,7 +48,7 @@ const AuditorCommentsContainer: React.FC<AuditorCommentsContainerProps> = ({
           </>
         )}
       </CommentsContainer>
-      <ParticipantsColumn>
+      <ParticipantsColumn isLight={isLight}>
         <ParticipantRoles cu={cuParticipants} auditors={auditors} coreUnitCode={coreUnitCode} mode={mode} />
       </ParticipantsColumn>
     </Container>
@@ -80,11 +83,12 @@ const CommentsContainer = styled.div({
   },
 });
 
-const ParticipantsColumn = styled.div({
+const ParticipantsColumn = styled.div<WithIsLight>(({ isLight }) => ({
   [lightTheme.breakpoints.down('table_834')]: {
-    borderTop: '1px solid #D4D9E1',
+    borderTop: isLight ? '1px solid #D4D9E1' : '1px solid  #405361',
     paddingTop: 32,
     width: '100%',
+    marginBottom: 8,
   },
 
   [lightTheme.breakpoints.up('table_834')]: {
@@ -103,4 +107,4 @@ const ParticipantsColumn = styled.div({
   [lightTheme.breakpoints.up('desktop_1440')]: {
     marginLeft: 40,
   },
-});
+}));

--- a/src/stories/containers/TransparencyReport/components/TransparencyAuditorComments/GenericCommentCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyAuditorComments/GenericCommentCard.tsx
@@ -38,6 +38,7 @@ const CommentCard = styled.div<{ isLight: boolean; variantColorSet: { [key: stri
     marginBottom: 32,
     background: isLight ? '#FFFFFF' : '#10191F',
     borderRadius: 6,
+    wordBreak: 'break-word',
     boxShadow: isLight
       ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
       : '10px 15px 20px 6px rgba(20, 0, 141, 0.1)',


### PR DESCRIPTION
# Ticket

https://trello.com/c/Z1EJXde6/265-qc-round-v-90

#What solved
Should display the #405361 color in the Expenditure (headers) in the core units list (375).

# Actions
1-Add correct color in dark mode card Core Unit Table
2-Should display the line with the correct color in dark mode. (375 resolution, RWF Core unit, Expense Reports view, Comments tab).
3-Should display a space = 40 px between the Participant Role and Additional Notes section.(375 resolution, Expense Reports view, Comments tab)
