### PR TITLE
[SES-257] Save the auditor view status

### DIFF
--- a/src/core/models/dto/userActivityDto.ts
+++ b/src/core/models/dto/userActivityDto.ts
@@ -1,0 +1,32 @@
+export interface UserActivityDto {
+  id: string;
+  userId: string;
+  collection: string;
+  data: object | null;
+  lastVisit: string;
+}
+
+export interface DataAndStamp {
+  data: object | null;
+  timestamp: string;
+}
+
+export interface UserActivityUpdatePayload {
+  id: string;
+  userId: string;
+  collection: string;
+  current: DataAndStamp;
+  previous: DataAndStamp;
+}
+
+export interface UserActivityUpdateInput {
+  collection: string;
+  userId: string;
+  data?: object;
+  timestamp?: string;
+}
+
+export interface LocalStoredUserActivity {
+  data: object | null;
+  timestamp: string;
+}

--- a/src/core/utils/userActivity.ts
+++ b/src/core/utils/userActivity.ts
@@ -1,0 +1,142 @@
+import { GRAPHQL_ENDPOINT } from '@ses/config/endpoints';
+import request, { gql } from 'graphql-request';
+import { SafeLocalStorage } from './localStorage';
+import type PermissionManager from '../auth/permissionManager';
+import type {
+  LocalStoredUserActivity,
+  UserActivityDto,
+  UserActivityUpdateInput,
+  UserActivityUpdatePayload,
+} from '../models/dto/userActivityDto';
+
+export const USER_ACTIVITY_UPDATE_MUTATION = (input: UserActivityUpdateInput) => ({
+  query: gql`
+    mutation UserActivityUpdate($input: UserActivityUpdateInput) {
+      userActivityUpdate(input: $input) {
+        id
+        collection
+        userId
+        current {
+          data
+          timestamp
+        }
+        previous {
+          data
+          timestamp
+        }
+      }
+    }
+  `,
+  input: {
+    input,
+  },
+});
+
+export const USER_ACTIVITY_QUERY = (collection: string, userId: string) => ({
+  query: gql`
+    query ($filter: UserActivityFilter) {
+      userActivity(filter: $filter) {
+        id
+        collection
+        data
+        lastVisit
+        userId
+      }
+    }
+  `,
+  filter: {
+    filter: {
+      collection,
+      userId,
+    },
+  },
+});
+
+class UserActivityManager {
+  private readonly _permissionManager: PermissionManager;
+  private _storage: Storage;
+
+  constructor(permissionManager: PermissionManager) {
+    this._permissionManager = permissionManager;
+    this._storage = new SafeLocalStorage();
+  }
+
+  public async create(input: UserActivityUpdateInput): Promise<UserActivityUpdatePayload> {
+    if (this._permissionManager.isAuthenticated()) {
+      // create using API mutation
+      const { query, input: params } = USER_ACTIVITY_UPDATE_MUTATION(input);
+      const result = await request<{ userActivityUpdate: UserActivityUpdatePayload[] }>(
+        GRAPHQL_ENDPOINT,
+        query,
+        params,
+        {
+          Authorization: `Bearer ${this._permissionManager.token}`,
+        }
+      );
+
+      return result.userActivityUpdate[0];
+    } else {
+      // create using local storage
+      const key = input.collection;
+      const value = input.data
+        ? JSON.stringify({
+            data: input.data,
+            timestamp: input.timestamp,
+          })
+        : input.timestamp;
+
+      let previousValue;
+      try {
+        previousValue = JSON.parse(this._storage.getItem(key) ?? '{}');
+      } catch {}
+
+      this._storage.setItem(key, value?.toString() ?? '');
+      return {
+        id: input.collection,
+        userId: '',
+        collection: input.collection,
+        current: {
+          data: typeof input.data === 'string' ? JSON.parse(input.data) : input.data ?? null,
+          timestamp: input.timestamp?.toString() ?? '',
+        },
+        previous: {
+          data: typeof previousValue === 'object' ? previousValue.data : null,
+          timestamp: typeof previousValue === 'object' ? previousValue.timestamp : previousValue,
+        },
+      };
+    }
+  }
+
+  public async getLastActivity(collection: string): Promise<UserActivityDto | undefined> {
+    if (this._permissionManager.isAuthenticated()) {
+      // get activity from the API
+      const { query, filter } = USER_ACTIVITY_QUERY(collection, this._permissionManager.loggedUser?.id || '');
+      const result = await request<{ userActivity: UserActivityDto[] }>(GRAPHQL_ENDPOINT, query, filter, {
+        Authorization: `Bearer ${this._permissionManager.token}`,
+      });
+
+      return result.userActivity[0];
+    } else {
+      // get activity from the local storage
+      const storedValue = this._storage.getItem(collection);
+      const activity = {
+        id: collection,
+        userId: '',
+        collection,
+        data: null,
+        lastVisit: '',
+      };
+      try {
+        const parsedValue = JSON.parse(storedValue ?? '{}') as LocalStoredUserActivity;
+        activity.data =
+          typeof parsedValue?.data === 'string' ? JSON.parse(parsedValue?.data) : parsedValue?.data ?? null;
+        activity.lastVisit = parsedValue?.timestamp ?? '';
+      } catch {
+        activity.lastVisit = storedValue ?? '';
+      }
+      return activity;
+    }
+  }
+}
+
+export default UserActivityManager;

