### PR TITLE
[SES-257] Allow to expand or compress the breakdown tabs

### DIFF
--- a/src/stories/components/Tabs/Tabs.tsx
+++ b/src/stories/components/Tabs/Tabs.tsx
@@ -90,29 +90,33 @@ const Tabs: React.FC<TabsProps> = ({
     }
     return expandedDefault;
   });
-  const [expandedActiveId, setExpandedActiveId] = useState<string | undefined>(activeIdDefault ?? tabs?.[0]?.id);
+  const isValidQueryValue = useCallback(
+    (value: string): boolean => {
+      if (value) {
+        const actualId = value;
+        if (expanded) {
+          return tabs.some((element) => element.id === actualId);
+        } else {
+          return !!compressedTabs?.some((element) => element.id === actualId);
+        }
+      } else {
+        return true;
+      }
+    },
+    [compressedTabs, expanded, tabs]
+  );
+  const [expandedActiveId, setExpandedActiveId] = useState<string | undefined>(
+    activeIdDefault ?? (!!queryValue && isValidQueryValue(queryValue)) ? queryValue : tabs?.[0]?.id
+  );
   const [compressedActiveId, setCompressedActiveId] = useState<string | undefined>(
-    activeIdDefault ?? compressedTabs?.[0]?.id
+    activeIdDefault ?? (!!queryValue && isValidQueryValue(queryValue)) ? queryValue : compressedTabs?.[0]?.id
   );
   const activeId = expanded ? expandedActiveId : compressedActiveId;
-
-  const isValidQueryValue = useCallback(() => {
-    if (queryValue) {
-      const actualId = queryValue;
-      if (expanded) {
-        return tabs.some((element) => element.id === actualId);
-      } else {
-        return !!compressedTabs?.some((element) => element.id === actualId);
-      }
-    } else {
-      return true;
-    }
-  }, [compressedTabs, expanded, queryValue, tabs]);
 
   useEffect(() => {
     if (!controlled) {
       // update active id
-      if (queryValue && isValidQueryValue()) {
+      if (queryValue && isValidQueryValue(queryValue)) {
         if (
           queryValue !== activeId ||
           (expanded && queryValue === tabs?.[0]?.id) ||

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
@@ -3,19 +3,20 @@ import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedI
 import Container from '@ses/components/Container/Container';
 import { CustomLink } from '@ses/components/CustomLink/CustomLink';
 import Tabs from '@ses/components/Tabs/Tabs';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { MAKER_BURN_LINK } from '@ses/core/utils/const';
-import React, { useState } from 'react';
+import React from 'react';
+import {
+  ACTUALS_BREAKDOWN_QUERY_PARAM,
+  BREAKDOWN_VIEW_QUERY_KEY,
+  FORECAST_BREAKDOWN_QUERY_PARAM,
+} from '../../utils/constants';
 import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import { LinkDescription } from '../TransparencyActuals/TransparencyActuals';
-import { useTransparencyActuals } from '../TransparencyActuals/useTransparencyActuals';
-import { useTransparencyForecast } from '../TransparencyForecast/useTransparencyForecast';
 import MkrVestingInfo from '../TransparencyMkrVesting/MkrVestingInfo';
 import MkrVestingTotalFTE from '../TransparencyMkrVesting/MkrVestingTotalFTE';
-import { useTransparencyMkrVesting } from '../TransparencyMkrVesting/useTransparencyMkrVesting';
-import { useTransparencyTransferRequest } from '../TransparencyTransferRequest/useTransparencyTransferRequest';
 import BudgetSection from './components/BudgetSection/BudgetSection';
 import SectionTitle from './components/SectionTitle/SectionTitle';
+import useBudgetReport from './useBudgetReport';
 import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { DateTime } from 'luxon';
@@ -28,18 +29,15 @@ interface BudgetReportProps {
 }
 
 const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStatements, code, longCode }) => {
-  const { isLight } = useThemeContext();
-
-  const actualsData = useTransparencyActuals(currentMonth, budgetStatements);
-  const forecastData = useTransparencyForecast(currentMonth, budgetStatements);
-  const mkrVestingData = useTransparencyMkrVesting(currentMonth, budgetStatements);
-  const transferRequestsData = useTransparencyTransferRequest(currentMonth, budgetStatements);
-
-  const [breakdownSelected, setBreakdownSelected] = useState<string | undefined>();
-
-  const handleBreakdownChange = (current?: string) => {
-    setBreakdownSelected(current);
-  };
+  const {
+    isLight,
+    actualsData,
+    forecastData,
+    mkrVestingData,
+    transferRequestsData,
+    breakdownSelected,
+    handleBreakdownChange,
+  } = useBudgetReport(currentMonth, budgetStatements);
 
   return (
     <BudgetReportWrapper>
@@ -82,8 +80,8 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
               }))}
               expandable
               expandedDefault={false}
-              tabQuery={actualsData.tabQuery}
-              viewKey={'breakdownView'}
+              tabQuery={ACTUALS_BREAKDOWN_QUERY_PARAM}
+              viewKey={BREAKDOWN_VIEW_QUERY_KEY}
               onChange={handleBreakdownChange}
             />
 
@@ -145,8 +143,8 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
               }))}
               expandable
               expandedDefault={false}
