### PR TITLE
[SES-265] Fix the delegates transparency reports page

### DIFF
--- a/pages/recognized-delegates/finances/reports/index.tsx
+++ b/pages/recognized-delegates/finances/reports/index.tsx
@@ -1,6 +1,6 @@
 import { CURRENT_ENVIRONMENT } from '@ses/config/endpoints';
 
-import { fetchRecognizedDelegatesReport } from '@ses/containers/RecognizedDelegatesReports/RecognizedDelegatesReportAPI';
+import { fetchRecognizedDelegatesBudgetStatements } from '@ses/containers/RecognizedDelegatesReports/RecognizedDelegatesReportAPI';
 import RecognizedDelegatesReportContainer from '@ses/containers/RecognizedDelegatesReports/RecognizedDelegatesReportContainer';
 import { CoreUnitContext } from '@ses/core/context/CoreUnitContext';
 import { featureFlags } from 'feature-flags/feature-flags';
@@ -42,7 +42,7 @@ export async function getServerSideProps() {
     };
   }
 
-  const delegates = await fetchRecognizedDelegatesReport();
+  const delegates = await fetchRecognizedDelegatesBudgetStatements();
 
   return {
     props: {

--- a/src/core/auth/delegatesExtension.ts
+++ b/src/core/auth/delegatesExtension.ts
@@ -1,25 +1,17 @@
 import { RoleEnum } from '../enums/roleEnum';
 import type { UserDTO } from '../models/dto/authDTO';
-import type { DelegatesDto } from '../models/dto/delegatesDTO';
 import type PermissionManager from './permissionManager';
 
 class DelegatesExtension {
   static UPDATE_PERMISSION = 'Delegates/Update';
+  static AUDIT_PERMISSION = 'Delegates/Audit';
   permissionManager;
 
   constructor(permissionManager: PermissionManager) {
     this.permissionManager = permissionManager;
   }
 
-  private getDelegatesId(delegates: DelegatesDto | string): string {
-    if (typeof delegates === 'string') {
-      return delegates;
-    }
-
-    return delegates.id;
-  }
-
-  canComment(delegates: DelegatesDto | string, user?: UserDTO): boolean {
+  canComment(user?: UserDTO): boolean {
     if (!user) {
       user = this.permissionManager.loggedUser;
     }
@@ -29,10 +21,9 @@ class DelegatesExtension {
       return false;
     }
 
-    const id = this.getDelegatesId(delegates);
     return this.permissionManager.hasAnyPermission([
       DelegatesExtension.UPDATE_PERMISSION,
-      `${DelegatesExtension.UPDATE_PERMISSION}/${id}`,
+      DelegatesExtension.AUDIT_PERMISSION,
     ]);
   }
 
@@ -46,6 +37,19 @@ class DelegatesExtension {
     }
 
     return this.permissionManager.hasRole(RoleEnum.DelegatesAdmin);
+  }
+
+  isDelegatesAuditor(user?: UserDTO): boolean {
+    if (!user) {
+      user = this.permissionManager.loggedUser;
+    }
+
+    if (!user) {
+      // there is not authenticated user
+      return false;
+    }
+
+    return this.permissionManager.hasPermission(DelegatesExtension.AUDIT_PERMISSION);
   }
 }
 

--- a/src/stories/containers/RecognizedDelegatesReports/DelegatesActuals/DelegatesActuals.tsx
+++ b/src/stories/containers/RecognizedDelegatesReports/DelegatesActuals/DelegatesActuals.tsx
@@ -119,9 +119,9 @@ const TitleBreakdown = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   marginTop: 40,
   marginBottom: 32,
   color: isLight ? '#231536' : '#9FAFB9',
+
   [lightTheme.breakpoints.up('table_834')]: {
     marginTop: 0,
-    marginBottom: 24,
     fontSize: '20px',
     lineHeight: '24px',
   },

--- a/src/stories/containers/RecognizedDelegatesReports/DelegatesForecast/DelegatesForecast.tsx
+++ b/src/stories/containers/RecognizedDelegatesReports/DelegatesForecast/DelegatesForecast.tsx
@@ -74,10 +74,11 @@ const TitleBreakdown = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   lineHeight: '19px',
   letterSpacing: '0.4px',
   marginTop: 40,
+  marginBottom: 32,
   color: isLight ? '#231536' : '#9FAFB9',
+
   [lightTheme.breakpoints.up('table_834')]: {
     marginTop: 0,
-    marginBottom: 24,
     fontSize: '20px',
     lineHeight: '24px',
   },

--- a/src/stories/containers/RecognizedDelegatesReports/RecognizedDelegatesReportAPI.ts
+++ b/src/stories/containers/RecognizedDelegatesReports/RecognizedDelegatesReportAPI.ts
@@ -1,68 +1,16 @@
 import { GRAPHQL_ENDPOINT } from '@ses/config/endpoints';
 import request, { gql } from 'graphql-request';
+import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
 import type { DelegatesDto } from '@ses/core/models/dto/delegatesDTO';
 
-export const RECOGNIED_DELEGATES_REPORT_REQUEST = () => ({
+const RECOGNIZED_DELEGATES_BUDGET_STATEMENTS_QUERY = () => ({
   query: gql`
-    query CoreUnits($filter: CoreUnitFilter) {
-      coreUnits(filter: $filter) {
+    query ($filter: BudgetStatementFilter) {
+      budgetStatements(filter: $filter) {
         id
-        code
-        shortCode
-        budgetStatements {
-          id
-          month
-          status
-          publicationUrl
-          activityFeed {
-            id
-            created_at
-            event
-            params
-            description
-          }
-          comments {
-            id
-            budgetStatementId
-            timestamp
-            comment
-            status
-            author {
-              id
-              username
-            }
-          }
-          budgetStatementFTEs {
-            month
-            ftes
-          }
-          auditReport {
-            reportUrl
-            timestamp
-            auditStatus
-          }
-          budgetStatementWallet {
-            name
-            address
-            currentBalance
-            id
-            budgetStatementLineItem {
-              group
-              actual
-              forecast
-              budgetCategory
-              headcountExpense
-              comments
-              month
-              budgetCap
-              payment
-            }
-            budgetStatementTransferRequest {
-              requestAmount
-              walletBalance
-            }
-          }
-        }
+        month
+        status
+        publicationUrl
         activityFeed {
           id
           created_at
@@ -70,19 +18,70 @@ export const RECOGNIED_DELEGATES_REPORT_REQUEST = () => ({
           params
           description
         }
+        comments {
+          id
+          budgetStatementId
+          timestamp
+          comment
+          status
+          author {
+            id
+            username
+          }
+        }
+        budgetStatementFTEs {
+          month
+          ftes
+        }
+        auditReport {
+          reportUrl
+          timestamp
+          auditStatus
+        }
+        budgetStatementWallet {
+          name
+          address
+          currentBalance
+          id
+          budgetStatementLineItem {
+            group
+            actual
+            forecast
+            budgetCategory
+            headcountExpense
+            comments
+            month
+            budgetCap
+            payment
+          }
+          budgetStatementTransferRequest {
+            requestAmount
+            walletBalance
+          }
+        }
       }
     }
   `,
   filter: {
     filter: {
-      shortCode: 'DEL',
+      ownerType: 'Delegates',
     },
   },
 });
 
-export const fetchRecognizedDelegatesReport = async (): Promise<DelegatesDto> => {
-  const { query: gqlQuery, filter } = RECOGNIED_DELEGATES_REPORT_REQUEST();
+export const fetchRecognizedDelegatesBudgetStatements = async (): Promise<DelegatesDto> => {
+  const { query, filter } = RECOGNIZED_DELEGATES_BUDGET_STATEMENTS_QUERY();
 
-  const response = await request<{ coreUnits: [DelegatesDto] }>(GRAPHQL_ENDPOINT, gqlQuery, filter);
-  return response.coreUnits[0];
+  const response = await request<{ budgetStatements: BudgetStatementDto[] }>(GRAPHQL_ENDPOINT, query, filter);
+  const delegates = {
+    shortCode: 'DEL',
+    code: 'Delegates',
+    budgetStatements: response.budgetStatements,
+    activityFeed: response.budgetStatements.reduce((acc, budgetStatement) => ({
+      ...acc,
+      activityFeed: [...acc.activityFeed, ...budgetStatement.activityFeed],
+    })).activityFeed,
+  } as DelegatesDto;
+
+  return delegates;
 };

--- a/src/stories/containers/RecognizedDelegatesReports/useRecognizedDelegatesReport.tsx
+++ b/src/stories/containers/RecognizedDelegatesReports/useRecognizedDelegatesReport.tsx
@@ -98,12 +98,12 @@ const useRecognizedDelegatesReport = (delegates: DelegatesDto) => {
   useEffect(() => {
     switch (currentBudgetStatement?.status) {
       case BudgetStatus.Draft:
-        setShowExpenseReportStatusCTA(permissionManager.coreUnit.isCoreUnitAdmin(delegates.id));
+        setShowExpenseReportStatusCTA(permissionManager.delegates.canComment());
         break;
       default:
         setShowExpenseReportStatusCTA(false);
     }
-  }, [currentBudgetStatement, delegates.id, permissionManager]);
+  }, [currentBudgetStatement, permissionManager]);
 
   const { comments, numbersComments, commentsLastVisitState, updateHasNewComments } = useBudgetStatementComments(
     currentBudgetStatement,

--- a/src/stories/containers/TransparencyReport/components/ExpenseReport/components/ExpenseSection/ExpenseSection.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReport/components/ExpenseSection/ExpenseSection.tsx
@@ -101,11 +101,6 @@ const WrapperL2 = styled.div<WithIsLight>(({ isLight }) => ({
     marginTop: 24,
     marginBottom: 8,
   },
-
-  // custom style for the table transparency card on mobile view
-  // '.advance-table--transparency-card': {
-  //   padding: '16px 16px 6px',
-  // },
 }));
 
 const ChildrenContainer = styled.div<{ hasMargin: boolean }>(({ hasMargin }) => ({

--- a/src/stories/containers/TransparencyReport/components/TransparencyAuditorComments/AuditorCommentsContainer/useCommentsContainer.ts
+++ b/src/stories/containers/TransparencyReport/components/TransparencyAuditorComments/AuditorCommentsContainer/useCommentsContainer.ts
@@ -42,7 +42,7 @@ const useCommentsContainer = (
     if (mode === 'CoreUnits') {
       return permissionManager.coreUnit.canComment(currentCoreUnit || '-1');
     } else {
-      return permissionManager.delegates.canComment(currentCoreUnit?.id || '-1');
+      return permissionManager.delegates.canComment();
     }
   }, [permissionManager, currentCoreUnit, mode]);
 


### PR DESCRIPTION
# Ticket
https://trello.com/c/Z1EJXde6/265-qc-round-v-90-r

# Description
The delegates transparency page got broken after the Delegates was removed from the CU endpoint as it is not a CU, the page was fixed using the new way: fetching directly the budget statements owned by the delegates

# What solved
-  Should fix the Recognize delegates report page after the API breaking change.
- Should update the spacing of the section: Actuals and Forecast of the Delegates repots reports page