### PR TITLE
[SES-257] Allow to open breakdown tabs in a new tab

### DIFF
--- a/src/stories/components/Tabs/Tabs.tsx
+++ b/src/stories/components/Tabs/Tabs.tsx
@@ -111,6 +111,13 @@ const Tabs: React.FC<TabsProps> = ({
       } else {
         setCompressedActiveId(actualId);
       }
+    } else {
+      // select the first tab
+      if (expanded) {
+        setExpandedActiveId(tabs?.[0]?.id);
+      } else {
+        setCompressedActiveId(compressedTabs?.[0]?.id);
+      }
     }
   }, [
     activeId,

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
@@ -1,17 +1,17 @@
 import styled from '@emotion/styled';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
+import { CustomLink } from '@ses/components/CustomLink/CustomLink';
+import Tabs from '@ses/components/Tabs/Tabs';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { MAKER_BURN_LINK } from '@ses/core/utils/const';
+import { getShortCode } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
-import { useThemeContext } from '../../../../../core/context/ThemeContext';
-import { MAKER_BURN_LINK } from '../../../../../core/utils/const';
-import { getShortCode } from '../../../../../core/utils/string';
-import { AdvancedInnerTable } from '../../../../components/AdvancedInnerTable/AdvancedInnerTable';
-import { CustomLink } from '../../../../components/CustomLink/CustomLink';
-import { Tabs } from '../../../../components/Tabs/TabsLegacy';
 import { Title } from '../../TransparencyReport';
 import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import { useTransparencyActuals } from './useTransparencyActuals';
-import type { BudgetStatementDto } from '../../../../../core/models/dto/coreUnitDTO';
+import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
 import type { DateTime } from 'luxon';
 
 interface Props {
@@ -27,7 +27,6 @@ export const TransparencyActuals = (props: Props) => {
 
   const {
     headerIds,
-    thirdIndex,
     breakdownTitleRef,
     breakdownColumns,
     breakdownItems,
@@ -77,11 +76,10 @@ export const TransparencyActuals = (props: Props) => {
 
       {mainTableItems.length > 0 && (
         <Tabs
-          items={breakdownTabs.map((header, i) => ({
+          tabs={breakdownTabs.map((header, i) => ({
             item: header,
             id: headerIds[i],
           }))}
-          currentIndex={thirdIndex}
         />
       )}
 

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
@@ -1,19 +1,15 @@
+import { useUrlAnchor } from '@ses/core/hooks/useUrlAnchor';
+import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
+import { capitalizeSentence, getWalletWidthForWallets } from '@ses/core/utils/string';
 import _ from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useUrlAnchor } from '../../../../../core/hooks/useUrlAnchor';
-import { API_MONTH_TO_FORMAT } from '../../../../../core/utils/date';
-import { capitalizeSentence, getWalletWidthForWallets } from '../../../../../core/utils/string';
 import { renderLinks, renderWallet } from '../../transparencyReportUtils';
+import type { InnerTableColumn, InnerTableRow, RowType } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
 import type {
   BudgetStatementDto,
   BudgetStatementLineItemDto,
   BudgetStatementWalletDto,
-} from '../../../../../core/models/dto/coreUnitDTO';
-import type {
-  InnerTableColumn,
-  InnerTableRow,
-  RowType,
-} from '../../../../components/AdvancedInnerTable/AdvancedInnerTable';
+} from '@ses/core/models/dto/coreUnitDTO';
 import type { DateTime } from 'luxon';
 
 export const useTransparencyActuals = (
@@ -601,7 +597,6 @@ export const useTransparencyActuals = (
 
   return {
     headerIds,
-    thirdIndex,
     breakdownTitleRef,
     breakdownColumns,
     breakdownItems,

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
@@ -1,18 +1,18 @@
 import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
+import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
+import { CustomLink } from '@ses/components/CustomLink/CustomLink';
+import Tabs from '@ses/components/Tabs/Tabs';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { MAKER_BURN_LINK } from '@ses/core/utils/const';
+import { getShortCode } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
-import { useThemeContext } from '../../../../../core/context/ThemeContext';
-import { MAKER_BURN_LINK } from '../../../../../core/utils/const';
-import { getShortCode } from '../../../../../core/utils/string';
-import { AdvancedInnerTable } from '../../../../components/AdvancedInnerTable/AdvancedInnerTable';
-import { CustomLink } from '../../../../components/CustomLink/CustomLink';
-import { Tabs } from '../../../../components/Tabs/TabsLegacy';
 import { Title } from '../../TransparencyReport';
 import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import { LinkDescription } from '../TransparencyActuals/TransparencyActuals';
 import { useTransparencyForecast } from './useTransparencyForecast';
-import type { BudgetStatementDto } from '../../../../../core/models/dto/coreUnitDTO';
+import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
 import type { DateTime } from 'luxon';
 
 interface Props {
@@ -27,7 +27,6 @@ export const TransparencyForecast = (props: Props) => {
   const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
 
   const {
-    thirdIndex,
     headerIds,
     mainTableColumns,
     mainTableItems,
@@ -78,11 +77,10 @@ export const TransparencyForecast = (props: Props) => {
 
       {!!breakdownItems.length && (
         <Tabs
-          items={breakdownTabs.map((header, i) => ({
+          tabs={breakdownTabs.map((header, i) => ({
             item: header,
             id: headerIds[i],
           }))}
-          currentIndex={thirdIndex}
         />
       )}
 

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
@@ -815,7 +815,6 @@ export const useTransparencyForecast = (currentMonth: DateTime, propBudgetStatem
   ]);
 
   return {
-    thirdIndex,
     mainTableItems,
     mainTableColumns,
     headerIds,


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
Upgrade the breakdown tabs in the actuals and forecast main tabs to allow opening the tabs in new tabs

# What solved
- Should allow opening in a new browser tab when the user right click on the tabs on the actuals breakdown and the forecast breakdown