### PR TITLE
Feature/add progressive forecast indicator

### DIFF
--- a/src/core/utils/math.ts
+++ b/src/core/utils/math.ts
@@ -1,1 +1,4 @@
-export const percentageRespectTo = (a: number, b: number): number => (a / b) * 100;
+export const percentageRespectTo = (a: number, b: number): number => {
+  if (b === 0) return 0;
+  return (a / b) * 100;
+};

--- a/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
+++ b/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
@@ -1,0 +1,145 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { ExpenditureLevel } from '@ses/core/enums/expenditureLevelEnum';
+import { percentageRespectTo } from '@ses/core/utils/math';
+import React from 'react';
+import { getExpenditureLevelForecast } from '../../utils/forecastHelper';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface Props {
+  value: number;
+  relativeValue: number;
+  month: string;
+  budgetCap: number;
+  forecast: number;
+}
+
+const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, month, forecast, budgetCap }) => {
+  const { isLight } = useThemeContext();
+  const expenditureLevel = getExpenditureLevelForecast(value, relativeValue);
+  const percent = percentageRespectTo(value, relativeValue);
+  return (
+    <ContainerInside>
+      <RowMonthDescription>
+        <Month>{month}</Month>
+        <SeverityDistinction
+          isLight={isLight}
+          levelExpenditure={expenditureLevel === '0' ? ExpenditureLevel.OVERBUDGET : expenditureLevel}
+        >
+          {expenditureLevel === '0' ? '0' : expenditureLevel}
+        </SeverityDistinction>
+      </RowMonthDescription>
+      <RowPercentBudgetCap>
+        <Percent isLight={isLight}>{Math.trunc(percent)}%</Percent>
+        <Description isLight={isLight}>of budget cap forecasted</Description>
+      </RowPercentBudgetCap>
+      <RowAbsoluteNumbers>
+        <Forecast>
+          <Value isLight={isLight}>{forecast}</Value>
+          <DescriptionValue isLight={isLight}>Forecast</DescriptionValue>
+        </Forecast>
+        <BudgetCap>
+          <Value isLight={isLight}>{budgetCap}</Value>
+          <DescriptionValue isLight={isLight}>Budget Cap</DescriptionValue>
+        </BudgetCap>
+      </RowAbsoluteNumbers>
+    </ContainerInside>
+  );
+};
+
+export default PopoverForecastDescription;
+
+const ContainerInside = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  fontFamily: 'Inter, sans-serif',
+  fontStyle: 'normal',
+});
+
+const RowMonthDescription = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+});
+const Month = styled.div({
+  fontWeight: 600,
+  fontSize: '12px',
+  lineHeight: '15px',
+  letterSpacing: '1px',
+  textTransform: 'uppercase',
+  color: '#9FAFB9',
+});
+const SeverityDistinction = styled.div<WithIsLight & { levelExpenditure: string }>(({ isLight, levelExpenditure }) => ({
+  fontWeight: 300,
+  fontSize: '11px',
+  lineHeight: '13px',
+  textTransform: 'uppercase',
+  color: isLight
+    ? levelExpenditure === ExpenditureLevel.LOW || levelExpenditure === ExpenditureLevel.OPTIMAL
+      ? '#02CB9B'
+      : levelExpenditure === ExpenditureLevel.STRETCHED
+      ? '#F08B04'
+      : levelExpenditure === ExpenditureLevel.OVERBUDGET
+      ? '#CB3A0D'
+      : '#1E2C37'
+    : levelExpenditure === ExpenditureLevel.LOW || levelExpenditure === ExpenditureLevel.OPTIMAL
+    ? '#00ED18'
+    : levelExpenditure === ExpenditureLevel.STRETCHED
+    ? '#FF8237'
+    : levelExpenditure === ExpenditureLevel.OVERBUDGET
+    ? '#FF4085'
+    : '#ECF1F3',
+}));
+const RowPercentBudgetCap = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const Percent = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 400,
+  fontSize: '18px',
+  lineHeight: '22px',
+  letterSpacing: '0.3px',
+  fontFeatureSettings: "'tnum' on, 'lnum' on",
+  color: isLight ? '#000000' : '#FFFFFF',
+  marginBottom: 4,
+}));
+const Description = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 400,
+  fontSize: 12,
+  lineHeight: '15px',
+  color: isLight ? '#231536' : '#FFFFFF',
+}));
+const DescriptionValue = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 400,
+  fontSize: '12px',
+  lineHeight: '15px',
+  color: isLight ? '#231536' : '#EDEFFF',
+}));
+
+const RowAbsoluteNumbers = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+});
+
+const Forecast = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const Value = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 700,
+  fontSize: '14px',
+  lineHeight: '17px',
+  letterSpacing: '0.3px',
+  fontFeatureSettings: " 'tnum' on, 'lnum' on",
+  color: isLight ? '#000000' : '#EDEFFF',
+  marginBottom: 4,
+}));
+
+const BudgetCap = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+});

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.stories.tsx
@@ -1,0 +1,142 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import BarWithDottedLine from './BarWithDottedLine';
+import type { ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/BarWithDottedLine',
+  component: BarWithDottedLine,
+  parameters: {
+    chromatic: {
+      viewports: [1440],
+    },
+  },
+} as ComponentMeta<typeof BarWithDottedLine>;
+const variantsArgs = [
+  {
+    value: 58000,
+    relativeValue: 856579,
+  },
+  {
+    value: 846579,
+    relativeValue: 856579,
+  },
+  {
+    value: 70200,
+    relativeValue: 55000,
+  },
+  {
+    value: 43500,
+    relativeValue: 0,
+  },
+  {
+    value: 0,
+    relativeValue: 10000,
+  },
+];
+
+export const [
+  [ProgressiveGreen, ProgressiveGreenDark],
+  [ProgressiveYellow, ProgressiveYellowDark],
+  [ProgressiveRed, ProgressiveRedDark],
+
+  [ProgressiveGray, ProgressiveGrayDark],
+  [ProgressiveGrayStrong, ProgressiveGrayStrongDark],
+] = createThemeModeVariants(BarWithDottedLine, variantsArgs);
+
+ProgressiveGreen.parameters = {
+  figma: {
+    component: {
+      1440: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=17273:217604&t=glCgbUhycsocnnqd-4',
+        options: {
+          style: {
+            left: -40,
+            top: -20,
+          },
+          componentStyle: {
+            width: 1312,
+          },
+        },
+      },
+    },
+  },
+};
+ProgressiveYellow.parameters = {
+  figma: {
+    component: {
+      1440: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=17273:217604&t=PI6pSxhgdF0jUODH-4',
+        options: {
+          style: {
+            left: -40,
+            top: -20,
+          },
+          componentStyle: {
+            width: 1312,
+          },
+        },
+      },
+    },
+  },
+};
+ProgressiveRed.parameters = {
+  figma: {
+    component: {
+      1440: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=17273:217604&t=PI6pSxhgdF0jUODH-4',
+        options: {
+          style: {
+            left: -40,
+            top: -20,
+          },
+          componentStyle: {
+            width: 1312,
+          },
+        },
+      },
+    },
+  },
+};
+ProgressiveYellow.parameters = {
+  figma: {
+    component: {
+      1440: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=17273:217604&t=PI6pSxhgdF0jUODH-4',
+        options: {
+          style: {
+            left: -40,
+            top: -20,
+          },
+          componentStyle: {
+            width: 1312,
+          },
+        },
+      },
+    },
+  },
+};
+ProgressiveGrayStrong.parameters = {
+  figma: {
+    component: {
+      1440: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=17273:217604&t=PI6pSxhgdF0jUODH-4',
+        options: {
+          style: {
+            left: -40,
+            top: -20,
+          },
+          componentStyle: {
+            width: 1312,
+          },
+        },
+      },
+    },
+  },
+};
+
+ProgressiveYellow.parameters = {};

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled';
+import { CustomPopover } from '@ses/components/CustomPopover/CustomPopover';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import { percentageRespectTo } from '@ses/core/utils/math';
 import React from 'react';