-              tabQuery={forecastData.tabQuery}
-              viewKey={'breakdownView'}
+              tabQuery={FORECAST_BREAKDOWN_QUERY_PARAM}
+              viewKey={BREAKDOWN_VIEW_QUERY_KEY}
               onChange={handleBreakdownChange}
             />
 

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/useBudgetReport.ts
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/useBudgetReport.ts
@@ -1,0 +1,34 @@
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { useCallback, useState } from 'react';
+import { useTransparencyActuals } from '../TransparencyActuals/useTransparencyActuals';
+import { useTransparencyForecast } from '../TransparencyForecast/useTransparencyForecast';
+import { useTransparencyMkrVesting } from '../TransparencyMkrVesting/useTransparencyMkrVesting';
+import { useTransparencyTransferRequest } from '../TransparencyTransferRequest/useTransparencyTransferRequest';
+import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
+import type { DateTime } from 'luxon';
+
+const useBudgetReport = (currentMonth: DateTime, budgetStatements?: BudgetStatementDto[]) => {
+  const { isLight } = useThemeContext();
+
+  const actualsData = useTransparencyActuals(currentMonth, budgetStatements);
+  const forecastData = useTransparencyForecast(currentMonth, budgetStatements);
+  const mkrVestingData = useTransparencyMkrVesting(currentMonth, budgetStatements);
+  const transferRequestsData = useTransparencyTransferRequest(currentMonth, budgetStatements);
+
+  const [breakdownSelected, setBreakdownSelected] = useState<string | undefined>();
+  const handleBreakdownChange = useCallback((current?: string) => {
+    setBreakdownSelected(current);
+  }, []);
+
+  return {
+    isLight,
+    actualsData,
+    forecastData,
+    mkrVestingData,
+    transferRequestsData,
+    breakdownSelected,
+    handleBreakdownChange,
+  };
+};
+
+export default useBudgetReport;

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
@@ -9,6 +9,7 @@ import { getShortCode } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { Title } from '../../TransparencyReport';
+import { ACTUALS_BREAKDOWN_QUERY_PARAM } from '../../utils/constants';
 import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import { useTransparencyActuals } from './useTransparencyActuals';
 import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
@@ -33,7 +34,6 @@ export const TransparencyActuals = (props: Props) => {
     mainTableColumns,
     mainTableItems,
     breakdownTabs,
-    tabQuery,
   } = useTransparencyActuals(props.currentMonth, props.budgetStatements);
 
   return (
@@ -85,7 +85,7 @@ export const TransparencyActuals = (props: Props) => {
             item: header,
             id: headerIds[i],
           }))}
-          tabQuery={tabQuery}
+          tabQuery={ACTUALS_BREAKDOWN_QUERY_PARAM}
         />
       )}
 

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
@@ -1,7 +1,7 @@
-import { useUrlAnchor } from '@ses/core/hooks/useUrlAnchor';
 import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
 import { capitalizeSentence, getWalletWidthForWallets, toKebabCase } from '@ses/core/utils/string';
 import _ from 'lodash';
