### PR TITLE
[SES-265] Fix Auditor view breaks on refresh

### DIFF
--- a/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
@@ -70,7 +70,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
           longCode={longCode}
         />
 
-        {actualsData.mainTableItems.length > 0 && (
+        {actualsData.mainTableItems?.length > 0 && (
           <>
             <TitleSpacer>
               <SectionTitle level={2} hasExternalIcon={isBreakdownExpanded}>
@@ -141,7 +141,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
           cardsTotalPosition={'top'}
         />
 
-        {forecastData.breakdownItems.length > 0 && (
+        {forecastData.breakdownItems?.length > 0 && (
           <>
             <TitleSpacer>
               <SectionTitle level={2} hasExternalIcon={isBreakdownExpanded}>
@@ -210,7 +210,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
           longCode={longCode}
         />
 
-        {mkrVestingData.mainTableItems.length > 0 && (
+        {mkrVestingData.mainTableItems?.length > 0 && (
           <MkrVestingInfoContainer>
             <MkrVestingInfo />
           </MkrVestingInfoContainer>


### PR DESCRIPTION
# Ticket
https://trello.com/c/Z1EJXde6/265-qc-round-v-90-r

# Description
When the user navigates between the core units with the Auditor view activated and then refresh the page it breaks

# What solved
- When accessing the SH, COM, GROW, KING core units, an error is displayed (the access can be through the url or core unit navigators).