### PR TITLE
[SES-257] Manage tabs through query params

### DIFF
--- a/src/core/utils/string.ts
+++ b/src/core/utils/string.ts
@@ -157,3 +157,10 @@ export const replaceAllNumberLetOneBeforeDot = (num: number) => {
 };
 
 export const pascalCaseToNormalString = (str: string): string => str.replace(/([a-z])([A-Z])/g, '$1 $2');
+
+export const toKebabCase = (str: string): string =>
+  str
+    .replace(/([a-z])([A-Z])/g, '$1-$2') // Convert camel case to kebab case
+    .replace(/[\s_]+/g, '-') // Replace spaces and underscores with hyphens
+    .replace(/[^a-zA-Z0-9-]/g, '') // Remove any non-alphanumeric characters (except hyphens)
+    .toLowerCase(); // Convert all characters to lowercase

--- a/src/stories/components/CUActivityTable/CUActivityItem.tsx
+++ b/src/stories/components/CUActivityTable/CUActivityItem.tsx
@@ -27,21 +27,26 @@ export default function CUActivityItem({ activity, isNew }: CUActivityItemProps)
   );
 
   const detailsUrl = useMemo(() => {
-    let anchor = '';
+    let goToComments = false;
     if (['CU_BUDGET_STATEMENT_COMMENT', 'DELEGATES_BUDGET_STATEMENT_COMMENT'].includes(activity.activityFeed.event)) {
-      anchor = '#comments';
+      goToComments = true;
     }
 
     const month = DateTime.fromFormat(activity.activityFeed.params.month, 'y-M').toFormat('LLLy');
+    let url = '';
     if (activity.activityFeed.event.startsWith('DELEGATES')) {
       // it is a delegate
-      return `${siteRoutes.recognizedDelegateReport}?viewMonth=${month}${anchor}`;
+      url = `${siteRoutes.recognizedDelegateReport}?viewMonth=${month}`;
+    } else {
+      // it is a core unit
+      url = `${siteRoutes.coreUnitReports(activity.activityFeed.params.coreUnit?.shortCode)}?viewMonth=${month}`;
     }
 
-    // it is a core unit
-    return `${siteRoutes.coreUnitReports(
-      activity.activityFeed.params.coreUnit?.shortCode
-    )}?viewMonth=${month}${anchor}`;
+    if (goToComments) {
+      url += '&section=comments';
+    }
+
+    return url;
   }, [activity]);
 
   const goToDetails = () => {

--- a/src/stories/components/Tabs/Tab.tsx
+++ b/src/stories/components/Tabs/Tab.tsx
@@ -1,19 +1,34 @@
 import styled from '@emotion/styled';
+import { BASE_URL } from '@ses/config/routes';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import Link from 'next/link';
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useMemo } from 'react';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface TabProps extends React.PropsWithChildren {
   id?: string;
   href?: string;
+  tabQuery?: string;
   active: boolean;
   onClick?: (e: React.MouseEvent) => void;
   className?: string;
 }
 
