### PR TITLE
[SES-257] Add "Actuals" to the "Budget Report" tab

### DIFF
--- a/src/stories/components/svg/wallet.tsx
+++ b/src/stories/components/svg/wallet.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+interface Props {
+  width?: number;
+  height?: number;
+  fill?: string;
+}
+
+const Wallet: React.FC<Props> = ({ fill = '#231536', width = 20, height = 20 }) => (
+  <svg width={width} height={height} viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M12.5 11.875C12.5 10.8395 13.3395 10 14.375 10C15.4105 10 16.25 10.8395 16.25 11.875C16.25 12.9105 15.4105 13.75 14.375 13.75C13.3395 13.75 12.5 12.9105 12.5 11.875Z"
+      fill={fill}
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.125 0C1.39911 0 0 1.39911 0 3.125C0 3.25485 0.00792505 3.38285 0.0233001 3.50854C0.00801255 3.58666 0 3.6674 0 3.75V17.5C0 18.8808 1.11929 20 2.5 20H17.5C18.8808 20 20 18.8808 20 17.5V6.25C20 4.86929 18.8808 3.75 17.5 3.75H16.25V1.25C16.25 0.55965 15.6904 0 15 0H3.125ZM13.75 2.5H3.125C2.77982 2.5 2.5 2.77982 2.5 3.125C2.5 3.47018 2.77982 3.75 3.125 3.75H13.75V2.5ZM2.5 6.25V17.5H17.5V6.25H2.5Z"
+      fill={fill}
+    />
+  </svg>
+);
+
+export default Wallet;

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import Container from '@ses/components/Container/Container';
+import PageContainer from '@ses/components/Container/PageContainer';
 import Tabs from '@ses/components/Tabs/Tabs';
 import React from 'react';
 import lightTheme from '../../../../styles/theme/light';
@@ -11,6 +13,7 @@ import { CoreUnitSummary } from '../../components/CoreUnitSummary/CoreUnitSummar
 import { CustomLink } from '../../components/CustomLink/CustomLink';
 import { CustomPager } from '../../components/CustomPager/CustomPager';
 import { SEOHead } from '../../components/SEOHead/SEOHead';
+import BudgetReport from './components/BudgetReport/BudgetReport';
 import ExpenseReportStatusIndicator from './components/ExpenseReportStatusIndicator/ExpenseReportStatusIndicator';
 import { TransparencyActuals } from './components/TransparencyActuals/TransparencyActuals';
 