-import { getDisplacementDashLine, getProgressiveBarColor } from '../../utils/forecastHelper';
+import { getBorderColor, getDisplacementDashLine, getProgressiveBarColor } from '../../utils/forecastHelper';
+import PopoverForecastDescription from '../PopverForecastDescription/PopoverForecastDescription';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
@@ -13,14 +15,39 @@ interface Props {
 
 const BarWithDottedLine: React.FC<Props> = ({ value, relativeValue }) => {
   const { isLight } = useThemeContext();
+  const month = 'August';
   const barColor = getProgressiveBarColor(value, relativeValue, isLight);
   const percent = percentageRespectTo(value, relativeValue);
   const displacement = getDisplacementDashLine(value, relativeValue);
+  const borderColor = getBorderColor(value, relativeValue, isLight);
   return (
     <Container>
       <ContainerBar>
         <BudgetBar isLight={isLight}>{<BarPercent width={percent} color={barColor} />}</BudgetBar>
-        <VerticalBar displacement={displacement} />
+
+        <CustomPopover
+          popoverStyle={{
+            border: `1px solid ${borderColor}`,
+            boxShadow: isLight
+              ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
+              : '10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
+            background: isLight ? 'white' : '#000A13',
+            borderRadius: '6px',
+          }}
+          popupStyle={{}}
+          id="mouse-over-information"
+          title={
+            <PopoverForecastDescription
+              relativeValue={relativeValue}
+              value={value}
+              month={month}
+              budgetCap={relativeValue}
+              forecast={value}
+            />
+          }
+        >
+          <VerticalBar displacement={displacement} />
+        </CustomPopover>
       </ContainerBar>
       <BudgetCap isLight={isLight}>{usLocalizedNumber(relativeValue)}</BudgetCap>
     </Container>
@@ -53,11 +80,13 @@ const VerticalBar = styled.div<{ displacement: number }>(({ displacement }) => (
   height: 14,
   width: 1,
   border: '1px dashed #447AFB',
+  backgroundSize: '4px 4px',
   borderRadius: '6px',
   position: 'absolute',
   top: 0,
   right: `${displacement}%`,
   transform: 'rotate(180deg)',
+  cursor: 'pointer',
 }));
 
 const BudgetBar = styled.div<WithIsLight>(({ isLight }) => ({
@@ -65,8 +94,8 @@ const BudgetBar = styled.div<WithIsLight>(({ isLight }) => ({
   width: '100%',
   height: 6,
   overflow: 'hidden',
-  borderRadius: 6,
-  background: isLight ? '#ECF1F3' : 'red',
+  borderRadius: 2,
+  background: isLight ? '#ECF1F3' : '#48495F',
 }));
 
 const BarPercent = styled.div<{ width: number; color: string }>(({ width, color }) => ({
@@ -74,7 +103,7 @@ const BarPercent = styled.div<{ width: number; color: string }>(({ width, color 
   top: 0,
   left: 0,
   background: color,
-  borderRadius: 6,
+  borderRadius: 2,
   width: `${width}%`,
   height: '100%',
   transition: 'width 0.5s ease-in-out',
@@ -83,5 +112,5 @@ const BudgetCap = styled.div<WithIsLight>(({ isLight }) => ({
   fontSize: 12,
   lineHeight: '15px',
   textAlign: 'right',
-  color: isLight ? '#708390' : 'red',
+  color: isLight ? '#708390' : '#546978',
 }));

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
@@ -1,0 +1,87 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import { percentageRespectTo } from '@ses/core/utils/math';
+import React from 'react';
+import { getDisplacementDashLine, getProgressiveBarColor } from '../../utils/forecastHelper';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface Props {
+  value: number;
+  relativeValue: number;
+}
+
+const BarWithDottedLine: React.FC<Props> = ({ value, relativeValue }) => {
+  const { isLight } = useThemeContext();
+  const barColor = getProgressiveBarColor(value, relativeValue, isLight);
+  const percent = percentageRespectTo(value, relativeValue);
+  const displacement = getDisplacementDashLine(value, relativeValue);
+  return (
+    <Container>
+      <ContainerBar>
+        <BudgetBar isLight={isLight}>{<BarPercent width={percent} color={barColor} />}</BudgetBar>
+        <VerticalBar displacement={displacement} />
+      </ContainerBar>
+      <BudgetCap isLight={isLight}>{usLocalizedNumber(relativeValue)}</BudgetCap>
+    </Container>
+  );
+};
+
+export default BarWithDottedLine;
+
+const Container = styled.div({
+  paddingTop: 4,
+  width: 100,
+  display: 'flex',
+  flexDirection: 'column',
+  fontFamily: 'Inter, sans-serif',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  letterSpacing: '0.3px',
+  fontFeatureSettings: "'tnum' on, 'lnum' on",
+});
+const ContainerBar = styled.div({
+  height: 14,
+  paddingTop: 4,
+  paddingBottom: 4,
+  marginBottom: 2,
+  position: 'relative',
+  width: '100%',
+});
+
+const VerticalBar = styled.div<{ displacement: number }>(({ displacement }) => ({
+  height: 14,
+  width: 1,
+  border: '1px dashed #447AFB',
+  borderRadius: '6px',
+  position: 'absolute',
+  top: 0,
+  right: `${displacement}%`,
+  transform: 'rotate(180deg)',
+}));
+
+const BudgetBar = styled.div<WithIsLight>(({ isLight }) => ({
+  position: 'relative',
+  width: '100%',
+  height: 6,
+  overflow: 'hidden',
+  borderRadius: 6,
+  background: isLight ? '#ECF1F3' : 'red',
+}));
+
+const BarPercent = styled.div<{ width: number; color: string }>(({ width, color }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  background: color,
+  borderRadius: 6,
+  width: `${width}%`,
+  height: '100%',
+  transition: 'width 0.5s ease-in-out',
+}));
+const BudgetCap = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 12,
+  lineHeight: '15px',
+  textAlign: 'right',
+  color: isLight ? '#708390' : 'red',
+}));

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/ProgresiveIndicator.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/ProgresiveIndicator.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface Props {
+  forecast: number;
+  budgetCap: number;
+}
+
+const ProgressiveIndicator: React.FC<Props> = ({ forecast, budgetCap }) => {
+  const { isLight } = useThemeContext();
+  return (
+    <Container>
+      <Forecast isLight={isLight}>{forecast}</Forecast>
+      <BudgetCap isLight={isLight}>{budgetCap}</BudgetCap>
+    </Container>
+  );
+};
+
+export default ProgressiveIndicator;
+
+const Container = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  fontFamily: 'Inter, sans-serif',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  letterSpacing: '0.3px',
+  fontFeatureSettings: "'tnum' on, 'lnum' on",
+});
+
+const Forecast = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: '16px',
+  lineHeight: '19px',
+  textAlign: 'right',
+
+  color: isLight ? '#231536' : 'red',
+}));
+
+const BudgetCap = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 12,
+  lineHeight: '15px',
+  textAlign: 'right',
+  color: isLight ? '#708390' : 'red',
+}));