-const Tab: React.FC<TabProps> = ({ children, id, href, active = false, onClick, className }) => {
+const Tab: React.FC<TabProps> = ({ children, id, href, tabQuery, active = false, onClick, className }) => {
   const { isLight } = useThemeContext();
+  const router = useRouter();
+  const url = useMemo(() => {
+    if (href) return href;
+
+    const currentUrl = new URL(router.asPath, BASE_URL);
+    const currentQueryParams = new URLSearchParams(currentUrl.search);
+    currentQueryParams.set(tabQuery || 'tab', id || '');
+
+    const updatedUrl = `${currentUrl.pathname}?${currentQueryParams.toString()}${currentUrl.hash}`;
+
+    return updatedUrl;
+  }, [href, id, router.asPath, tabQuery]);
 
   const content = (
     <StyledTab isLight={isLight} active={active} onClick={onClick} className={className}>
@@ -24,7 +39,7 @@ const Tab: React.FC<TabProps> = ({ children, id, href, active = false, onClick, 
   if (!id && !href) return content;
 
   return (
-    <Link href={href || `#${id}`} passHref>
+    <Link href={url} passHref shallow={true}>
       {content}
     </Link>
   );

--- a/src/stories/components/Tabs/Tabs.tsx
+++ b/src/stories/components/Tabs/Tabs.tsx
@@ -22,9 +22,6 @@ export interface TabsProps {
   styleForTab?: CSSProperties;
   // default selected tab
   activeIdDefault?: string;
-
-  // managedBy?: 'hash' | 'query'; // TODO: do I use this methodology????
-
   // do this this `Tabs` allow to be expanded/compressed
   expandable?: boolean;
   // is this `Tabs` expanded by default

--- a/src/stories/containers/RecognizedDelegatesReports/RecognizedDelegatesReportContainer.tsx
+++ b/src/stories/containers/RecognizedDelegatesReports/RecognizedDelegatesReportContainer.tsx
@@ -88,7 +88,7 @@ const RecognizedDelegatesReportContainer: React.FC<RecognizedDelegatesProps> = (
         </ContainerPagerBar>
 
         <ContainerTabs>
-          <Tabs tabs={tabItems} onChange={onTabChange} />
+          <Tabs tabs={tabItems} onChange={onTabChange} tabQuery={'section'} />
         </ContainerTabs>
 
         {selectedTab === DELEGATES_REPORT_IDS_ENUM.ACTUALS && (

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -103,14 +103,10 @@ export const TransparencyReport = ({ coreUnits, coreUnit }: TransparencyReportPr
                   default: 'Default View',
                   compressed: 'Auditor View',
                 }}
+                tabQuery={'section'}
                 viewValues={{
                   default: 'default',
                   compressed: 'auditor',
-                }}
-                anchorToActualId={(anchor) => {
-                  if (anchor.startsWith('actuals-')) return 'actuals';
-                  if (anchor.startsWith('forecast-')) return 'forecast';
-                  return anchor;
                 }}
               />
             </TabsContainer>

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
@@ -82,6 +82,7 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
               }))}
               expandable
               expandedDefault={false}
+              tabQuery={actualsData.tabQuery}
               viewKey={'breakdownView'}
               onChange={handleBreakdownChange}
             />
@@ -144,6 +145,7 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
               }))}
               expandable
               expandedDefault={false}
+              tabQuery={forecastData.tabQuery}
               viewKey={'breakdownView'}
               onChange={handleBreakdownChange}
             />

--- a/src/stories/containers/TransparencyReport/components/ExpenseReportStatusIndicator/ExpenseReportStatusIndicator.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReportStatusIndicator/ExpenseReportStatusIndicator.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
+import { BASE_URL } from '@ses/config/routes';
 import Link from 'next/link';
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useMemo } from 'react';
 import lightTheme from '../../../../../../styles/theme/light';
 import { BudgetStatus } from '../../../../../core/models/dto/coreUnitDTO';
 import ExpenseReportStatus from '../ExpenseReportStatus/ExpenseReportStatus';
@@ -13,16 +15,27 @@ export type ExpenseReportStatusIndicatorProps = {
 const ExpenseReportStatusIndicator: React.FC<ExpenseReportStatusIndicatorProps> = ({
   budgetStatus = BudgetStatus.Draft,
   showCTA,
-}) => (
-  <IndicatorContainer>
-    <ExpenseReportStatus status={budgetStatus} />
-    {showCTA && budgetStatus !== BudgetStatus.Final && (
-      <Link href={'#comments'}>
-        <StyledLink>Go to {budgetStatus}</StyledLink>
-      </Link>
-    )}
-  </IndicatorContainer>
-);
+}) => {
+  const router = useRouter();
+  const url = useMemo(() => {
+    const currentUrl = new URL(router.asPath, BASE_URL);
+    const currentQueryParams = new URLSearchParams(currentUrl.search);
+    currentQueryParams.set('section', 'comments');
+
+    return `${currentUrl.pathname}?${currentQueryParams.toString()}${currentUrl.hash}`;
+  }, [router.asPath]);
+
+  return (
+    <IndicatorContainer>
+      <ExpenseReportStatus status={budgetStatus} />
+      {showCTA && budgetStatus !== BudgetStatus.Final && (
+        <Link href={url} shallow={true}>
+          <StyledLink>Go to {budgetStatus}</StyledLink>
+        </Link>
+      )}
+    </IndicatorContainer>
+  );
+};
 
 export default ExpenseReportStatusIndicator;
 

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
@@ -33,6 +33,7 @@ export const TransparencyActuals = (props: Props) => {
     mainTableColumns,
     mainTableItems,
     breakdownTabs,
+    tabQuery,
   } = useTransparencyActuals(props.currentMonth, props.budgetStatements);
 
   return (
@@ -84,6 +85,7 @@ export const TransparencyActuals = (props: Props) => {
             item: header,
             id: headerIds[i],
           }))}
