### PR TITLE
[SES-257] Open Budget Sections in a new tab

### DIFF
--- a/src/core/hooks/useHashFragment.tsx
+++ b/src/core/hooks/useHashFragment.tsx
@@ -1,0 +1,53 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+interface Options {
+  offset?: number;
+  addListeners?: boolean;
+  delayOnLoad?: number;
+}
+
+export const useHashFragment = ({ offset = 0, addListeners = true, delayOnLoad = 0 }: Options = {}) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    // function to scroll to the hash element
+    const scrollToHashElement = () => {
+      const { hash } = window.location;
+      const elementToScroll = document.getElementById(hash);
+
+      if (!elementToScroll) return;
+
+      window.scrollTo({
+        top: elementToScroll.offsetTop - offset,
+        behavior: 'smooth',
+      });
+    };
+    const delayedScrollToHashElement = () => {
+      setTimeout(() => {
+        scrollToHashElement();
+      }, delayOnLoad);
+    };
+    // function to handle the route change event
+    const handleRouteChange = (url: string) => {
+      if (url.includes('#')) {
+        delayedScrollToHashElement();
+      }
+    };
+
+    // If we don't want to add listeners, we just scroll to the hash element on page load
+    if (!addListeners) {
+      delayedScrollToHashElement();
+      return;
+    }
+
+    // scroll to the hash element on page load
+    delayedScrollToHashElement();
+
+    router.events.on('hashChangeComplete', handleRouteChange);
+    // Clean up the event listener
+    return () => {
+      router.events.off('hashChangeComplete', handleRouteChange);
+    };
+  }, [addListeners, delayOnLoad, offset, router.events]);
+};

