### PR TITLE
[SES-268] Add Accounts Snapshot tab

### DIFF
--- a/feature-flags/feature-flags.development.ts
+++ b/feature-flags/feature-flags.development.ts
@@ -11,4 +11,5 @@ export const flagsDevelopment: FeatureFlagsInterface = {
   FEATURE_RECOGNIZED_DELEGATES_REPORT: true,
   FEATURE_TRANSPARENCY_COMMENTS: true,
   FEATURE_RECOGNIZED_DELEGATES: true,
+  FEATURE_ACCOUNTS_SNAPSHOT: true,
 };

--- a/feature-flags/feature-flags.interface.ts
+++ b/feature-flags/feature-flags.interface.ts
@@ -5,6 +5,7 @@ export interface FeatureFlagsInterface {
   FEATURE_AUTH: boolean;
   FEATURE_MKR_VESTING: boolean; // disable MKR Vesting tab in the expense reports tab
   FEATURE_AUDIT_REPORTS: boolean; // disable Audit Reports tab in the expense reports tab
+  FEATURE_ACCOUNTS_SNAPSHOT: boolean; // disable Accounts Snapshot tab in the expense reports tab
   FEATURE_FINANCES_OVERVIEW: boolean; // disable Finances Overview page
   FEATURE_RECOGNIZED_DELEGATES_REPORT: boolean; // disable Finances Delegates Report page
   FEATURE_TRANSPARENCY_COMMENTS: boolean; // disable Comments Tab

--- a/feature-flags/feature-flags.production.ts
+++ b/feature-flags/feature-flags.production.ts
@@ -11,4 +11,5 @@ export const flagsProduction: FeatureFlagsInterface = {
   FEATURE_RECOGNIZED_DELEGATES_REPORT: true,
   FEATURE_TRANSPARENCY_COMMENTS: true,
   FEATURE_RECOGNIZED_DELEGATES: true,
+  FEATURE_ACCOUNTS_SNAPSHOT: false,
 };

--- a/feature-flags/feature-flags.staging.ts
+++ b/feature-flags/feature-flags.staging.ts
@@ -11,4 +11,5 @@ export const flagsStaging: FeatureFlagsInterface = {
   FEATURE_RECOGNIZED_DELEGATES_REPORT: true,
   FEATURE_TRANSPARENCY_COMMENTS: true,
   FEATURE_RECOGNIZED_DELEGATES: true,
+  FEATURE_ACCOUNTS_SNAPSHOT: false,
 };

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -13,6 +13,7 @@ import { CoreUnitSummary } from '../../components/CoreUnitSummary/CoreUnitSummar
 import { CustomLink } from '../../components/CustomLink/CustomLink';
 import { CustomPager } from '../../components/CustomPager/CustomPager';
 import { SEOHead } from '../../components/SEOHead/SEOHead';
+import AccountsSnapshot from './components/AccountsSnapshot/AccountsSnapshot';
 import ExpenseReport from './components/ExpenseReport/ExpenseReport';
 import ExpenseReportStatusIndicator from './components/ExpenseReportStatusIndicator/ExpenseReportStatusIndicator';
 import { TransparencyActuals } from './components/TransparencyActuals/TransparencyActuals';
@@ -149,6 +150,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit }: TransparencyReportPr
                 longCode={longCode}
               />
             )}
+            {tabsIndex === TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS && <AccountsSnapshot />}
             {tabsIndex === TRANSPARENCY_IDS_ENUM.AUDIT_REPORTS && isEnabled('FEATURE_AUDIT_REPORTS') && (
               <TransparencyAudit budgetStatement={currentBudgetStatement} />
             )}

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -1,0 +1,10 @@
+import Container from '@ses/components/Container/Container';
+import React from 'react';
+
+const AccountsSnapshot: React.FC = () => {
+  console.log('hello world');
+
+  return <Container>Hello</Container>;
+};
+
+export default AccountsSnapshot;

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -1,10 +1,31 @@
+import styled from '@emotion/styled';
 import Container from '@ses/components/Container/Container';
 import React from 'react';