+          tabQuery={tabQuery}
         />
       )}
 

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
@@ -1,6 +1,6 @@
 import { useUrlAnchor } from '@ses/core/hooks/useUrlAnchor';
 import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
-import { capitalizeSentence, getWalletWidthForWallets } from '@ses/core/utils/string';
+import { capitalizeSentence, getWalletWidthForWallets, toKebabCase } from '@ses/core/utils/string';
 import _ from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { renderLinks, renderWallet } from '../../transparencyReportUtils';
@@ -97,13 +97,8 @@ export const useTransparencyActuals = (
 
   const breakdownTitleRef = useRef<HTMLDivElement>(null);
 
-  const headerToId = (header: string): string => {
-    const id = header.toLowerCase().trim().replaceAll(/ /g, '-');
-    return `actuals-${id}`;
-  };
-
   useEffect(() => {
-    setHeaderIds(breakdownTabs.map((header: string) => headerToId(header)));
+    setHeaderIds(breakdownTabs.map((header: string) => toKebabCase(header)));
   }, [breakdownTabs]);
 
   useEffect(() => {
@@ -290,5 +285,6 @@ export const useTransparencyActuals = (
     mainTableItems,
     breakdownTabs,
     wallets,
+    tabQuery: 'actual-account',
   };
 };

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
@@ -34,6 +34,7 @@ export const TransparencyForecast = (props: Props) => {
     breakdownItems,
     breakdownTitleRef,
     breakdownTabs,
+    tabQuery,
   } = useTransparencyForecast(props.currentMonth, props.budgetStatements);
 
   return (
@@ -81,6 +82,7 @@ export const TransparencyForecast = (props: Props) => {
             item: header,
             id: headerIds[i],
           }))}
+          tabQuery={tabQuery}
         />
       )}
 

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
@@ -1,6 +1,6 @@
 import { useUrlAnchor } from '@ses/core/hooks/useUrlAnchor';
 import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
-import { capitalizeSentence, getWalletWidthForWallets } from '@ses/core/utils/string';
+import { capitalizeSentence, getWalletWidthForWallets, toKebabCase } from '@ses/core/utils/string';
 import _ from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { renderLinks, renderWallet } from '../../transparencyReportUtils';
@@ -49,14 +49,9 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
     return wallets?.map((wallet) => wallet.name);
   }, [budgetStatements, wallets]);
 
-  const headerToId = (header: string): string => {
-    const id = header.toLowerCase().trim().replaceAll(/ /g, '-');
-    return `forecast-${id}`;
-  };
-
   const [headerIds, setHeaderIds] = useState<string[]>([]);
   useEffect(() => {
-    setHeaderIds(breakdownTabs.map((header) => headerToId(header)));
+    setHeaderIds(breakdownTabs.map((header) => toKebabCase(header)));
   }, [breakdownTabs]);
 
   const anchor = useUrlAnchor();
@@ -300,8 +295,7 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
     firstMonth,
     secondMonth,
     thirdMonth,
-    getForecastSumOfMonthsOnWallet,
-    getForecastSumForMonths,
     wallets,
+    tabQuery: 'forecast-account',
   };
 };

--- a/src/stories/containers/TransparencyReport/components/TransparencyMkrVesting/MkrVestingInfo.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyMkrVesting/MkrVestingInfo.tsx
@@ -22,7 +22,7 @@ const MkrVestingInfo: React.FC = () => {
 export default MkrVestingInfo;
 
 const InfoContainer = styled.div({
-  '& > div:first-child': {
+  '& > div:first-of-type': {
     marginBottom: 16,
   },
 });


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
Updated the Tabs component to be self-controlled using the URL query params instead of the hash, this way we can have several tabs on the same page without any conflict by using different query params keys. The query param key for all the current tabs was updated.

# What solved
- Should update the `Tabs` component to allow to store of the state of the selected tab through a query string instead of a hash
- Should allow to share the state of the selected tabs through the `section` query string for the main tabs, `actual-account` for the tabs of the actuals breakdowns tabs and `forecast-account` for the forecast breakdown tabs