### PR TITLE
[SES-257] Add Budget Report story variant

### DIFF
--- a/src/stories/containers/TransparencyReport/TransparencyReport.stories.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.stories.tsx
@@ -60,6 +60,11 @@ const variantsArgs = [
     coreUnit: SESCoreUnitMocked,
     coreUnits: [SESCoreUnitMocked],
   },
+  // budget report
+  {
+    coreUnit: SESCoreUnitMocked,
+    coreUnits: [SESCoreUnitMocked],
+  },
 ];
 
 export const [
@@ -68,6 +73,7 @@ export const [
   [ForecastTabLightMode, ForecastTabDarkMode],
   [MKRVestingLightMode, MKRVestingDarkMode],
   [TransferRequestsLightMode, TransferRequestsDarkMode],
+  [BudgetReportLightMode, BudgetReportDarkMode],
 ] = createThemeModeVariants(
   (props) => (
     <FeatureFlagsProvider enabledFeatures={featureFlags[CURRENT_ENVIRONMENT]}>
@@ -106,3 +112,15 @@ const transferRequestsParams = {
 };
 TransferRequestsLightMode.parameters = transferRequestsParams;
 TransferRequestsDarkMode.parameters = transferRequestsParams;
+
+const budgetReportParams = {
+  nextRouter: {
+    path: '/core-unit/[code]/finances/reports?view=auditor',
+    asPath: '/core-unit/SES/finances/reports?view=auditor',
+    query: {
+      view: 'auditor',
+    },
+  },
+};
+BudgetReportLightMode.parameters = budgetReportParams;
+BudgetReportDarkMode.parameters = budgetReportParams;

--- a/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
@@ -34,7 +34,9 @@ export const useTransparencyReport = (coreUnit: CoreUnitDto) => {
   const { permissionManager } = useAuthContext();
   const { isTimestampTrackingAccepted } = useCookiesContextTracking();
 
-  const [tabsIndex, setTabsIndex] = useState<TRANSPARENCY_IDS_ENUM>(TRANSPARENCY_IDS_ENUM.ACTUALS);
+  const [tabsIndex, setTabsIndex] = useState<TRANSPARENCY_IDS_ENUM>(
+    query?.view === 'auditor' ? TRANSPARENCY_IDS_ENUM.BUDGET_REPORT : TRANSPARENCY_IDS_ENUM.ACTUALS
+  );
 
   const [scrolled, setScrolled] = useState<boolean>(false);
 


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
Added a variant for the Transparency report page with the Budget report (Auditori view) tab activated

# What solved
 - Should add the "Budget Report" story variant to the `TransparecyReport` Story