--- a/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
+++ b/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
@@ -1,3 +1,4 @@
+import { ExpenditureLevel } from '@ses/core/enums/expenditureLevelEnum';
 import { percentageRespectTo } from '@ses/core/utils/math';
 const COLORS_BAR = {
   COLOR_GREEN: '#B6EDE7',
@@ -5,7 +6,20 @@ const COLORS_BAR = {
   COLOR_GRAY: '#D1DEE6',
   COLOR_GRAY_STRONG: '#9FAFB9',
   COLOR_YELLOW: '#FEDB88',
+  COLOR_YELLOW_DARK: '#FDC134',
   COLOR_RED: '#F77249',
+  COLOR_RED_DARK: '#EB4714',
+};
+
+const COLORS_BORDERS_POPOVER = {
+  COLOR_GREEN: '#6EDBD0',
+  COLOR_GREEN_DARK: 'rgba(0, 237, 24, 0.4)',
+  COLOR_GRAY: '#D1DEE6',
+  COLOR_GRAY_STRONG: '#708390',
+  COLOR_YELLOW: '#FEDB88',
+  COLOR_YELLOW_DARK: 'rgba(255, 130, 55, 0.4)',
+  COLOR_RED: '#F99374',
+  COLOR_RED_DARK: 'rgba(255, 64, 133, 0.4)',
 };
 
 export const getProgressiveBarColor = (value: number, valueRelative: number, isLight: boolean): string => {
@@ -14,15 +28,15 @@ export const getProgressiveBarColor = (value: number, valueRelative: number, isL
   let color = '';
   const percent = percentageRespectTo(value, valueRelative);
   if (percent > 0 && percent <= 90) {
-    color = isLight ? COLORS_BAR.COLOR_GREEN : 'red';
+    color = isLight ? COLORS_BAR.COLOR_GREEN : COLORS_BAR.COLOR_GREEN_DARK;
   }
 
   if (percent > 90 && percent <= 100) {
-    color = isLight ? COLORS_BAR.COLOR_YELLOW : 'red';
+    color = isLight ? COLORS_BAR.COLOR_YELLOW : COLORS_BAR.COLOR_YELLOW_DARK;
   }
 
   if (percent > 100) {
-    color = isLight ? COLORS_BAR.COLOR_RED : 'red';
+    color = isLight ? COLORS_BAR.COLOR_RED : COLORS_BAR.COLOR_RED_DARK;
   }
   return color;
 };
@@ -37,4 +51,46 @@ export const getDisplacementDashLine = (value: number, valueRelative: number): n
     const displacement = displacementPercent / 2;
     return displacement;
   }
+};
+
+export const getExpenditureLevelForecast = (valueActual: number, budgetCapActual: number): string => {
+  if (budgetCapActual === 0) return '0';
+  if (valueActual === 0) return 'NO FORECAST';
+  const percent = (valueActual * 100) / budgetCapActual;
+  let expenditureLevel = '';
+  if (percent > 0 && percent <= 75) {
+    expenditureLevel = ExpenditureLevel.LOW;
+  }
+
+  if (percent > 75 && percent <= 90) {
+    expenditureLevel = ExpenditureLevel.OPTIMAL;
+  }
+
+  if (percent > 90 && percent <= 100) {
+    expenditureLevel = ExpenditureLevel.STRETCHED;
+  }
+  if (percent > 100) {
+    expenditureLevel = ExpenditureLevel.OVERBUDGET;
+  }
+
+  return expenditureLevel;
+};
+
+export const getBorderColor = (value: number, valueRelative: number, isLight: boolean): string => {
+  if (!valueRelative) return COLORS_BORDERS_POPOVER.COLOR_GRAY;
+  if (!value) return COLORS_BORDERS_POPOVER.COLOR_GRAY_STRONG;
+  let color = '';
+  const percent = percentageRespectTo(value, valueRelative);
+  if (percent > 0 && percent <= 90) {
+    color = isLight ? COLORS_BORDERS_POPOVER.COLOR_GREEN : COLORS_BORDERS_POPOVER.COLOR_GREEN_DARK;
+  }
+
+  if (percent > 90 && percent <= 100) {
+    color = isLight ? COLORS_BORDERS_POPOVER.COLOR_YELLOW : COLORS_BORDERS_POPOVER.COLOR_YELLOW_DARK;
+  }
+
+  if (percent > 100) {
+    color = isLight ? COLORS_BORDERS_POPOVER.COLOR_RED : COLORS_BORDERS_POPOVER.COLOR_RED_DARK;
+  }
+  return color;
 };

