### PR TITLE
Add color gray and give hight when the value is cero

### DIFF
--- a/src/core/businessLogic/reconizedDelegate.ts
+++ b/src/core/businessLogic/reconizedDelegate.ts
@@ -19,7 +19,7 @@ export const getLinksFromRecognizedDelegates = (del: RecognizedDelegatesDto): Li
   };
   const descriptionOfTooltip: Record<string, string> = {
     twitter: 'Twitter',
-    youtube: 'youtube',
+    youtube: 'Youtube',
     forumPlatform: 'Forum',
     forumProfile: 'Profile',
     votingPortal: 'Voting Portal',

--- a/src/stories/components/CustomBarChart/CustomBarChart.tsx
+++ b/src/stories/components/CustomBarChart/CustomBarChart.tsx
@@ -62,9 +62,8 @@ export const CustomBarChart = (props: CustomBarChartProps) => {
 
   const padding = 8;
   const maxBarHeight = 50;
-
   const calculateHeight = (value: number): number => {
-    if (!value) return 0;
+    if (!value) return 16;
 
     const allItems = [...(props?.items?.map((item) => item?.value || 0) || []), ...(props?.maxValues || [])];
     const max = Math.max(...allItems);
@@ -78,6 +77,7 @@ export const CustomBarChart = (props: CustomBarChartProps) => {
 
   const getColor = (value: number, pos: number): string => {
     if (!props.maxValues || props.maxValues.length === 0) return COLOR_RED;
+    if (!value) return COLOR_GRAY;
     if (props.maxValues[pos] === 0) return COLOR_RED;
     const percent = (value * 100) / props.maxValues[pos];
     let color = COLOR_RED;


### PR DESCRIPTION
# Ticket

https://trello.com/c/6zp6dgWU/258-feature-delegatestransparencyreporting-v2

# What solved
✅Should The bars should display gray color when there is no value in the month

# Actions
Add the color gray and give height when the value is cero