+import { useRouter } from 'next/router';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { renderLinks, renderWallet } from '../../transparencyReportUtils';
 import { getActualsBreakdownColumns, getActualsBreakdownItemsForWallet } from '../../utils/actualsTableHelpers';
@@ -11,6 +11,7 @@ import {
   getWalletForecast,
   getWalletPayment,
 } from '../../utils/budgetStatementsUtils';
+import { ACTUALS_BREAKDOWN_QUERY_PARAM } from '../../utils/constants';
 import type { InnerTableColumn, InnerTableRow } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
 import type { BudgetStatementDto, BudgetStatementWalletDto } from '@ses/core/models/dto/coreUnitDTO';
 import type { DateTime } from 'luxon';
@@ -20,7 +21,11 @@ export const useTransparencyActuals = (
   budgetStatements: BudgetStatementDto[] | undefined
 ) => {
   const currentMonth = useMemo(() => propsCurrentMonth.toFormat(API_MONTH_TO_FORMAT), [propsCurrentMonth]);
-  const anchor = useUrlAnchor();
+  const router = useRouter();
+  const query = router.query;
+  const selectedBreakdown = Array.isArray(query[ACTUALS_BREAKDOWN_QUERY_PARAM])
+    ? query[ACTUALS_BREAKDOWN_QUERY_PARAM][0]
+    : query[ACTUALS_BREAKDOWN_QUERY_PARAM];
 
   const wallets: BudgetStatementWalletDto[] = useMemo(() => {
     const dict: { [id: string]: BudgetStatementWalletDto } = {};
@@ -91,7 +96,10 @@ export const useTransparencyActuals = (
   const [headerIds, setHeaderIds] = useState<string[]>([]);
   const [scrolled, setScrolled] = useState<boolean>(false);
 
-  const thirdIndex = useMemo(() => Math.max(headerIds?.indexOf(anchor ?? ''), 0), [headerIds, anchor]);
+  const thirdIndex = useMemo(
+    () => Math.max(headerIds?.indexOf(selectedBreakdown ?? ''), 0),
+    [headerIds, selectedBreakdown]
+  );
 
   const currentWallet = useMemo(() => wallets[thirdIndex], [thirdIndex, wallets]);
 
@@ -102,7 +110,7 @@ export const useTransparencyActuals = (
   }, [breakdownTabs]);
 
   useEffect(() => {
-    if (!scrolled && anchor && !_.isEmpty(headerIds) && headerIds.includes(anchor)) {
+    if (!scrolled && selectedBreakdown && !_.isEmpty(headerIds) && headerIds.includes(selectedBreakdown)) {
       setScrolled(true);
       let offset = (breakdownTitleRef?.current?.offsetTop || 0) - 260;
       const windowsWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
@@ -114,7 +122,7 @@ export const useTransparencyActuals = (
       }
       window.scrollTo(0, Math.max(0, offset));
     }
-  }, [anchor, headerIds, scrolled]);
+  }, [selectedBreakdown, headerIds, scrolled]);
 
   const mainTableColumns = useMemo(() => {
     const mainTableColumns: InnerTableColumn[] = [
@@ -285,6 +293,5 @@ export const useTransparencyActuals = (
     mainTableItems,
     breakdownTabs,
     wallets,
-    tabQuery: 'actual-account',
   };
 };

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
@@ -9,6 +9,7 @@ import { getShortCode } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { Title } from '../../TransparencyReport';
+import { FORECAST_BREAKDOWN_QUERY_PARAM } from '../../utils/constants';
 import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import { LinkDescription } from '../TransparencyActuals/TransparencyActuals';
 import { useTransparencyForecast } from './useTransparencyForecast';
@@ -34,7 +35,6 @@ export const TransparencyForecast = (props: Props) => {
     breakdownItems,
     breakdownTitleRef,
     breakdownTabs,
-    tabQuery,
   } = useTransparencyForecast(props.currentMonth, props.budgetStatements);
 
   return (
@@ -82,7 +82,7 @@ export const TransparencyForecast = (props: Props) => {
             item: header,
             id: headerIds[i],
           }))}
-          tabQuery={tabQuery}
+          tabQuery={FORECAST_BREAKDOWN_QUERY_PARAM}
         />
       )}
 

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
@@ -1,7 +1,7 @@
-import { useUrlAnchor } from '@ses/core/hooks/useUrlAnchor';
 import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
 import { capitalizeSentence, getWalletWidthForWallets, toKebabCase } from '@ses/core/utils/string';
 import _ from 'lodash';