@@ -63,167 +66,167 @@ export const TransparencyReport = ({ coreUnits, coreUnit }: TransparencyReportPr
         twitterCard={coreUnit.image ? 'summary' : 'summary_large_image'}
       />
       <CoreUnitSummary coreUnits={coreUnits} trailingAddress={['Expense Reports']} breadcrumbTitle="Expense Reports" />
-      <Container isLight={isLight}>
-        <InnerPage>
-          <PagerBar className="no-select" ref={transparencyTableRef}>
-            <PagerBarLeft>
-              <CustomPager
-                label={currentMonth.toFormat('MMM yyyy').toUpperCase()}
-                onPrev={handlePreviousMonth}
-                onNext={handleNextMonth}
-                hasNext={hasNextMonth()}
-                hasPrevious={hasPreviousMonth()}
-              />
-              <ExpenseReportStatusIndicator
-                budgetStatus={currentBudgetStatement?.status || BudgetStatus.Draft}
-                showCTA={showExpenseReportStatusCTA}
-              />
-            </PagerBarLeft>
+      <PageContainer hasImageBackground={true}>
+        <PageSeparator>
+          <Container>
+            <PagerBar className="no-select" ref={transparencyTableRef}>
+              <PagerBarLeft>
+                <CustomPager
+                  label={currentMonth.toFormat('MMM yyyy').toUpperCase()}
+                  onPrev={handlePreviousMonth}
+                  onNext={handleNextMonth}
+                  hasNext={hasNextMonth()}
+                  hasPrevious={hasPreviousMonth()}
+                />
+                <ExpenseReportStatusIndicator
+                  budgetStatus={currentBudgetStatement?.status || BudgetStatus.Draft}
+                  showCTA={showExpenseReportStatusCTA}
+                />
+              </PagerBarLeft>
 
-            <Spacer />
-            {lastUpdateForBudgetStatement && (
-              <LastUpdate>
-                <Since isLight={isLight}>Last Update</Since>
-                <SinceDate>{lastUpdateForBudgetStatement.setZone('UTC').toFormat('dd-LLL-y HH:mm ZZZZ')}</SinceDate>
-              </LastUpdate>
+              <Spacer />
+              {lastUpdateForBudgetStatement && (
+                <LastUpdate>
+                  <Since isLight={isLight}>Last Update</Since>
+                  <SinceDate>{lastUpdateForBudgetStatement.setZone('UTC').toFormat('dd-LLL-y HH:mm ZZZZ')}</SinceDate>
+                </LastUpdate>
+              )}
+            </PagerBar>
+
+            <TabsContainer>
+              <Tabs
+                tabs={tabItems}
+                expandable
+                compressedTabs={compressedTabItems}
+                onChange={onTabChange}
+                expandToolTip={{
+                  default: 'Default View',
+                  compressed: 'Auditor View',
+                }}
+                viewValues={{
+                  default: 'default',
+                  compressed: 'auditor',
+                }}
+                anchorToActualId={(anchor) => {
+                  if (anchor.startsWith('actuals-')) return 'actuals';
+                  if (anchor.startsWith('forecast-')) return 'forecast';
+                  return anchor;
+                }}
+              />
+            </TabsContainer>
+          </Container>
+
+          <Container>
+            {tabsIndex === TRANSPARENCY_IDS_ENUM.ACTUALS && (
+              <TransparencyActuals
+                code={code}
+                currentMonth={currentMonth}
+                budgetStatements={coreUnit?.budgetStatements}
+                longCode={longCode}
+              />
             )}
-          </PagerBar>
+            {tabsIndex === TRANSPARENCY_IDS_ENUM.FORECAST && (
+              <TransparencyForecast
+                currentMonth={currentMonth}
+                budgetStatements={coreUnit?.budgetStatements}
+                code={code}
+                longCode={longCode}
+              />
+            )}
+            {tabsIndex === TRANSPARENCY_IDS_ENUM.MKR_VESTING && (
+              <TransparencyMkrVesting
+                currentMonth={currentMonth}
+                budgetStatements={coreUnit?.budgetStatements}
+                code={code}
+                longCode={longCode}
+              />
+            )}
+            {tabsIndex === TRANSPARENCY_IDS_ENUM.TRANSFER_REQUESTS && (
+              <TransparencyTransferRequest
+                currentMonth={currentMonth}
+                budgetStatements={coreUnit?.budgetStatements}
+                code={code}
+                longCode={longCode}
+              />
+            )}
+            {tabsIndex === TRANSPARENCY_IDS_ENUM.AUDIT_REPORTS && isEnabled('FEATURE_AUDIT_REPORTS') && (
+              <TransparencyAudit budgetStatement={currentBudgetStatement} />
+            )}
 
-          <TabsContainer>
-            <Tabs
-              tabs={tabItems}
-              expandable
-              compressedTabs={compressedTabItems}
-              onChange={onTabChange}
-              expandToolTip={{
-                default: 'Default View',
-                compressed: 'Auditor View',
-              }}
-              viewValues={{
-                default: 'default',
-                compressed: 'auditor',
-              }}
-              anchorToActualId={(anchor) => {
-                if (anchor.startsWith('actuals-')) return 'actuals';
-                if (anchor.startsWith('forecast-')) return 'forecast';
-                return anchor;
-              }}
-            />
-          </TabsContainer>
-          {tabsIndex === TRANSPARENCY_IDS_ENUM.ACTUALS && (
-            <TransparencyActuals
-              code={code}
-              currentMonth={currentMonth}
-              budgetStatements={coreUnit?.budgetStatements}
-              longCode={longCode}
-            />
-          )}
-          {tabsIndex === TRANSPARENCY_IDS_ENUM.FORECAST && (
-            <TransparencyForecast
-              currentMonth={currentMonth}
-              budgetStatements={coreUnit?.budgetStatements}
-              code={code}
-              longCode={longCode}
-            />
-          )}
-          {tabsIndex === TRANSPARENCY_IDS_ENUM.MKR_VESTING && (
-            <TransparencyMkrVesting
-              currentMonth={currentMonth}
-              budgetStatements={coreUnit?.budgetStatements}
-              code={code}
-              longCode={longCode}
-            />
-          )}
-          {tabsIndex === TRANSPARENCY_IDS_ENUM.TRANSFER_REQUESTS && (
-            <TransparencyTransferRequest
-              currentMonth={currentMonth}
-              budgetStatements={coreUnit?.budgetStatements}
-              code={code}
-              longCode={longCode}
-            />
-          )}
-          {tabsIndex === TRANSPARENCY_IDS_ENUM.AUDIT_REPORTS && isEnabled('FEATURE_AUDIT_REPORTS') && (
-            <TransparencyAudit budgetStatement={currentBudgetStatement} />
-          )}
-
-          {tabsIndex === TRANSPARENCY_IDS_ENUM.COMMENTS && (
-            <CommentActivityContext.Provider value={{ lastVisitHandler }}>
-              <AuditorCommentsContainer budgetStatement={currentBudgetStatement} comments={comments} />
-            </CommentActivityContext.Provider>
-          )}
+            {tabsIndex === TRANSPARENCY_IDS_ENUM.COMMENTS && (
+              <CommentActivityContext.Provider value={{ lastVisitHandler }}>
+                <AuditorCommentsContainer budgetStatement={currentBudgetStatement} comments={comments} />
+              </CommentActivityContext.Provider>
+            )}
+          </Container>
 
           {tabsIndex === TRANSPARENCY_IDS_ENUM.BUDGET_REPORT && (
-            <div style={{ margin: '3rem 0' }}>(WIP) Budget Report tabs is activated</div>
+            <BudgetReport
+              code={code}
+              currentMonth={currentMonth}
+              budgetStatements={coreUnit?.budgetStatements}
+              longCode={longCode}
+            />
           )}
 
-          <AdditionalNotesSection>
-            <Title isLight={isLight} isTitleOfPage={false}>
-              Additional Notes
-            </Title>
+          <Container>
+            <AdditionalNotesSection>
+              <Title isLight={isLight} isTitleOfPage={false}>
+                Additional Notes
+              </Title>
 
-            <Paragraph isLight={isLight}>
-              {coreUnit.auditors.length === 0 ? (
-                <div>
-                  Every month, the {coreUnit.shortCode} Core Unit submits an Expense Report to MakerDAO governance with
-                  a detailed budget update. The Core Unit works <b>without auditor</b>, submitting its reports directly
-                  to the community.
-                </div>
-              ) : (
-                <div>
-                  Every month, the {coreUnit.shortCode} Core Unit submits an Expense Report to MakerDAO governance with
-                  a detailed budget update. The Core Unit's reports are reviewed{' '}
-                  <b>
-                    by auditor(s){' '}
-                    {coreUnit.auditors.map((auditor, index, array) => (
-                      <span key={auditor.id}>
-                        <b>{auditor.username}</b>
-                        {array.length > 1 && index !== array.length - 1
-                          ? index !== array.length - 2
-                            ? ', '
-                            : ', and '
-                          : ''}
-                      </span>
-                    ))}{' '}
-                  </b>
-                  before they are marked as final.
-                </div>
-              )}
+              <Paragraph isLight={isLight}>
+                {coreUnit.auditors.length === 0 ? (
+                  <div>
+                    Every month, the {coreUnit.shortCode} Core Unit submits an Expense Report to MakerDAO governance
+                    with a detailed budget update. The Core Unit works <b>without auditor</b>, submitting its reports
+                    directly to the community.
+                  </div>
+                ) : (
+                  <div>
+                    Every month, the {coreUnit.shortCode} Core Unit submits an Expense Report to MakerDAO governance
+                    with a detailed budget update. The Core Unit's reports are reviewed{' '}
+                    <b>
+                      by auditor(s){' '}
+                      {coreUnit.auditors.map((auditor, index, array) => (
+                        <span key={auditor.id}>
+                          <b>{auditor.username}</b>
+                          {array.length > 1 && index !== array.length - 1
+                            ? index !== array.length - 2
+                              ? ', '
+                              : ', and '
+                            : ''}
+                        </span>
+                      ))}{' '}
+                    </b>
+                    before they are marked as final.
+                  </div>
+                )}
 
-              {coreUnit.legacyBudgetStatementUrl && (
-                <LegacyReportParagraph>
-                  <span>Legacy expense reports can be found</span>
-                  <CustomLink
-                    fontWeight={500}
-                    href={coreUnit.legacyBudgetStatementUrl}
-                    iconHeight={10}
-                    iconWidth={10}
-                    fontSize={16}
-                    fontSizeMobile={14}
-                    fontFamily={'Inter, sans-serif'}
-                  >
-                    here
-                  </CustomLink>
-                </LegacyReportParagraph>
-              )}
-            </Paragraph>
-          </AdditionalNotesSection>
-        </InnerPage>
-      </Container>
+                {coreUnit.legacyBudgetStatementUrl && (
+                  <LegacyReportParagraph>
+                    <span>Legacy expense reports can be found</span>
+                    <CustomLink
+                      fontWeight={500}
+                      href={coreUnit.legacyBudgetStatementUrl}
+                      iconHeight={10}
+                      iconWidth={10}
+                      fontSize={16}
+                      fontSizeMobile={14}
+                      fontFamily={'Inter, sans-serif'}
+                    >
+                      here
+                    </CustomLink>
+                  </LegacyReportParagraph>
+                )}
+              </Paragraph>
+            </AdditionalNotesSection>
+          </Container>
+        </PageSeparator>
+      </PageContainer>
     </Wrapper>
   );
 };
-
-const Container = styled.div<{ isLight: boolean }>(({ isLight }) => ({
-  flexDirection: 'column',
-  alignItems: 'center',
-  paddingTop: '64px',
-  paddingBottom: '64px',
-  flex: 1,
-  backgroundColor: isLight ? '#FFFFFF' : '#000000',
-  backgroundImage: isLight ? 'url(/assets/img/bg-page.png)' : 'url(/assets/img/bg-page-dark.png)',
-  backgroundAttachment: 'fixed',
-  backgroundSize: 'cover',
-}));
 
 const Wrapper = styled.div({
   display: 'flex',
@@ -231,37 +234,12 @@ const Wrapper = styled.div({
   width: '100%',
 });
 
-const InnerPage = styled.div({
-  display: 'block',
-  textAlign: 'left',
-  width: '100%',
-  maxWidth: '1440px',
-  margin: '0 auto',
-  paddingRight: '64px',
-  paddingLeft: '64px',
+const PageSeparator = styled.div({
   marginTop: 32,
+
   [lightTheme.breakpoints.up('table_834')]: {
     paddingTop: 32,
     marginTop: 0,
-  },
-
-  [lightTheme.breakpoints.between('table_834', 'desktop_1280')]: {
-    paddingRight: '32px',
-    paddingLeft: '32px',
-  },
-  [lightTheme.breakpoints.up('desktop_1920')]: {
-    maxWidth: '1312px',
-    paddingRight: '0px',
-    paddingLeft: '0px',
-  },
-  [lightTheme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
-    paddingRight: '48px',
-    paddingLeft: '48px',
-  },
-
-  [lightTheme.breakpoints.down('table_834')]: {
-    paddingRight: '16px',
-    paddingLeft: '16px',
   },
 });
 

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
@@ -1,0 +1,144 @@
+import styled from '@emotion/styled';
+import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
+import Container from '@ses/components/Container/Container';
+import { CustomLink } from '@ses/components/CustomLink/CustomLink';
+import Tabs from '@ses/components/Tabs/Tabs';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { MAKER_BURN_LINK } from '@ses/core/utils/const';
+import lightTheme from '@ses/styles/theme/light';
+import React, { useState } from 'react';
+import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
+import { LinkDescription } from '../TransparencyActuals/TransparencyActuals';
+import { useTransparencyActuals } from '../TransparencyActuals/useTransparencyActuals';
+import BudgetSection from './components/BudgetSection/BudgetSection';
+import SectionTitle from './components/SectionTitle/SectionTitle';
+import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+import type { DateTime } from 'luxon';
+
+interface BudgetReportProps {
+  currentMonth: DateTime;
+  budgetStatements?: BudgetStatementDto[];
+  code: string;
+  longCode: string;
+}
+
+const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStatements, code, longCode }) => {
+  const { isLight } = useThemeContext();
+
+  const actualsData = useTransparencyActuals(currentMonth, budgetStatements);
+  const [actualsBreakdownSelected, setActualsBreakdownSelected] = useState<string | undefined>();
+
+  const handleActualsBreakdownChange = (current?: string) => {
+    setActualsBreakdownSelected(current);
+  };
+
+  return (
+    <BudgetReportWrapper>
+      <ActualsSection>
+        <Container>
+          <LinkDescription isLight={isLight}>
+            <span> Visit makerburn.com to</span>
+            <ActualViewOnChainLink
+              href={`${MAKER_BURN_LINK}/${longCode}`}
+              fontSize={16}
+              fontWeight={500}
+              iconWidth={10}
+              iconHeight={10}
+              marginLeft="7px"
+            >
+              {`view the ${code} Core Unit on-chain transaction history`}
+            </ActualViewOnChainLink>
+
+            <BudgetDateTitle isLight={isLight}>{currentMonth.toFormat('MMMM yyyy')} Budget Report</BudgetDateTitle>
+          </LinkDescription>
+        </Container>
+
+        <BudgetSection title={'Actuals - Totals'}>
+          <AdvancedInnerTable
+            columns={actualsData.mainTableColumns}
+            items={actualsData.mainTableItems}
+            cardsTotalPosition="top"
+            longCode={longCode}
+          />
+
+          {actualsData.mainTableItems.length > 0 && (
+            <>
+              <TitleSpacer>
+                <SectionTitle>Actuals Breakdown</SectionTitle>
+              </TitleSpacer>
+
+              <Tabs
+                tabs={actualsData.breakdownTabs.map((header, i) => ({
+                  item: header,
+                  id: actualsData.headerIds[i],
+                }))}
+                expandable
+                expandedDefault={false}
+                viewKey={'breakdownView'}
+                onChange={handleActualsBreakdownChange}
+              />
+
+              {actualsBreakdownSelected ? (
+                <AdvancedInnerTable
+                  columns={actualsData.breakdownColumns}
+                  items={actualsData.breakdownItems}
+                  longCode={longCode}
+                  style={{ marginTop: 16 }}
+                  tablePlaceholder={<TransparencyEmptyTable breakdown longCode={longCode} />}
+                />
+              ) : (
+                <BudgetSection level={2}>
+                  {actualsData.breakdownTabs.map((header) => (
+                    <div key={header}>
+                      <SectionTitle level={2} hasIcon={true}>
+                        {header}
+                      </SectionTitle>
+                      <div>table here...</div>
+                    </div>
+                  ))}
+                </BudgetSection>
+              )}
+            </>
+          )}
+        </BudgetSection>
+      </ActualsSection>
+    </BudgetReportWrapper>
+  );
+};
+
+export default BudgetReport;
+
+const BudgetReportWrapper = styled.div({});
+
+const ActualsSection = styled.div({});
+
+const ActualViewOnChainLink = styled(CustomLink)({
+  flexWrap: 'wrap',
+  color: '#447AFB',
+  letterSpacing: '0.3px',
+  lineHeight: '18px',
+  marginLeft: 0,
+  whiteSpace: 'break-spaces',
+  display: 'inline-block',
+  marginBottom: 0,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    marginBottom: 32,
+  },
+});
+
+const BudgetDateTitle = styled.h1<WithIsLight>(({ isLight }) => ({
+  fontSize: 24,
+  fontWeight: 600,
+  lineHeight: '29px',
+  letterSpacing: '0.4px',
+  color: isLight ? '#231536' : '#F00',
+  marginTop: 0,
+  marginBottom: 32,
+}));
+
+const TitleSpacer = styled.div({
+  marginTop: 32,
+  marginBottom: 16,
+});

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/components/BudgetSection/BudgetSection.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/components/BudgetSection/BudgetSection.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+import Container from '@ses/components/Container/Container';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import React from 'react';
+import SectionTitle from '../SectionTitle/SectionTitle';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface BudgetSectionProps extends React.PropsWithChildren {
+  title?: string;
+  level?: 1 | 2;
+}
+
+const BudgetSection: React.FC<BudgetSectionProps> = ({ children, level = 1, title }) => {
+  const { isLight } = useThemeContext();
+  const Wrapper = level === 1 ? WrapperL1 : WrapperL2;
+  const LevelContainer = level === 1 ? Container : React.Fragment;
+
+  return (
+    <Wrapper isLight={isLight}>
+      <LevelContainer>
+        {title && <SectionTitle>{title}</SectionTitle>}
+
+        <ChildrenContainer hasMargin={!!title}>{children}</ChildrenContainer>
+      </LevelContainer>
+    </Wrapper>
+  );
+};
+
+export default BudgetSection;
+
+const WrapperL1 = styled.div<WithIsLight>(({ isLight }) => ({
+  padding: '16px 0 32px',
+  background: isLight ? '#F6F8F9' : '#F6000066',
+  boxShadow: isLight ? '0px 20px 40px -40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)' : '#f00',
+  marginTop: 32,
+}));
+
+const WrapperL2 = styled.div<WithIsLight>(({ isLight }) => ({
+  padding: '16px 32px 32px',
+  background: isLight ? '#ECF1F3' : '#F6000066',
+  marginTop: 32,
+  borderRadius: 6,
+}));
+
+const ChildrenContainer = styled.div<{ hasMargin: boolean }>(({ hasMargin }) => ({
+  marginTop: hasMargin ? 32 : 0,
+}));

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/components/SectionTitle/SectionTitle.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/components/SectionTitle/SectionTitle.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+import Wallet from '@ses/components/svg/wallet';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface SectionTitleProps extends React.PropsWithChildren {
+  level?: 1 | 2;
+  hasIcon?: boolean;
+}
+
+const SectionTitle: React.FC<SectionTitleProps> = ({ children, level = 1, hasIcon = false }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Title isLight={isLight} level={level} as={level === 1 ? 'h2' : 'h3'}>
+      {hasIcon && (
+        <IconContainer>
+          <Wallet fill={isLight ? '#231536' : '#F00'} />
+        </IconContainer>
+      )}
+      {children}
+    </Title>
+  );
+};
+
+export default SectionTitle;
+
+const Title = styled.h2<{ level: number } & WithIsLight>(({ isLight, level }) => ({
+  display: 'flex',
+  fontSize: 20,
+  lineHeight: '24px',
+  letterSpacing: '0.4px',
+  fontWeight: level === 1 ? 600 : 500,
+  color: isLight ? '#231536' : '#f00',
+  margin: 0,
+}));
+
+const IconContainer = styled.div({
+  display: 'inline-flex',
+  marginRight: 14,
+});


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
Added the actuals section to the Budget Report tab

# What solved
- Should add the "Actuals - Totals" section in the new "Budget Report" tab
- Should display the heading at the top of the page in the format "MONTH - YEAR - Budget Report" (e.g., "January 2023 Budget Report")
- Should add the "Actuals - Breakdown" section in the new "Budget Report" tab