+import CUReserves from './components/CUReserves/CUReserves';
+import ExpensesComparison from './components/ExpensesComparison/ExpensesComparison';
+import FundingOverview from './components/FundingOverview/FundingOverview';
+import useAccountsSnapshot from './useAccountsSnapshot';
 
 const AccountsSnapshot: React.FC = () => {
-  console.log('hello world');
+  // TODO: use the values from the hook
+  useAccountsSnapshot();
 
-  return <Container>Hello</Container>;
+  return (
+    <Container>
+      <Wrapper>
+        <FundingOverview coreUnitCode="SES" />
+        <CUReserves coreUnitCode="SES" />
+        <ExpensesComparison />
+      </Wrapper>
+    </Container>
+  );
 };
 
 export default AccountsSnapshot;
+
+const Wrapper = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 64,
+  marginBottom: 64,
+});

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import SectionHeader from '../SectionHeader/SectionHeader';
+
+interface CUReservesProps {
+  coreUnitCode: string;
+}
+
+const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode }) => (
+  <div>
+    <SectionHeader
+      title="Total Core Unit Reserves"
+      subtitle={`On-chain and off-chain reserves accessible to the ${coreUnitCode} Core Unit.`}
+      tooltip={'pending...'}
+    />
+  </div>
+);
+
+export default CUReserves;

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import SectionHeader from '../SectionHeader/SectionHeader';
+
+const ExpensesComparison: React.FC = () => (
+  <div>
+    <SectionHeader
+      title="Reported Expenses Comparison"
+      subtitle={'Reported actuals compared to expense and revenue transactions.'}
+      tooltip={'pending...'}
+    />
+  </div>
+);
+
+export default ExpensesComparison;

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import SectionHeader from '../SectionHeader/SectionHeader';
+
+interface FundingOverviewProps {
+  coreUnitCode: string;
+}
+
+const FundingOverview: React.FC<FundingOverviewProps> = ({ coreUnitCode }) => (
+  <div>
+    <SectionHeader
+      title="MakerDAO Funding Overview"
+      subtitle={`Totals funds made available to the ${coreUnitCode} Core Unit over its entire lifetime, since June 2021.`}
+      tooltip={'pending...'}
+    />
+  </div>
+);
+
+export default FundingOverview;

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -1,0 +1,70 @@
+import styled from '@emotion/styled';
+import { CustomPopover } from '@ses/components/CustomPopover/CustomPopover';
+import Information from '@ses/components/svg/information';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { toKebabCase } from '@ses/core/utils/string';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface SectionHeaderProps {
+  title: string;
+  subtitle: string;
+  tooltip?: string;
+  isSubsection?: boolean;
+}
+
+const SectionHeader: React.FC<SectionHeaderProps> = ({ title, subtitle, tooltip, isSubsection = false }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Header>
+      <TitleWrapper>
+        <Title isLight={isLight} isSubsection={isSubsection}>
+          {title}
+        </Title>
+        {tooltip && (
+          <CustomPopover id={toKebabCase(title)} title={tooltip}>
+            <IconWrapper>
+              <Information />
+            </IconWrapper>
+          </CustomPopover>
+        )}
+      </TitleWrapper>
+      <Subtitle isLight={isLight}>{subtitle}</Subtitle>
+    </Header>
+  );
+};
+
+export default SectionHeader;
+
+const Header = styled.header({});
+
+const TitleWrapper = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  marginBottom: 8,
+});
+
+const Title = styled.h2<WithIsLight & { isSubsection: boolean }>(({ isLight, isSubsection }) => ({
+  color: isLight ? '#231536' : 'red',
+  fontWeight: isSubsection ? 700 : 600,
+  fontSize: isSubsection ? 16 : 20,
+  lineHeight: isSubsection ? '19px' : '24px',
+  letterSpacing: isSubsection ? 0 : 0.4,
+  margin: 0,
+}));
+
+const IconWrapper = styled.div({
+  width: 24,
+  height: 24,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginLeft: 12.5,
+});
+
+const Subtitle = styled.div<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#231536' : 'red',
+  fontSize: 16,
+  lineHeight: '22px',
+}));

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.ts
@@ -1,0 +1,11 @@
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+
+const useAccountsSnapshot = () => {
+  const { isLight } = useThemeContext();
+
+  return {
+    isLight,
+  };
+};
+
+export default useAccountsSnapshot;

