### PR TITLE
[SES-257] Change actuals and forecast negative numbers to green

### DIFF
--- a/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -10,7 +10,7 @@ import { TransparencyCard } from '../TransparencyCard/TransparencyCard';
 export interface InnerTableColumn {
   align?: string;
   header?: string;
-  type?: 'number' | 'text' | 'custom';
+  type?: 'number' | 'incomeNumber' | 'text' | 'custom';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   cellRender?: (data: any) => JSX.Element;
   headerAlign?: string;
@@ -59,6 +59,8 @@ export const AdvancedInnerTable = ({ cardsTotalPosition = 'bottom', ...props }: 
     switch (columnType) {
       case 'number':
         return <NumberCell key={column.header} value={Number(value)} bold={isBold} />;
+      case 'incomeNumber':
+        return <NumberCell key={column.header} value={Number(value)} bold={isBold} isIncome={true} />;
       case 'text':
         return (
           <TextCell key={column.header} bold={isBold} isHeader={column.isCardHeader}>

--- a/src/stories/components/NumberCell/NumberCell.tsx
+++ b/src/stories/components/NumberCell/NumberCell.tsx
@@ -52,11 +52,11 @@ const Container = styled.div<{ negative?: boolean; fontFamily?: string; isLight:
         ? '#1AAB9B'
         : '#F75524'
       : '#D2D4EF',
-    // color:
-    //   isLight && negative ? '#F75524' : isLight && !negative ? '#231536' : !isLight && negative ? '#F75524' : '#D2D4EF',
+
     '@media (min-width: 834px)': {
       padding: '10px 16px',
     },
+
     '@media (min-width: 1194px)': {
       fontSize: '16px',
       lineHeight: '19px',

--- a/src/stories/components/NumberCell/NumberCell.tsx
+++ b/src/stories/components/NumberCell/NumberCell.tsx
@@ -10,6 +10,7 @@ interface NumberCellProps {
   value: number;
   bold?: boolean;
   className?: string;
+  isIncome?: boolean;
 }
 
 export const NumberCell = (props: NumberCellProps) => {
@@ -24,14 +25,15 @@ export const NumberCell = (props: NumberCellProps) => {
         ...props.style,
       }}
       negative={props.value < 0}
+      isIncome={props.isIncome ?? false}
     >
       {formatNumber(props.value)}
     </Container>
   );
 };
 
-const Container = styled.div<{ negative?: boolean; fontFamily?: string; isLight: boolean }>(
-  ({ negative = false, fontFamily = 'Inter, sans-serif', isLight }) => ({
+const Container = styled.div<{ negative?: boolean; fontFamily?: string; isLight: boolean; isIncome: boolean }>(
+  ({ negative = false, fontFamily = 'Inter, sans-serif', isLight, isIncome }) => ({
     fontFamily,
     fontSize: '14px',
     lineHeight: '17px',
@@ -39,8 +41,19 @@ const Container = styled.div<{ negative?: boolean; fontFamily?: string; isLight:
     fontWeight: 400,
     letterSpacing: '0.3px',
     fontFeatureSettings: "'tnum' on, 'lnum' on",
-    color:
-      isLight && negative ? '#F75524' : isLight && !negative ? '#231536' : !isLight && negative ? '#F75524' : '#D2D4EF',
+    color: isLight
+      ? negative
+        ? isIncome
+          ? '#139D8D'
+          : '#F75524'
+        : '#231536'
+      : negative
+      ? isIncome
+        ? '#1AAB9B'
+        : '#F75524'
+      : '#D2D4EF',
+    // color:
+    //   isLight && negative ? '#F75524' : isLight && !negative ? '#231536' : !isLight && negative ? '#F75524' : '#D2D4EF',
     '@media (min-width: 834px)': {
       padding: '10px 16px',
     },

--- a/src/stories/containers/RecognizedDelegatesReports/DelegatesActuals/useDelegatesActuals.ts
+++ b/src/stories/containers/RecognizedDelegatesReports/DelegatesActuals/useDelegatesActuals.ts
@@ -131,12 +131,12 @@ export const useDelegatesActuals = (
       {
         header: 'Forecast',
         align: 'right',
-        type: 'number',
+        type: 'incomeNumber',
       },
       {
         header: 'Actuals',
         align: 'right',
-        type: 'number',
+        type: 'incomeNumber',
       },
       {
         header: 'Difference',
@@ -258,12 +258,12 @@ export const useDelegatesActuals = (
       {
         header: 'Forecast',
         align: 'right',
-        type: 'number',
+        type: 'incomeNumber',
       },
       {
         header: 'Actuals',
         align: 'right',
-        type: 'number',
+        type: 'incomeNumber',
       },
       {
         header: 'Difference',

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
@@ -130,12 +130,12 @@ export const useTransparencyActuals = (
       {
         header: 'Forecast',
         align: 'right',
-        type: 'number',
+        type: 'incomeNumber',
       },
       {
         header: 'Actuals',
         align: 'right',
-        type: 'number',
+        type: 'incomeNumber',
       },
       {
         header: 'Difference',

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
@@ -70,13 +70,13 @@ export const TransparencyForecast = (props: Props) => {
         style={{ marginBottom: '64px' }}
         cardsTotalPosition={'top'}
       />
-      {!!breakdownItems.length && (
+      {!!breakdownItems?.length && (
         <Title isLight={isLight} marginBottom={24} ref={breakdownTitleRef}>
           {props.currentMonth.toFormat('MMM yyyy')} Breakdown
         </Title>
       )}
 
-      {!!breakdownItems.length && (
+      {!!breakdownItems?.length && (
         <Tabs
           tabs={breakdownTabs.map((header, i) => ({
             item: header,
@@ -86,7 +86,7 @@ export const TransparencyForecast = (props: Props) => {
         />
       )}
 
-      {!!breakdownItems.length && (
+      {!!breakdownItems?.length && (
         <AdvancedInnerTable
           longCode={props.longCode}
           columns={breakdownColumnsForActiveTab}

--- a/src/stories/containers/TransparencyReport/utils/actualsTableHelpers.ts
+++ b/src/stories/containers/TransparencyReport/utils/actualsTableHelpers.ts
@@ -38,12 +38,12 @@ export const getActualsBreakdownColumns = (wallet: BudgetStatementWalletDto) => 
     {
       header: 'Forecast',
       align: 'right',
-      type: 'number',
+      type: 'incomeNumber',
     },
     {
       header: 'Actuals',
       align: 'right',
-      type: 'number',
+      type: 'incomeNumber',
     },
     {
       header: 'Difference',


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
The numbers in the tables of the actuals and forecast columns of the actuals tab were changed to green when they were negative. The change was made on the CU and delegates report pages. 

# What solved
- Should show the negative number in the actuals and forecast tabs of the actuals total table in green
- Should show the negative number in the actuals and forecast tabs of the actuals breakdown table in green