--- a/src/core/utils/string.ts
+++ b/src/core/utils/string.ts
@@ -160,6 +160,7 @@ export const pascalCaseToNormalString = (str: string): string => str.replace(/([
 
 export const toKebabCase = (str: string): string =>
   str
+    .replace(/-/g, ' ')
     .replace(/([a-z])([A-Z])/g, '$1-$2') // Convert camel case to kebab case
     .replace(/[\s_]+/g, '-') // Replace spaces and underscores with hyphens
     .replace(/[^a-zA-Z0-9-]/g, '') // Remove any non-alphanumeric characters (except hyphens)

--- a/src/stories/components/svg/ArrowLink.tsx
+++ b/src/stories/components/svg/ArrowLink.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 interface Props {
+  className?: string;
   width?: number;
   height?: number;
   href?: string;
@@ -7,8 +8,8 @@ interface Props {
   fill?: string;
 }
 
-const ArrowLink = ({ width = 16, height = 16, href, target, fill = '#626472', ...props }: Props) => (
-  <a href={href} target={target}>
+const ArrowLink = ({ width = 16, height = 16, href, target, fill = '#626472', className, ...props }: Props) => (
+  <a href={href} target={target} className={className}>
     <svg width={width} height={height} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
       <path
         d="M10.36 2c-.35 0-.525.404-.278.64l1.13 1.08-6.275 6a.727.727 0 000 1.06.81.81 0 001.109 0l6.274-6 1.13 1.08c.246.236.669.069.669-.265v-3.22A.384.384 0 0013.727 2H10.36z"

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/BudgetReport.tsx
@@ -63,7 +63,9 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
         {actualsData.mainTableItems.length > 0 && (
           <>
             <TitleSpacer>
-              <SectionTitle level={2}>Actuals - Breakdown</SectionTitle>
+              <SectionTitle level={2} hasExternalIcon={isBreakdownExpanded}>
+                Actuals - Breakdown
+              </SectionTitle>
             </TitleSpacer>
 
             <Tabs
@@ -89,7 +91,7 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
               <BudgetSection level={2}>
                 {actualsData.breakdownTabs.map((header, index) => (
                   <BudgetSubsectionContainer isFirst={index === 0} key={header}>
-                    <SectionTitle level={2} hasIcon={true}>
+                    <SectionTitle level={2} hasIcon={true} hasExternalIcon={true} idPrefix={'actuals'}>
                       {header}
                     </SectionTitle>
                     <div>
@@ -125,7 +127,9 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
         {forecastData.breakdownItems.length > 0 && (
           <>
             <TitleSpacer>
-              <SectionTitle level={2}>Forecast - Breakdown</SectionTitle>
+              <SectionTitle level={2} hasExternalIcon={isBreakdownExpanded}>
+                Forecast - Breakdown
+              </SectionTitle>
             </TitleSpacer>
 
             <Tabs
@@ -151,7 +155,7 @@ const BudgetReport: React.FC<BudgetReportProps> = ({ currentMonth, budgetStateme
               <BudgetSection level={2}>
                 {forecastData.breakdownTabs.map((header, index) => (
                   <BudgetSubsectionContainer isFirst={index === 0} key={header}>
-                    <SectionTitle level={2} hasIcon={true}>
+                    <SectionTitle level={2} hasIcon={true} hasExternalIcon={true} idPrefix={'forecast'}>
                       {header}
                     </SectionTitle>
                     <AdvancedInnerTable

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/components/BudgetSection/BudgetSection.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/components/BudgetSection/BudgetSection.tsx
@@ -18,7 +18,7 @@ const BudgetSection: React.FC<BudgetSectionProps> = ({ children, level = 1, titl
   return (
     <Wrapper isLight={isLight}>
       <LevelContainer>
-        {title && <SectionTitle>{title}</SectionTitle>}
+        {title && <SectionTitle hasExternalIcon={true}>{title}</SectionTitle>}
 
         <ChildrenContainer hasMargin={!!title}>{children}</ChildrenContainer>
       </LevelContainer>

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/components/SectionTitle/SectionTitle.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/components/SectionTitle/SectionTitle.stories.tsx
@@ -7,7 +7,6 @@ export default {
   title: 'Components/CUTransparencyReport/Section Title',
   component: SectionTitle,
   argTypes: {
-    // level
     hasIcon: {
       defaultValue: true,
       control: { type: 'boolean' },

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/components/SectionTitle/SectionTitle.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/components/SectionTitle/SectionTitle.stories.tsx
@@ -1,0 +1,66 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import SectionTitle from './SectionTitle';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/CUTransparencyReport/Section Title',
+  component: SectionTitle,
+  argTypes: {
+    // level
+    hasIcon: {
+      defaultValue: true,
+      control: { type: 'boolean' },
+    },
+    hasExternalIcon: {
+      defaultValue: undefined,
+      control: { type: 'text' },
+    },
+  },
+} as ComponentMeta<typeof SectionTitle>;
+
+const variantsArgs = [
+  {
+    level: 1,
+    hasIcon: false,
+    hasExternalIcon: true,
+    children: 'Actuals - Totals',
+  },
+  {
+    level: 2,
+    hasIcon: true,
+    hasExternalIcon: true,
+    children: 'Permanent Team',
+  },
+];
+
+export const [[L1WithoutIconLightMode, L1WithoutIconDarkMode], [L2FullLightMode, L2FullDarkMode]] =
+  createThemeModeVariants(SectionTitle, variantsArgs);
+
+L1WithoutIconLightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=16948%3A288375&t=GWd1sRImP81dQTUt-4',
+      },
+    },
+  } as FigmaParams,
+};
+
+L2FullLightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=16948%3A288420&t=GWd1sRImP81dQTUt-4',
+      },
+    },
+    options: {
+      style: {
+        top: -5,
+        left: -5,
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/components/SectionTitle/SectionTitle.tsx
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/components/SectionTitle/SectionTitle.tsx
@@ -1,25 +1,49 @@
 import styled from '@emotion/styled';
+import ArrowLink from '@ses/components/svg/ArrowLink';
 import Wallet from '@ses/components/svg/wallet';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { toKebabCase } from '@ses/core/utils/string';
 import React from 'react';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface SectionTitleProps extends React.PropsWithChildren {
   level?: 1 | 2;
   hasIcon?: boolean;
+  hasExternalIcon?: boolean;
+  idPrefix?: string;
 }
 
-const SectionTitle: React.FC<SectionTitleProps> = ({ children, level = 1, hasIcon = false }) => {
+const SectionTitle: React.FC<SectionTitleProps> = ({
+  children,
+  level = 1,
+  hasIcon = false,
+  hasExternalIcon = false,
+  idPrefix = '',
+}) => {
   const { isLight } = useThemeContext();
 
   return (
-    <Title isLight={isLight} level={level} as={level === 1 ? 'h2' : 'h3'}>
+    <Title
+      isLight={isLight}
+      level={level}
+      as={level === 1 ? 'h2' : 'h3'}
+      id={`#${idPrefix}-${toKebabCase(children as string)}`}
+    >
       {hasIcon && (
         <IconContainer>
           <Wallet fill={isLight ? '#231536' : '#F00'} />
         </IconContainer>
       )}
       {children}
+      {hasExternalIcon && (
+        <StyledArrowLink
+          href={`#${idPrefix}-${toKebabCase(children as string)}`}
+          target="_blank"
+          fill={isLight ? '#447AFB' : 'red'}
+          width={20}
+          height={20}
+        />
+      )}
     </Title>
   );
 };
@@ -39,4 +63,10 @@ const Title = styled.h2<{ level: number } & WithIsLight>(({ isLight, level }) =>
 const IconContainer = styled.div({
   display: 'inline-flex',
   marginRight: 14,
+});
+
+const StyledArrowLink = styled(ArrowLink)({
+  marginLeft: 10,
+  display: 'flex',
+  alignItems: 'center',
 });

--- a/src/stories/containers/TransparencyReport/components/BudgetReport/useBudgetReport.ts
+++ b/src/stories/containers/TransparencyReport/components/BudgetReport/useBudgetReport.ts
@@ -1,4 +1,7 @@
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { useHashFragment } from '@ses/core/hooks/useHashFragment';
+import lightTheme from '@ses/styles/theme/light';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { BREAKDOWN_VIEW_QUERY_KEY } from '../../utils/constants';
@@ -12,6 +15,14 @@ import type { DateTime } from 'luxon';
 const useBudgetReport = (currentMonth: DateTime, budgetStatements?: BudgetStatementDto[]) => {
   const { isLight } = useThemeContext();
   const query = useRouter().query;
+
+  // move to the hash id when the page loads
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+  useHashFragment({
+    offset: isMobile ? 180 : 270,
+    addListeners: false,
+    delayOnLoad: 300,
+  });
 
   const actualsData = useTransparencyActuals(currentMonth, budgetStatements);
   const forecastData = useTransparencyForecast(currentMonth, budgetStatements);


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
Allow opening the Budget sections in a new tab and move the scroll to the section

# What solved
- Should allow to update the active section through the hash and move the scroll to that section with the link is shared, the page is refreshed or opened in a new tab
-  Should allow opening in a new tab the "Actuals - Totals" when the page is in Auditor View
- Should allow opening in a new tab the "Actuals - Breakdown" when the page is in Auditor View
- Should allow opening in a new tab the "Forecasts - Totals" when the page is in Auditor View
- Should allow opening in a new tab the "Forecasts - Breakdown" when the page is in Auditor View 
- Should allow opening in a new tab the "MKR Vesting Overview" when the page is in Auditor View
- Should allow opening in a new tab the "Transfer Requests" when the page is in Auditor View