--- a/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
@@ -24,6 +24,7 @@ export enum TRANSPARENCY_IDS_ENUM {
   MKR_VESTING = 'mkr-vesting',
   TRANSFER_REQUESTS = 'transfer-requests',
   AUDIT_REPORTS = 'audit-reports',
+  ACCOUNTS_SNAPSHOTS = 'accounts-snapshots',
   COMMENTS = 'comments',
   EXPENSE_REPORT = 'expense-report',
 }
@@ -102,32 +103,10 @@ export const useTransparencyReport = (coreUnit: CoreUnitDto) => {
   );
 
   const [isEnabled] = useFlagsActive();
-  const tabItems: TableItems[] = [
-    {
-      item: 'Actuals',
-      id: TRANSPARENCY_IDS_ENUM.ACTUALS,
-    },
-    {
-      item: 'Forecast',
-      id: TRANSPARENCY_IDS_ENUM.FORECAST,
-    },
-  ];
-  if (isEnabled('FEATURE_MKR_VESTING')) {
-    tabItems.push({
-      item: 'MKR Vesting',
-      id: TRANSPARENCY_IDS_ENUM.MKR_VESTING,
-    });
-  }
-  tabItems.push({
-    item: 'Transfer Requests',
-    id: TRANSPARENCY_IDS_ENUM.TRANSFER_REQUESTS,
-  });
-  if (isEnabled('FEATURE_AUDIT_REPORTS')) {
-    tabItems.push({
-      item: 'Audit Reports',
-      id: TRANSPARENCY_IDS_ENUM.AUDIT_REPORTS,
-    });
-  }
+  const accountsSnapshotTab = {
+    item: 'Accounts Snapshot',
+    id: TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS,
+  };
   const commentTab = {
     item: (
       <CommentsTab
@@ -137,15 +116,45 @@ export const useTransparencyReport = (coreUnit: CoreUnitDto) => {
     ),
     id: TRANSPARENCY_IDS_ENUM.COMMENTS,
   };
-  if (isEnabled('FEATURE_TRANSPARENCY_COMMENTS')) {
-    tabItems.push(commentTab);
-  }
+  const tabItems: TableItems[] = [
+    {
+      item: 'Actuals',
+      id: TRANSPARENCY_IDS_ENUM.ACTUALS,
+    },
+    {
+      item: 'Forecast',
+      id: TRANSPARENCY_IDS_ENUM.FORECAST,
+    },
+    ...(isEnabled('FEATURE_MKR_VESTING')
+      ? [
+          {
+            item: 'MKR Vesting',
+            id: TRANSPARENCY_IDS_ENUM.MKR_VESTING,
+          },
+        ]
+      : []),
+    {
+      item: 'Transfer Requests',
+      id: TRANSPARENCY_IDS_ENUM.TRANSFER_REQUESTS,
+    },
+    ...(isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') ? [accountsSnapshotTab] : []),
+    ...(isEnabled('FEATURE_AUDIT_REPORTS')
+      ? [
+          {
+            item: 'Audit Reports',
+            id: TRANSPARENCY_IDS_ENUM.AUDIT_REPORTS,
+          },
+        ]
+      : []),
+    ...(isEnabled('FEATURE_TRANSPARENCY_COMMENTS') ? [commentTab] : []),
+  ];
 
   const compressedTabItems: TableItems[] = [
     {
       item: 'Expense Report',
       id: TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT,
     },
+    ...(isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') ? [accountsSnapshotTab] : []),
     commentTab,
   ];
 


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Added the Accounts Snapshot tab and the headers of each section

# What solved
- Should enable/disable the "Accounts Snapshot" section through feature flags
- Should create a new tab called "Accounts Snapshot"
- Should add the MakerDAO Funding Overview section within the "Accounts Snapshot" tab (header) 
- Should add the Total Core Unit Reserves section within the "Accounts Snapshot" tab (header)
- Should add the Reported Expenses Comparison section within the "Accounts Snapshot" tab (header)