### PR TITLE
[SES-QC-266] Fix Auditor view pending issues

### DIFF
--- a/src/stories/components/CoreUnitSummary/CoreUnitSummary.tsx
+++ b/src/stories/components/CoreUnitSummary/CoreUnitSummary.tsx
@@ -78,9 +78,11 @@ export const CoreUnitSummary: React.FC<CoreUnitSummaryProps> = ({
   const page = useMemo(() => filteredData?.findIndex((item) => item.shortCode === code) + 1, [code, filteredData]);
 
   const queryStrings = buildQueryString({
+    ...router.query,
     filteredStatuses,
     filteredCategories,
     searchText,
+    code: null, // override the Core Unit code to avoid add it to the query string
   });
 
   const changeCoreUnitCode = useCallback(

--- a/src/stories/components/Tabs/Tabs.tsx
+++ b/src/stories/components/Tabs/Tabs.tsx
@@ -16,6 +16,16 @@ export interface TabItem {
   href?: string;
 }
 
+export interface InternalTabsProps {
+  isExpanded: boolean;
+  setExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+  queryValue?: string;
+  expandedActiveId?: string;
+  setExpandedActiveId: React.Dispatch<React.SetStateAction<string | undefined>>;
+  compressedActiveId?: string;
+  setCompressedActiveId: React.Dispatch<React.SetStateAction<string | undefined>>;
+}
+
 export interface TabsProps {
   // tabs to be shown in default view
   tabs: TabItem[];
@@ -29,6 +39,8 @@ export interface TabsProps {
   expandedDefault?: boolean;
   // tabs to be shown in compressed view
   compressedTabs?: TabItem[];
+  // callback called after the `Tabs` is initialized
+  onInit?: (internalState: InternalTabsProps) => void;
   // callback when the `Tabs` is expanded/compressed
   onExpand?: (isExpanded: boolean) => void;
   // callback when the active tab is changed
@@ -61,6 +73,7 @@ const Tabs: React.FC<TabsProps> = ({
   activeIdDefault,
   expandedDefault = true,
   compressedTabs = [],
+  onInit,
   onExpand,
   onChange,
   expandToolTip,
@@ -123,6 +136,23 @@ const Tabs: React.FC<TabsProps> = ({
     return activeIdDefault ?? compressedTabs?.[0]?.id;
   });
   const activeId = expanded ? expandedActiveId : compressedActiveId;
+
+  useEffect(() => {
+    // called on init...
+    if (onInit) {
+      onInit({
+        isExpanded: expanded,
+        setExpanded,
+        queryValue,
+        expandedActiveId,
+        setExpandedActiveId,
+        compressedActiveId,
+        setCompressedActiveId,
+      });
+    }
+    // this hook should be called only once even if the dependencies changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (!controlled) {
@@ -192,17 +222,6 @@ const Tabs: React.FC<TabsProps> = ({
     onExpand?.(!expanded);
     setExpanded(!expanded);
   };
-
-  useEffect(() => {
-    // sync expanded status with the URL to keep the tabs synced with other tabs in the page
-    if (
-      [viewValues.default, viewValues.compressed].includes(router.query[viewKey] as string) &&
-      (router.query[viewKey] === viewValues.default) !== expanded
-    ) {
-      setExpanded(!expanded);
-      // onExpand callback should not be fired to avoid double calls when tabs are synced
-    }
-  }, [expanded, router.query, viewKey, viewValues]);
 
   const activeTabs = expanded ? tabs : compressedTabs;
 

--- a/src/stories/components/Tabs/Tabs.tsx
+++ b/src/stories/components/Tabs/Tabs.tsx
@@ -18,7 +18,7 @@ export interface TabItem {
 
 export interface InternalTabsProps {
   isExpanded: boolean;
-  setExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+  setExpanded: (isExpanded: boolean) => void;
   queryValue?: string;
   expandedActiveId?: string;
   setExpandedActiveId: React.Dispatch<React.SetStateAction<string | undefined>>;

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -52,6 +52,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit }: TransparencyReportPr
     comments,
     showExpenseReportStatusCTA,
     lastVisitHandler,
+    onTabsInit,
     onTabChange,
     onTabsExpand,
     compressedTabItems,
@@ -99,6 +100,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit }: TransparencyReportPr
                 tabs={tabItems}
                 expandable
                 compressedTabs={compressedTabItems}
+                onInit={onTabsInit}
                 onChange={onTabChange}
                 onExpand={onTabsExpand}
                 expandToolTip={{

--- a/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
@@ -39,6 +39,11 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
     mkrVestingData,
     transferRequestsData,
     isBreakdownExpanded,
+
+    onActualsBreakdownTabsInit,
+    onForecastBreakdownTabsInit,
+    onActualsBreakdownExpand,
+    onForecastBreakdownExpand,
   } = useExpenseReport(currentMonth, budgetStatements);
 
   return (
@@ -87,6 +92,8 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
               expandedDefault={false}
               tabQuery={ACTUALS_BREAKDOWN_QUERY_PARAM}
               viewKey={BREAKDOWN_VIEW_QUERY_KEY}
+              onInit={onActualsBreakdownTabsInit}
+              onExpand={onActualsBreakdownExpand}
             />
 
             {isBreakdownExpanded ? (
@@ -157,6 +164,8 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
               expandedDefault={false}
               tabQuery={FORECAST_BREAKDOWN_QUERY_PARAM}
               viewKey={BREAKDOWN_VIEW_QUERY_KEY}
+              onInit={onForecastBreakdownTabsInit}
+              onExpand={onForecastBreakdownExpand}
             />
 
             {isBreakdownExpanded ? (

--- a/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
@@ -78,9 +78,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
         {actualsData.mainTableItems?.length > 0 && (
           <>
             <TitleSpacer>
-              <SectionTitle level={2} hasExternalIcon={isBreakdownExpanded}>
-                Actuals - Breakdown
-              </SectionTitle>
+              <SectionTitle level={2}>Actuals - Breakdown</SectionTitle>
             </TitleSpacer>
 
             <Tabs
@@ -150,9 +148,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
         {forecastData.mainTableItems?.length > 0 && (
           <>
             <TitleSpacer>
-              <SectionTitle level={2} hasExternalIcon={isBreakdownExpanded}>
-                Forecast - Breakdown
-              </SectionTitle>
+              <SectionTitle level={2}>Forecast - Breakdown</SectionTitle>
             </TitleSpacer>
 
             <Tabs

--- a/src/stories/containers/TransparencyReport/components/ExpenseReport/useExpenseReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReport/useExpenseReport.tsx
@@ -3,13 +3,14 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { useHashFragment } from '@ses/core/hooks/useHashFragment';
 import lightTheme from '@ses/styles/theme/light';
 import { useRouter } from 'next/router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { BREAKDOWN_VIEW_QUERY_KEY } from '../../utils/constants';
 import { useTransparencyActuals } from '../TransparencyActuals/useTransparencyActuals';
 import { useTransparencyForecast } from '../TransparencyForecast/useTransparencyForecast';
 import { useTransparencyMkrVesting } from '../TransparencyMkrVesting/useTransparencyMkrVesting';
 import { useTransparencyTransferRequest } from '../TransparencyTransferRequest/useTransparencyTransferRequest';
 import ExpenseSection from './components/ExpenseSection/ExpenseSection';
+import type { InternalTabsProps } from '@ses/components/Tabs/Tabs';
 import type { BudgetStatementDto } from '@ses/core/models/dto/coreUnitDTO';
 import type { DateTime } from 'luxon';
 
@@ -49,6 +50,32 @@ const useExpenseReport = (currentMonth: DateTime, budgetStatements?: BudgetState
     [isMobile]
   );
 
+  // sync the actuals and the forecast breakdown tabs expanded state
+  const [handleActualsBreakdownExpand, setHandleActualsBreakdownExpand] = useState<(a: boolean) => void | undefined>();
+  const [handleForecastBreakdownExpand, setHandleForecastBreakdownExpand] =
+    useState<(a: boolean) => void | undefined>();
+
+  const onActualsBreakdownTabsInit = useCallback(({ setExpanded }: InternalTabsProps) => {
+    setHandleActualsBreakdownExpand(() => setExpanded);
+  }, []);
+  const onForecastBreakdownTabsInit = useCallback(({ setExpanded }: InternalTabsProps) => {
+    setHandleForecastBreakdownExpand(() => setExpanded);
+  }, []);
+
+  const onActualsBreakdownExpand = useCallback(
+    (isExpanded: boolean) => {
+      handleForecastBreakdownExpand?.(isExpanded);
+    },
+    [handleForecastBreakdownExpand]
+  );
+
+  const onForecastBreakdownExpand = useCallback(
+    (isExpanded: boolean) => {
+      handleActualsBreakdownExpand?.(isExpanded);
+    },
+    [handleActualsBreakdownExpand]
+  );
+
   return {
     isMobile,
     L2SectionInner,
@@ -59,6 +86,11 @@ const useExpenseReport = (currentMonth: DateTime, budgetStatements?: BudgetState
     mkrVestingData,
     transferRequestsData,
     isBreakdownExpanded,
+
+    onActualsBreakdownTabsInit,
+    onForecastBreakdownTabsInit,
+    onActualsBreakdownExpand,
+    onForecastBreakdownExpand,
   };
 };
 

--- a/src/stories/containers/TransparencyReport/components/ExpenseReport/useExpenseReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReport/useExpenseReport.tsx
@@ -51,9 +51,10 @@ const useExpenseReport = (currentMonth: DateTime, budgetStatements?: BudgetState
   );
 
   // sync the actuals and the forecast breakdown tabs expanded state
-  const [handleActualsBreakdownExpand, setHandleActualsBreakdownExpand] = useState<(a: boolean) => void | undefined>();
+  const [handleActualsBreakdownExpand, setHandleActualsBreakdownExpand] =
+    useState<(inExpanded: boolean) => void | undefined>();
   const [handleForecastBreakdownExpand, setHandleForecastBreakdownExpand] =
-    useState<(a: boolean) => void | undefined>();
+    useState<(inExpanded: boolean) => void | undefined>();
 
   const onActualsBreakdownTabsInit = useCallback(({ setExpanded }: InternalTabsProps) => {
     setHandleActualsBreakdownExpand(() => setExpanded);


### PR DESCRIPTION
# Ticket
https://trello.com/c/kUYUN01m/266-qc-round-v-100-r

# Description
Fixed issues on Auditor View related to the tabs

# What solved
- When accessing the SH, COM, GROW, KING core units, an error is displayed (the access can be through the url or core unit navigators). 
- Expense Reports view is displayed but with the Auditor view tabs. **Visual Proof:** [video](https://trello.com/1/cards/641b2be81cff6a200ce72382/attachments/644bac600e853a55f67f15ef/download/screencast-expenses-dev.makerdao.network-2023.04.28-14_21_08.webm)
- Clicking on the collapse/expand icons, a jump is displayed. **Visual Proof:** [wrong behavior.webm](https://trello.com/1/cards/641b2be81cff6a200ce72382/attachments/6453a880da92ae3149f4ecc1/download/cinnamon-2023-05-04T144311%2B0200.webm)
- Should hide the red dot icon to the right of the comment tab for viewed doings
- The open icon is displayed when the tabs are expanded. **Visual Proof:** [design.png](https://trello.com/1/cards/64268e577f090781257fdb8a/attachments/6458edd4b9d5fed2dc4a3238/download/image.png), [system.png](https://trello.com/1/cards/64268e577f090781257fdb8a/attachments/6458eda9efaf42aa4502165e/download/image.png)
- The Actuals tab is selected but the data displayed is still from MKR Vesting. **Visual Proof:**[mkr.webm](https://trello.com/1/cards/643fb08255b18a0d27d36be9/attachments/645b7e163582bd37f78caf6e/download/cinnamon-2023-05-10T130542%2B0200.webm)