+import { useRouter } from 'next/router';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { renderLinks, renderWallet } from '../../transparencyReportUtils';
 import {
@@ -14,6 +14,7 @@ import {
   getForecastSumOfMonthsOnWallet,
   getTotalQuarterlyBudgetCapOnBudgetStatement,
 } from '../../utils/budgetStatementsUtils';
+import { FORECAST_BREAKDOWN_QUERY_PARAM } from '../../utils/constants';
 import { getBreakdownItemsForWallet, getForecastBreakdownColumns } from '../../utils/forecastTableHelpers';
 import type { InnerTableColumn, InnerTableRow } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
 import type { BudgetStatementDto, BudgetStatementWalletDto } from '@ses/core/models/dto/coreUnitDTO';
@@ -54,12 +55,15 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
     setHeaderIds(breakdownTabs.map((header) => toKebabCase(header)));
   }, [breakdownTabs]);
 
-  const anchor = useUrlAnchor();
+  const query = useRouter().query;
+  const selectedBreakdown = Array.isArray(query[FORECAST_BREAKDOWN_QUERY_PARAM])
+    ? query[FORECAST_BREAKDOWN_QUERY_PARAM][0]
+    : query[FORECAST_BREAKDOWN_QUERY_PARAM];
   const breakdownTitleRef = useRef<HTMLDivElement>(null);
   const [scrolled, setScrolled] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!scrolled && anchor && !_.isEmpty(headerIds) && headerIds.includes(anchor)) {
+    if (!scrolled && selectedBreakdown && !_.isEmpty(headerIds) && headerIds.includes(selectedBreakdown)) {
       setScrolled(true);
       let offset = (breakdownTitleRef?.current?.offsetTop || 0) - 260;
       const windowsWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
@@ -71,13 +75,13 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
       }
       window.scrollTo(0, Math.max(0, offset));
     }
-  }, [anchor, headerIds, scrolled]);
+  }, [selectedBreakdown, headerIds, scrolled]);
 
   useEffect(() => {
-    if (anchor && !_.isEmpty(headerIds)) {
-      setThirdIndex(Math.max(headerIds.indexOf(anchor), 0));
+    if (selectedBreakdown && !_.isEmpty(headerIds)) {
+      setThirdIndex(Math.max(headerIds.indexOf(selectedBreakdown), 0));
     }
-  }, [anchor, headerIds]);
+  }, [selectedBreakdown, headerIds]);
 
   const mainTableColumns: InnerTableColumn[] = useMemo(
     () => [
@@ -296,6 +300,5 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
     secondMonth,
     thirdMonth,
     wallets,
-    tabQuery: 'forecast-account',
   };
 };

--- a/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
+++ b/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
@@ -84,8 +84,11 @@ export const RenderNumberWithIcon = (data: TargetBalanceTooltipInformation) => {
   const { lockScroll, unlockScroll } = useScrollLock();
   const showIconToolTip = !!(data.description && data.link);
 
-  const md = new MobileDetect(window.navigator.userAgent);
-  const isMobileDevice = !!md.mobile();
+  let md;
+  if (typeof window !== 'undefined') {
+    md = new MobileDetect(window.navigator?.userAgent);
+  }
+  const isMobileDevice = !!md?.mobile();
 
   useEffect(() => {
     if (isMobileDevice) {

--- a/src/stories/containers/TransparencyReport/utils/constants.ts
+++ b/src/stories/containers/TransparencyReport/utils/constants.ts
@@ -1,0 +1,5 @@
+export const ACTUALS_BREAKDOWN_QUERY_PARAM = 'actual-account';
+
+export const FORECAST_BREAKDOWN_QUERY_PARAM = 'forecast-account';
+
+export const BREAKDOWN_VIEW_QUERY_KEY = 'breakdownView';


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
Allow to expand/compress the breakdown tabs

# What solved
- Should allow to expand or compress the Actual breakdown section in the "Budget Report" tab
- Should allow to expand or compress the Forecast breakdown section in the "Budget Report" tab