### PR TITLE
[SES-268] Add cards in the Accounts Snapshot tab sections

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.stories.tsx
@@ -1,0 +1,36 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import CUReserves from './CUReserves';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/CUTransparencyReport/Accounts Snapshot/Core Unit Reserves',
+  component: CUReserves,
+} as ComponentMeta<typeof CUReserves>;
+
+const variantsArgs = [
+  {
+    coreUnitCode: 'SES',
+  },
+];
+
+export const [[LightMode, DarkMode]] = createThemeModeVariants(CUReserves, variantsArgs);
+
+LightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=18149%3A200168',
+        options: {
+          componentStyle: {
+            width: 1312,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -1,4 +1,7 @@
+import styled from '@emotion/styled';
 import React from 'react';
+import FundChangeCard from '../Cards/FundChangeCard';
+import SimpleStatCard from '../Cards/SimpleStatCard';
 import SectionHeader from '../SectionHeader/SectionHeader';
 
 interface CUReservesProps {
@@ -12,7 +15,25 @@ const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode }) => (
       subtitle={`On-chain and off-chain reserves accessible to the ${coreUnitCode} Core Unit.`}
       tooltip={'pending...'}
     />
+
+    <CardsContainer>
+      <SimpleStatCard date="2023-05-12T22:52:54.494Z" value={1500000} caption="Initial Core Unit Reserves" />
+      <FundChangeCard
+        netChange={-242320}
+        leftValue={305000}
+        leftText="Inflow"
+        rightValue={538320}
+        rightText="Outflow"
+      />
+      <SimpleStatCard date="2023-06-14T22:52:54.494Z" value={1266680} caption="New Core Unit Reserves" hasEqualSign />
+    </CardsContainer>
   </div>
 );
 
 export default CUReserves;
+
+const CardsContainer = styled.div({
+  display: 'flex',
+  gap: 24,
+  marginTop: 24,
+});

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
@@ -4,13 +4,28 @@ import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import React from 'react';
 import NumberWithSignCard from '../NumberWithSignCard/NumberWithSignCard';
 import OutlinedCard from './OutlinedCard';
+import type { ValueColor } from '../NumberWithSignCard/NumberWithSignCard';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface FundChangeCardProps {
   netChange: number;
+  leftValue: number;
+  leftValueColor?: ValueColor;
+  leftText: string;
+  rightValue: number;
+  rightValueColor?: ValueColor;
+  rightText: string;
 }
 
-const FundChangeCard: React.FC<FundChangeCardProps> = ({ netChange }) => {
+const FundChangeCard: React.FC<FundChangeCardProps> = ({
+  netChange,
+  leftValue,
+  leftValueColor = 'normal',
+  leftText,
+  rightValue,
+  rightValueColor = 'normal',
+  rightText,
+}) => {
   const { isLight } = useThemeContext();
 
   return (
@@ -31,8 +46,14 @@ const FundChangeCard: React.FC<FundChangeCardProps> = ({ netChange }) => {
         </RightArrowContainer>
       </ChangeContainer>
       <ValuesContainer>
-        <NumberWithSignCard value={300000} sign="positive" text="Extra Funds Made Available" />
-        <NumberWithSignCard value={242320} valueColor="green" sign="negative" text="Funds Returned via DSSBlow" />
+        <NumberWithSignCard value={leftValue} valueColor={leftValueColor} sign="positive" text={leftText} width={224} />
+        <NumberWithSignCard
+          value={rightValue}
+          valueColor={rightValueColor}
+          sign="negative"
+          text={rightText}
+          width={235}
+        />
       </ValuesContainer>
     </Card>
   );

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
@@ -1,0 +1,147 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import React from 'react';
+import NumberWithSignCard from '../NumberWithSignCard/NumberWithSignCard';
+import OutlinedCard from './OutlinedCard';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface FundChangeCardProps {
+  netChange: number;
+}
+
+const FundChangeCard: React.FC<FundChangeCardProps> = ({ netChange }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Card>
+      <ChangeContainer>
+        <LeftArrowContainer>
+          <Arrow isLight={isLight} direction="left" />
+        </LeftArrowContainer>
+        <ChangeContent>
+          <Value isLight={isLight}>
+            {netChange > 0 && '+'}
+            {usLocalizedNumber(Math.round(netChange))} <span>DAI</span>
+          </Value>
+          <NetChangeMessage isLight={isLight}>Net Change</NetChangeMessage>
+        </ChangeContent>
+        <RightArrowContainer>
+          <Arrow isLight={isLight} direction="right" />
+        </RightArrowContainer>
+      </ChangeContainer>
+      <ValuesContainer>
+        <NumberWithSignCard value={300000} sign="positive" text="Extra Funds Made Available" />
+        <NumberWithSignCard value={242320} valueColor="green" sign="negative" text="Funds Returned via DSSBlow" />
+      </ValuesContainer>
+    </Card>
+  );
+};
+
+export default FundChangeCard;
+
+const Card = styled(OutlinedCard)({
+  padding: 15,
+  minWidth: 579,
+});
+
+const ChangeContainer = styled.div({
+  display: 'flex',
+  width: '100%',
+});
+
+const LeftArrowContainer = styled.div({
+  width: '100%',
+  paddingLeft: 159,
+  marginRight: 8,
+  paddingBottom: 1,
+});
+
+const RightArrowContainer = styled.div({
+  width: '100%',
+  paddingRight: 129,
+  marginLeft: 8,
+  paddingBottom: 1,
+});
+
+const Arrow = styled.div<WithIsLight & { direction: 'left' | 'right' }>(({ isLight, direction }) => {
+  const margin = 16;
+  const borderStyle = `2px solid ${isLight ? '#ECEFF9' : 'red'}`;
+
+  return {
+    position: 'relative',
+    height: `calc(100% - ${margin}px)`,
+    marginTop: margin,
+    borderTop: borderStyle,
+
+    ...(direction === 'left'
+      ? {
+          borderLeft: borderStyle,
+          borderTopLeftRadius: 20,
+        }
+      : {
+          borderRight: borderStyle,
+          borderTopRightRadius: 20,
+        }),
+
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      bottom: 1,
+      ...(direction === 'left' ? { left: -7.4 } : { right: -7.4 }),
+
+      width: 13,
+      height: 13,
+      borderTop: borderStyle,
+      borderLeft: borderStyle,
+      borderTopLeftRadius: 1,
+      transform: 'rotate(225deg)',
+    },
+
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      top: -8,
+      ...(direction === 'left' ? { right: 0 } : { left: 0 }),
+      width: 2,
+      height: 14,
+      background: isLight ? '#ECEFF9' : 'red',
+      borderRadius: 1,
+    },
+  };
+});
+
+const ChangeContent = styled.div({
+  paddingBottom: 16,
+  textAlign: 'center',
+});
+
+const Value = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  fontWeight: 500,
+  fontSize: 16,
+  lineHeight: '19px',
+  letterSpacing: 0.4,
+  color: isLight ? '#9FAFB9' : 'red',
+
+  '& > span': {
+    fontWeight: 700,
+    fontSize: 16,
+    lineHeight: '19px',
+    letterSpacing: 0.3,
+    fontFeatureSettings: "'tnum' on, 'lnum' on",
+    color: isLight ? '#9FAFB9' : 'red',
+    marginLeft: 4,
+  },
+}));
+
+const NetChangeMessage = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 14,
+  lineHeight: '17px',
+  color: isLight ? '#D1DEE6' : 'red',
+}));
+
+const ValuesContainer = styled.div({
+  display: 'flex',
+  gap: 24,
+});

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
@@ -73,14 +73,14 @@ const ChangeContainer = styled.div({
 
 const LeftArrowContainer = styled.div({
   width: '100%',
-  paddingLeft: 159,
+  paddingLeft: 143,
   marginRight: 8,
   paddingBottom: 1,
 });
 
 const RightArrowContainer = styled.div({
   width: '100%',
-  paddingRight: 129,
+  paddingRight: 113,
   marginLeft: 8,
   paddingBottom: 1,
 });
@@ -97,6 +97,7 @@ const Arrow = styled.div<WithIsLight & { direction: 'left' | 'right' }>(({ isLig
 
     ...(direction === 'left'
       ? {
+          width: 'calc(100% - 25px)',
           borderLeft: borderStyle,
           borderTopLeftRadius: 20,
         }
@@ -135,6 +136,7 @@ const Arrow = styled.div<WithIsLight & { direction: 'left' | 'right' }>(({ isLig
 const ChangeContent = styled.div({
   paddingBottom: 16,
   textAlign: 'center',
+  marginLeft: -25,
 });
 
 const Value = styled.div<WithIsLight>(({ isLight }) => ({

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/OutlinedCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/OutlinedCard.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface OutlinedCardProps extends React.PropsWithChildren {
+  className?: string;
+}
+
+const OutlinedCard: React.FC<OutlinedCardProps> = ({ children, className }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Card className={className} isLight={isLight}>
+      {children}
+    </Card>
+  );
+};
+
+export default OutlinedCard;
+
+const Card = styled.div<WithIsLight>(({ isLight }) => ({
+  width: '100%',
+  background: isLight ? '#FFFFFF' : 'red',
+  border: `1px solid ${isLight ? '#D1DEE6' : 'red'}`,
+  borderRadius: 6,
+  boxShadow: isLight
+    ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
+    : '0px 20px 40px red, 0px 1px 3px red',
+}));

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
@@ -41,7 +41,7 @@ const SimpleStatCard: React.FC<SimpleStatCardProps> = ({ date, value, caption, h
 export default SimpleStatCard;
 
 const Card = styled(OutlinedCard)({
-  padding: '24px 32px 22px',
+  padding: '23px 31px',
 });
 
 const Date = styled.div<WithIsLight>(({ isLight }) => ({

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
@@ -1,0 +1,96 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import { DateTime } from 'luxon';
+import React from 'react';
+import EqualSign from '../SVG/Equals';
+import OutlinedCard from './OutlinedCard';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface SimpleStatCardProps {
+  date: string;
+  value: number;
+  caption: string;
+  hasEqualSign?: boolean;
+}
+
+const SimpleStatCard: React.FC<SimpleStatCardProps> = ({ date, value, caption, hasEqualSign = false }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Card>
+      <Date isLight={isLight}>{DateTime.fromISO(date).toFormat('d MMM y')}</Date>
+
+      <ContentWrapper>
+        {hasEqualSign && (
+          <EqualSignContainer>
+            <EqualSign />
+          </EqualSignContainer>
+        )}
+        <Wrapper>
+          <Value isLight={isLight}>
+            {usLocalizedNumber(Math.round(value))} <span>DAI</span>
+          </Value>
+          <Caption isLight={isLight}>{caption}</Caption>
+        </Wrapper>
+      </ContentWrapper>
+    </Card>
+  );
+};
+
+export default SimpleStatCard;
+
+const Card = styled(OutlinedCard)({
+  padding: '24px 32px 22px',
+});
+
+const Date = styled.div<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#708390' : 'red',
+  fontWeight: 600,
+  fontSize: 12,
+  lineHeight: '15px',
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+}));
+
+const ContentWrapper = styled.div({
+  display: 'flex',
+  marginTop: 33,
+});
+
+const EqualSignContainer = styled.div({
+  paddingTop: 7,
+  marginRight: 16,
+});
+
+const Wrapper = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const Value = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  alignItems: 'baseline',
+  fontWeight: 500,
+  fontSize: 30,
+  lineHeight: '36px',
+  letterSpacing: 0.4,
+  color: isLight ? '#231536' : 'red',
+
+  '& > span': {
+    marginLeft: 4,
+    fontWeight: 700,
+    fontSize: 16,
+    lineHeight: '19px',
+    letterSpacing: 0.3,
+    fontFeatureSettings: "'tnum' on, 'lnum' on",
+    color: isLight ? '#9FAFB9' : 'red',
+  },
+}));
+
+const Caption = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 16,
+  lineHeight: '22px',
+  color: isLight ? '#708390' : 'red',
+  marginTop: 8,
+}));

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
@@ -1,0 +1,36 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import FundingOverview from './FundingOverview';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/CUTransparencyReport/Accounts Snapshot/Funding Overview',
+  component: FundingOverview,
+} as ComponentMeta<typeof FundingOverview>;
+
+const variantsArgs = [
+  {
+    coreUnitCode: 'SES',
+  },
+];
+
+export const [[LightMode, DarkMode]] = createThemeModeVariants(FundingOverview, variantsArgs);
+
+LightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=18118%3A195773',
+        options: {
+          componentStyle: {
+            width: 1312,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -18,7 +18,14 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({ coreUnitCode }) => (
 
     <CardsContainer>
       <SimpleStatCard date="2023-05-12T22:52:54.494Z" value={3685648} caption="Initial Lifetime Balance" />
-      <FundChangeCard netChange={57680} />
+      <FundChangeCard
+        netChange={57680}
+        leftValue={300000}
+        leftText="Extra Funds Made Available"
+        rightValue={242320}
+        rightValueColor="green"
+        rightText="Funds Returned via DSSBlow"
+      />
       <SimpleStatCard date="2023-06-14T22:52:54.494Z" value={3685648} caption="New Lifetime Balance" hasEqualSign />
     </CardsContainer>
   </div>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import React from 'react';
-import OutlinedCard from '../Cards/OutlinedCard';
+import FundChangeCard from '../Cards/FundChangeCard';
 import SimpleStatCard from '../Cards/SimpleStatCard';
 import SectionHeader from '../SectionHeader/SectionHeader';
 
@@ -18,9 +18,7 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({ coreUnitCode }) => (
 
     <CardsContainer>
       <SimpleStatCard date="2023-05-12T22:52:54.494Z" value={3685648} caption="Initial Lifetime Balance" />
-      <TemporaryContainer>
-        <OutlinedCard />
-      </TemporaryContainer>
+      <FundChangeCard netChange={57680} />
       <SimpleStatCard date="2023-06-14T22:52:54.494Z" value={3685648} caption="New Lifetime Balance" hasEqualSign />
     </CardsContainer>
   </div>
@@ -32,13 +30,4 @@ const CardsContainer = styled.div({
   display: 'flex',
   gap: 24,
   marginTop: 24,
-});
-
-const TemporaryContainer = styled.div({
-  width: 579,
-  minWidth: 579,
-
-  '& > div': {
-    height: '100%',
-  },
 });

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -1,4 +1,7 @@
+import styled from '@emotion/styled';
 import React from 'react';
+import OutlinedCard from '../Cards/OutlinedCard';
+import SimpleStatCard from '../Cards/SimpleStatCard';
 import SectionHeader from '../SectionHeader/SectionHeader';
 
 interface FundingOverviewProps {
@@ -12,7 +15,30 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({ coreUnitCode }) => (
       subtitle={`Totals funds made available to the ${coreUnitCode} Core Unit over its entire lifetime, since June 2021.`}
       tooltip={'pending...'}
     />
+
+    <CardsContainer>
+      <SimpleStatCard date="2023-05-12T22:52:54.494Z" value={3685648} caption="Initial Lifetime Balance" />
+      <TemporaryContainer>
+        <OutlinedCard />
+      </TemporaryContainer>
+      <SimpleStatCard date="2023-06-14T22:52:54.494Z" value={3685648} caption="New Lifetime Balance" hasEqualSign />
+    </CardsContainer>
   </div>
 );
 
 export default FundingOverview;
+
+const CardsContainer = styled.div({
+  display: 'flex',
+  gap: 24,
+  marginTop: 24,
+});
+
+const TemporaryContainer = styled.div({
+  width: 579,
+  minWidth: 579,
+
+  '& > div': {
+    height: '100%',
+  },
+});

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCard.tsx
@@ -4,16 +4,17 @@ import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import React from 'react';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
-type ValueColor = 'normal' | 'green';
+export type ValueColor = 'normal' | 'green';
 
 interface NumberWithSignCardProps {
   value: number;
   text: string;
   sign: 'positive' | 'negative';
   valueColor?: ValueColor;
+  width?: string | number;
 }
 
-const NumberWithSignCard: React.FC<NumberWithSignCardProps> = ({ value, sign, text, valueColor = 'normal' }) => {
+const NumberWithSignCard: React.FC<NumberWithSignCardProps> = ({ value, sign, text, valueColor = 'normal', width }) => {
   const { isLight } = useThemeContext();
 
   return (
@@ -30,7 +31,7 @@ const NumberWithSignCard: React.FC<NumberWithSignCardProps> = ({ value, sign, te
           </svg>
         )}
       </SignContainer>
-      <Card isLight={isLight}>
+      <Card isLight={isLight} width={width ?? 'auto'}>
         <Value isLight={isLight} valueColor={valueColor}>
           {usLocalizedNumber(Math.round(value))} <span>DAI</span>
         </Value>
@@ -52,11 +53,11 @@ const SignContainer = styled.div({
   marginRight: 8,
 });
 
-const Card = styled.div<WithIsLight>(({ isLight }) => ({
+const Card = styled.div<WithIsLight & { width: string | number }>(({ isLight, width }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  width: '100%',
+  width,
   padding: 8,
   background: isLight ? 'rgba(236, 239, 249, 0.5)' : 'red',
   borderRadius: 6,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCard.tsx
@@ -1,0 +1,97 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+type ValueColor = 'normal' | 'green';
+
+interface NumberWithSignCardProps {
+  value: number;
+  text: string;
+  sign: 'positive' | 'negative';
+  valueColor?: ValueColor;
+}
+
+const NumberWithSignCard: React.FC<NumberWithSignCardProps> = ({ value, sign, text, valueColor = 'normal' }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Container>
+      <SignContainer>
+        {sign === 'positive' ? (
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="10" width="4" height="24" rx="2" fill="#ADAFD4" />
+            <rect y="14" width="4" height="24" rx="2" transform="rotate(-90 0 14)" fill="#ADAFD4" />
+          </svg>
+        ) : (
+          <svg width="24" height="4" viewBox="0 0 24 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect y="4" width="4" height="24" rx="2" transform="rotate(-90 0 4)" fill="#ADAFD4" />
+          </svg>
+        )}
+      </SignContainer>
+      <Card isLight={isLight}>
+        <Value isLight={isLight} valueColor={valueColor}>
+          {usLocalizedNumber(Math.round(value))} <span>DAI</span>
+        </Value>
+        <Text isLight={isLight}>{text}</Text>
+      </Card>
+    </Container>
+  );
+};
+
+export default NumberWithSignCard;
+
+const Container = styled.div({
+  display: 'flex',
+});
+
+const SignContainer = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  marginRight: 8,
+});
+
+const Card = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  width: '100%',
+  padding: 8,
+  background: isLight ? 'rgba(236, 239, 249, 0.5)' : 'red',
+  borderRadius: 6,
+}));
+
+const Value = styled.div<WithIsLight & { valueColor: ValueColor }>(({ isLight, valueColor }) => {
+  let color = isLight ? '#231536' : 'red'; // normal
+  if (valueColor === 'green') {
+    color = isLight ? '#1AAB9B' : 'green';
+  }
+
+  return {
+    display: 'flex',
+    alignItems: 'baseline',
+    fontWeight: 500,
+    fontSize: 30,
+    lineHeight: '36px',
+    letterSpacing: 0.4,
+    color,
+
+    '& span': {
+      marginLeft: 4,
+      fontWeight: 700,
+      fontSize: 16,
+      lineHeight: '19px',
+      letterSpacing: 0.3,
+      fontFeatureSettings: "'tnum' on, 'lnum' on",
+      color: isLight ? '#9FAFB9' : 'red',
+    },
+  };
+});
+
+const Text = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 16,
+  lineHeight: '22px',
+  color: isLight ? '#708390' : 'red',
+  marginTop: 4,
+}));

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SVG/Equals.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SVG/Equals.tsx
@@ -1,0 +1,19 @@
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import * as React from 'react';
+
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+const EqualSign: React.FC<Props> = ({ height = 15, width = 24, ...props }) => {
+  const { isLight } = useThemeContext();
+  return (
+    <svg width={width} height={height} {...props} viewBox="0 0 24 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect y="15.5" width="4" height="24" rx="2" transform="rotate(-90 0 15.5)" fill={isLight ? '#ADAFD4' : 'red'} />
+      <rect y="4.5" width="4" height="24" rx="2" transform="rotate(-90 0 4.5)" fill={isLight ? '#ADAFD4' : 'red'} />
+    </svg>
+  );
+};
+
+export default EqualSign;

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -60,7 +60,7 @@ const IconWrapper = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  marginLeft: 12.5,
+  marginLeft: 8,
 });
 
 const Subtitle = styled.div<WithIsLight>(({ isLight }) => ({


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Added the cards in the Funding Overview section and in the Total Core Unit Reserves section

# What solved
- Should add the "Initial Lifetime Balance" card in the MakerDAO Funding Overview section
- Should add a card with the info of the " Extra Funds Made Available", the "Funds Returned via DSSBLow" and the "Net change"
- Should add the "Inflow Core Unit Amount" card in the Total Core Unit Reserves section
- Should add the inflow/outflow card in the Total Core Unit Reserves section
- Should add the "New Core Unit Reserves" card in the Total Core Unit Reserves