### PR TITLE
[SES-] Fix mobile spacing

### DIFF
--- a/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
@@ -90,15 +90,16 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
             />
 
             {isBreakdownExpanded ? (
-              <BudgetTable
-                isLight={isLight}
-                columns={actualsData.breakdownColumnsForActiveTab}
-                items={actualsData.breakdownItemsForActiveTab}
-                longCode={longCode}
-                style={{ marginTop: 16 }}
-                cardSpacingSize="small"
-                tablePlaceholder={<TransparencyEmptyTable breakdown longCode={longCode} />}
-              />
+              <BreakdownTableWrapper>
+                <BudgetTable
+                  isLight={isLight}
+                  columns={actualsData.breakdownColumnsForActiveTab}
+                  items={actualsData.breakdownItemsForActiveTab}
+                  longCode={longCode}
+                  cardSpacingSize="small"
+                  tablePlaceholder={<TransparencyEmptyTable breakdown longCode={longCode} />}
+                />
+              </BreakdownTableWrapper>
             ) : (
               <L2SectionOuter>
                 {actualsData.breakdownTabs.map((header, index) => (
@@ -107,21 +108,19 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                       <SectionTitle level={2} hasIcon={true} hasExternalIcon={true} idPrefix={'actuals'}>
                         {header}
                       </SectionTitle>
-                      <div>
-                        <BudgetTable
-                          isLight={isLight}
-                          columns={actualsData.allBreakdownColumns[header]}
-                          items={actualsData.allBreakdownItems[header]}
-                          longCode={longCode}
-                          style={{ marginTop: 16 }}
-                          cardSpacingSize="small"
-                          tablePlaceholder={
-                            <div style={{ marginTop: 16 }}>
-                              <TransparencyEmptyTable breakdown longCode={longCode} />
-                            </div>
-                          }
-                        />
-                      </div>
+                      <BudgetTable
+                        isLight={isLight}
+                        columns={actualsData.allBreakdownColumns[header]}
+                        items={actualsData.allBreakdownItems[header]}
+                        longCode={longCode}
+                        style={{ marginTop: 16 }}
+                        cardSpacingSize="small"
+                        tablePlaceholder={
+                          <div style={{ marginTop: 16 }}>
+                            <TransparencyEmptyTable breakdown longCode={longCode} />
+                          </div>
+                        }
+                      />
                     </BudgetSubsectionContainer>
                   </L2SectionInner>
                 ))}
@@ -161,15 +160,16 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
             />
 
             {isBreakdownExpanded ? (
-              <BudgetTable
-                isLight={isLight}
-                longCode={longCode}
-                columns={forecastData.breakdownColumnsForActiveTab}
-                items={forecastData.breakdownItems}
-                style={{ marginTop: 16 }}
-                cardSpacingSize="small"
-                tablePlaceholder={<TransparencyEmptyTable breakdown longCode={longCode} />}
-              />
+              <BreakdownTableWrapper>
+                <BudgetTable
+                  isLight={isLight}
+                  longCode={longCode}
+                  columns={forecastData.breakdownColumnsForActiveTab}
+                  items={forecastData.breakdownItems}
+                  cardSpacingSize="small"
+                  tablePlaceholder={<TransparencyEmptyTable breakdown longCode={longCode} />}
+                />
+              </BreakdownTableWrapper>
             ) : (
               <L2SectionOuter>
                 {forecastData.breakdownTabs.map((header, index) => (
@@ -287,11 +287,14 @@ const BudgetSubsectionContainer = styled.div<{ isFirst: boolean }>(({ isFirst })
   marginTop: 0,
 
   [lightTheme.breakpoints.up('table_834')]: {
-    // TODO: is this necessary?
     ...(isFirst ? {} : { marginTop: 24 }),
   },
 }));
 
 const MkrVestingInfoContainer = styled.div({
   marginTop: 32,
+});
+
+const BreakdownTableWrapper = styled.div({
+  marginTop: 16,
 });


### PR DESCRIPTION
# Ticket
https://trello.com/c/LwJSehNh/257-feature-auditorimprovements-v1

# Description
Fix spacing in the top of the breakdowns sections in auditor view

# What solved
-  Should display a space between the tab and the Headcount Expenses area.