### PR TITLE
[SES-257] Improve Breakdown tabs behavior on Budget Report section

### DIFF
--- a/src/core/utils/urls.ts
+++ b/src/core/utils/urls.ts
@@ -34,3 +34,13 @@ export const toAbsoluteURL = (relativeURL: string): string => {
   }
   return `${BASE_URL}${relativeURL}`;
 };
+
+export const removeEmptyProperties = <T extends object>(obj: T): Partial<T> => {
+  const newObj: Partial<T> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value) {
+      newObj[key as keyof T] = value;
+    }
+  }
+  return newObj;
+};

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
@@ -29,15 +29,8 @@ interface BudgetReportProps {
 }
 
 const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStatements, code, longCode }) => {
-  const {
-    isLight,
-    actualsData,
-    forecastData,
-    mkrVestingData,
-    transferRequestsData,
-    breakdownSelected,
-    handleBreakdownChange,
-  } = useBudgetReport(currentMonth, budgetStatements);
+  const { isLight, actualsData, forecastData, mkrVestingData, transferRequestsData, isBreakdownExpanded } =
+    useBudgetReport(currentMonth, budgetStatements);
 
   return (
     <BudgetReportWrapper>
@@ -82,10 +75,9 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
               expandedDefault={false}
               tabQuery={ACTUALS_BREAKDOWN_QUERY_PARAM}
               viewKey={BREAKDOWN_VIEW_QUERY_KEY}
-              onChange={handleBreakdownChange}
             />
 
-            {breakdownSelected ? (
+            {isBreakdownExpanded ? (
               <AdvancedInnerTable
                 columns={actualsData.breakdownColumnsForActiveTab}
                 items={actualsData.breakdownItemsForActiveTab}
@@ -145,10 +137,9 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
               expandedDefault={false}
               tabQuery={FORECAST_BREAKDOWN_QUERY_PARAM}
               viewKey={BREAKDOWN_VIEW_QUERY_KEY}
-              onChange={handleBreakdownChange}
             />
 
-            {breakdownSelected ? (
+            {isBreakdownExpanded ? (
               <AdvancedInnerTable
                 longCode={longCode}
                 columns={forecastData.breakdownColumnsForActiveTab}

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/useBudgetReport.ts
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/useBudgetReport.ts
@@ -1,5 +1,7 @@
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { useCallback, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { BREAKDOWN_VIEW_QUERY_KEY } from '../../utils/constants';
 import { useTransparencyActuals } from '../TransparencyActuals/useTransparencyActuals';
 import { useTransparencyForecast } from '../TransparencyForecast/useTransparencyForecast';
 import { useTransparencyMkrVesting } from '../TransparencyMkrVesting/useTransparencyMkrVesting';
@@ -9,16 +11,19 @@ import type { DateTime } from 'luxon';
 
 const useBudgetReport = (currentMonth: DateTime, budgetStatements?: BudgetStatementDto[]) => {
   const { isLight } = useThemeContext();
+  const query = useRouter().query;
 
   const actualsData = useTransparencyActuals(currentMonth, budgetStatements);
   const forecastData = useTransparencyForecast(currentMonth, budgetStatements);
   const mkrVestingData = useTransparencyMkrVesting(currentMonth, budgetStatements);
   const transferRequestsData = useTransparencyTransferRequest(currentMonth, budgetStatements);
 
-  const [breakdownSelected, setBreakdownSelected] = useState<string | undefined>();
-  const handleBreakdownChange = useCallback((current?: string) => {
-    setBreakdownSelected(current);
-  }, []);
+  const [isBreakdownExpanded, setIsBreakdownExpanded] = useState(() => query[BREAKDOWN_VIEW_QUERY_KEY] === 'default');
+  useEffect(() => {
+    // update breakdown expanded state when its query param changes
+    // this keeps both breakdown tabs content synced
+    setIsBreakdownExpanded(query[BREAKDOWN_VIEW_QUERY_KEY] === 'default');
+  }, [query]);
 
   return {
     isLight,
@@ -26,8 +31,7 @@ const useBudgetReport = (currentMonth: DateTime, budgetStatements?: BudgetStatem
     forecastData,
     mkrVestingData,
     transferRequestsData,
-    breakdownSelected,
-    handleBreakdownChange,
+    isBreakdownExpanded,
   };
 };
 

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/useTransparencyActuals.ts
@@ -94,7 +94,6 @@ export const useTransparencyActuals = (
   );
 
   const [headerIds, setHeaderIds] = useState<string[]>([]);
-  const [scrolled, setScrolled] = useState<boolean>(false);
 
   const thirdIndex = useMemo(
     () => Math.max(headerIds?.indexOf(selectedBreakdown ?? ''), 0),
@@ -108,21 +107,6 @@ export const useTransparencyActuals = (
   useEffect(() => {
     setHeaderIds(breakdownTabs.map((header: string) => toKebabCase(header)));
   }, [breakdownTabs]);
-
-  useEffect(() => {
-    if (!scrolled && selectedBreakdown && !_.isEmpty(headerIds) && headerIds.includes(selectedBreakdown)) {
-      setScrolled(true);
-      let offset = (breakdownTitleRef?.current?.offsetTop || 0) - 260;
-      const windowsWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
-      if (windowsWidth < 834) {
-        offset += 90;
-      }
-      if ('scrollRestoration' in window.history) {
-        window.history.scrollRestoration = 'manual';
-      }
-      window.scrollTo(0, Math.max(0, offset));
-    }
-  }, [selectedBreakdown, headerIds, scrolled]);
 
   const mainTableColumns = useMemo(() => {
     const mainTableColumns: InnerTableColumn[] = [

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.ts
@@ -60,22 +60,6 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
     ? query[FORECAST_BREAKDOWN_QUERY_PARAM][0]
     : query[FORECAST_BREAKDOWN_QUERY_PARAM];
   const breakdownTitleRef = useRef<HTMLDivElement>(null);
-  const [scrolled, setScrolled] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (!scrolled && selectedBreakdown && !_.isEmpty(headerIds) && headerIds.includes(selectedBreakdown)) {
-      setScrolled(true);
-      let offset = (breakdownTitleRef?.current?.offsetTop || 0) - 260;
-      const windowsWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
-      if (windowsWidth < 834) {
-        offset += 90;
-      }
-      if ('scrollRestoration' in window.history) {
-        window.history.scrollRestoration = 'manual';
-      }
-      window.scrollTo(0, Math.max(0, offset));
-    }
-  }, [selectedBreakdown, headerIds, scrolled]);
 
   useEffect(() => {
     if (selectedBreakdown && !_.isEmpty(headerIds)) {

--- a/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
@@ -36,29 +36,6 @@ export const useTransparencyReport = (coreUnit: CoreUnitDto) => {
     query?.view === 'auditor' ? TRANSPARENCY_IDS_ENUM.BUDGET_REPORT : TRANSPARENCY_IDS_ENUM.ACTUALS
   );
 
-  const [scrolled, setScrolled] = useState<boolean>(false);
-  useEffect(() => {
-    if (query.section === '') {
-      setScrolled(true);
-    }
-    if (
-      !scrolled &&
-      query.section &&
-      Object.values(TRANSPARENCY_IDS_ENUM).includes(query.section as TRANSPARENCY_IDS_ENUM)
-    ) {
-      setScrolled(true);
-      let offset = (transparencyTableRef?.current?.offsetTop || 0) - 280;
-      const windowsWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
-      if (windowsWidth < 834) {
-        offset += 100;
-      }
-      if ('scrollRestoration' in window.history) {
-        window.history.scrollRestoration = 'manual';
-      }
-      window.scrollTo(0, Math.max(0, offset));
-    }
-  }, [query.section, scrolled]);
-
   const [lastVisitHandler, setLastVisitHandler] = useState<LastVisitHandler>();
 
   const onPrevious = useCallback(() => {


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
Allow to compress/expand the breakdown tabs in the actuals and forecast sections simultaneously. The state of the tabs is shareable through the URL and the state should be kept after the page refresh or the URL opened on any other device.

# What solved
- Should compress the actuals and forecasts breakdown at the same time
- Should compress all the breakdown tabs by default when the auditor view is opened
- Should allow to share the state of the breakdown tabs (compressed/expanded) through the URL utilizing the `breakdownView` query string