--- a/src/stories/components/Tabs/Tabs.tsx
+++ b/src/stories/components/Tabs/Tabs.tsx
@@ -30,7 +30,7 @@ export interface TabsProps {
   // tabs to be shown in compressed view
   compressedTabs?: TabItem[];
   // callback when the `Tabs` is expanded/compressed
-  onExpand?: () => void;
+  onExpand?: (isExpanded: boolean) => void;
   // callback when the active tab is changed
   onChange?: ((currentId?: string, previousId?: string) => void) | ((currentId?: string) => void);
   // tooltip for the expand button
@@ -189,8 +189,8 @@ const Tabs: React.FC<TabsProps> = ({
       undefined,
       { shallow: true }
     );
+    onExpand?.(!expanded);
     setExpanded(!expanded);
-    onExpand?.();
   };
 
   useEffect(() => {

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -53,6 +53,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit }: TransparencyReportPr
     showExpenseReportStatusCTA,
     lastVisitHandler,
     onTabChange,
+    onTabsExpand,
     compressedTabItems,
   } = useTransparencyReport(coreUnit);
   const [isEnabled] = useFlagsActive();
@@ -99,6 +100,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit }: TransparencyReportPr
                 expandable
                 compressedTabs={compressedTabItems}
                 onChange={onTabChange}