--- a/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
+++ b/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
@@ -1,0 +1,40 @@
+import { percentageRespectTo } from '@ses/core/utils/math';
+const COLORS_BAR = {
+  COLOR_GREEN: '#B6EDE7',
+  COLOR_GREEN_DARK: '#06554C',
+  COLOR_GRAY: '#D1DEE6',
+  COLOR_GRAY_STRONG: '#9FAFB9',
+  COLOR_YELLOW: '#FEDB88',
+  COLOR_RED: '#F77249',
+};
+
+export const getProgressiveBarColor = (value: number, valueRelative: number, isLight: boolean): string => {
+  if (!valueRelative) return COLORS_BAR.COLOR_GRAY;
+  if (!value) return COLORS_BAR.COLOR_GRAY_STRONG;
+  let color = '';
+  const percent = percentageRespectTo(value, valueRelative);
+  if (percent > 0 && percent <= 90) {
+    color = isLight ? COLORS_BAR.COLOR_GREEN : 'red';
+  }
+
+  if (percent > 90 && percent <= 100) {
+    color = isLight ? COLORS_BAR.COLOR_YELLOW : 'red';
+  }
+
+  if (percent > 100) {
+    color = isLight ? COLORS_BAR.COLOR_RED : 'red';
+  }
+  return color;
+};
+
+export const getDisplacementDashLine = (value: number, valueRelative: number): number => {
+  if (valueRelative === 0) return 0;
+  const percentToMove = percentageRespectTo(value, valueRelative);
+  if (percentToMove < 100) {
+    return 0;
+  } else {
+    const displacementPercent = Math.max(percentToMove - 100, 0);
+    const displacement = displacementPercent / 2;
+    return displacement;
+  }
+};


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅Should add a progress indicator component (yellow, green, and red) depending on proximity to the budget cap (similar to the logic in the budget graph within the core unit list).


# Actions
Add new indicator progress
Add tooltip for dotted bar