+                onExpand={onTabsExpand}
                 expandToolTip={{
                   default: 'Default View',
                   compressed: 'Auditor View',

--- a/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
@@ -8,9 +8,12 @@ import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
 import { BudgetStatus } from '@ses/core/models/dto/coreUnitDTO';
 import { budgetStatementCommentsCollectionId } from '@ses/core/utils/collectionsIds';
 import { LastVisitHandler } from '@ses/core/utils/lastVisitHandler';
+import { removeEmptyProperties } from '@ses/core/utils/urls';
+import UserActivityManager from '@ses/core/utils/userActivity';
 import { DateTime } from 'luxon';
 import { useRouter } from 'next/router';
 import { useRef, useState, useEffect, useCallback, useMemo } from 'react';
+import { AUDITOR_VIEW_STORAGE_COLLECTION_KEY } from './utils/constants';
 import type { TableItems } from './TransparencyReport';
 import type { CoreUnitDto } from '@ses/core/models/dto/coreUnitDTO';
 
@@ -160,6 +163,50 @@ export const useTransparencyReport = (coreUnit: CoreUnitDto) => {
     [isTimestampTrackingAccepted, lastVisitHandler, updateHasNewComments]
   );
 
+  interface AuditorViewStoragePayload {
+    isAuditorViewEnabled: boolean;
+  }
+  const onTabsExpand = useCallback(
+    // save the auditor view status on the storage/server
+    async (isExpanded: boolean) => {
+      const manager = new UserActivityManager(permissionManager);
+      await manager.create({
+        userId: permissionManager.loggedUser?.id || '',
+        collection: AUDITOR_VIEW_STORAGE_COLLECTION_KEY,
+        data: {
+          isAuditorViewEnabled: !isExpanded,
+        },
+      });
+    },
+    [permissionManager]
+  );
+
+  useEffect(() => {
+    const restoreAuditorViewFunction = async () => {
+      // restore the auditor view status form the storage/server if needed
+      // the auditor view status in the query param has priority over the stored value
+      if (!query.view && isTimestampTrackingAccepted) {
+        const manager = new UserActivityManager(permissionManager);
+        const result = await manager.getLastActivity(AUDITOR_VIEW_STORAGE_COLLECTION_KEY);
+        if ((result?.data as AuditorViewStoragePayload)?.isAuditorViewEnabled) {
+          // activate the auditor view
+          router.replace(
+            {
+              pathname: router.pathname,
+              query: {
+                ...removeEmptyProperties(router.query),
+                view: 'auditor',
+              },
+            },
+            undefined,
+            { shallow: true }
+          );
+        }
+      }
+    };
+    restoreAuditorViewFunction();
+  }, [isTimestampTrackingAccepted, permissionManager, query.view, router]);
+
   return {
     tabItems,
     code,
@@ -177,6 +224,7 @@ export const useTransparencyReport = (coreUnit: CoreUnitDto) => {
     comments,
     lastVisitHandler,
     onTabChange,
+    onTabsExpand,
     compressedTabItems,
   };
 };

--- a/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
@@ -169,23 +169,25 @@ export const useTransparencyReport = (coreUnit: CoreUnitDto) => {
   const onTabsExpand = useCallback(
     // save the auditor view status on the storage/server
     async (isExpanded: boolean) => {
-      const manager = new UserActivityManager(permissionManager);
-      await manager.create({
-        userId: permissionManager.loggedUser?.id || '',
-        collection: AUDITOR_VIEW_STORAGE_COLLECTION_KEY,
-        data: {
-          isAuditorViewEnabled: !isExpanded,
-        },
-      });
+      if (isTimestampTrackingAccepted) {
+        const manager = new UserActivityManager(permissionManager);
+        await manager.create({
+          userId: permissionManager.loggedUser?.id || '',
+          collection: AUDITOR_VIEW_STORAGE_COLLECTION_KEY,
+          data: {
+            isAuditorViewEnabled: !isExpanded,
+          },
+        });
+      }
     },
-    [permissionManager]
+    [isTimestampTrackingAccepted, permissionManager]
   );
 
   useEffect(() => {
     const restoreAuditorViewFunction = async () => {
       // restore the auditor view status form the storage/server if needed
       // the auditor view status in the query param has priority over the stored value
-      if (!query.view && isTimestampTrackingAccepted) {
+      if (!query.view) {
         const manager = new UserActivityManager(permissionManager);
         const result = await manager.getLastActivity(AUDITOR_VIEW_STORAGE_COLLECTION_KEY);
         if ((result?.data as AuditorViewStoragePayload)?.isAuditorViewEnabled) {
@@ -205,7 +207,7 @@ export const useTransparencyReport = (coreUnit: CoreUnitDto) => {
       }
     };
     restoreAuditorViewFunction();
-  }, [isTimestampTrackingAccepted, permissionManager, query.view, router]);
+  }, [permissionManager, query.view, router]);
 
   return {
     tabItems,

--- a/src/stories/containers/TransparencyReport/utils/constants.ts
+++ b/src/stories/containers/TransparencyReport/utils/constants.ts
@@ -3,3 +3,5 @@ export const ACTUALS_BREAKDOWN_QUERY_PARAM = 'actual-account';
 export const FORECAST_BREAKDOWN_QUERY_PARAM = 'forecast-account';
 
 export const BREAKDOWN_VIEW_QUERY_KEY = 'breakdownView';
+
+export const AUDITOR_VIEW_STORAGE_COLLECTION_KEY = 'auditorView';


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
The status of the auditor's view is now saved to local storage if the user is not logged in or in the server if the user is logged in and it is restored when the transparency page is opened

# What solved
- Should utilize browser cookies (or equivalent user preference storage) to store the auditor view preference, allowing the application to remember the user's selected view and maintain it across sessions, thus offering a personalized and consistent user experience.