### PR TITLE
[SES-268] Include/Exclude Off-Chain Reserves toggle box

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -1,34 +1,46 @@
 import styled from '@emotion/styled';
+import Checkbox from '@mui/material/Checkbox';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
 import React from 'react';
 import FundChangeCard from '../Cards/FundChangeCard';
 import SimpleStatCard from '../Cards/SimpleStatCard';
 import SectionHeader from '../SectionHeader/SectionHeader';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface CUReservesProps {
   coreUnitCode: string;
 }
 
-const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode }) => (
-  <div>
-    <SectionHeader
-      title="Total Core Unit Reserves"
-      subtitle={`On-chain and off-chain reserves accessible to the ${coreUnitCode} Core Unit.`}
-      tooltip={'pending...'}
-    />
+const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode }) => {
+  const { isLight } = useThemeContext();
 
-    <CardsContainer>
-      <SimpleStatCard date="2023-05-12T22:52:54.494Z" value={1500000} caption="Initial Core Unit Reserves" />
-      <FundChangeCard
-        netChange={-242320}
-        leftValue={305000}
-        leftText="Inflow"
-        rightValue={538320}
-        rightText="Outflow"
-      />
-      <SimpleStatCard date="2023-06-14T22:52:54.494Z" value={1266680} caption="New Core Unit Reserves" hasEqualSign />
-    </CardsContainer>
-  </div>
-);
+  return (
+    <div>
+      <HeaderContainer>
+        <SectionHeader
+          title="Total Core Unit Reserves"
+          subtitle={`On-chain and off-chain reserves accessible to the ${coreUnitCode} Core Unit.`}
+          tooltip={'pending...'}
+        />
+        <CheckContainer isLight={isLight}>
+          Include Off-Chain Reserves <Checkbox size="small" />
+        </CheckContainer>
+      </HeaderContainer>
+
+      <CardsContainer>
+        <SimpleStatCard date="2023-05-12T22:52:54.494Z" value={1500000} caption="Initial Core Unit Reserves" />
+        <FundChangeCard
+          netChange={-242320}
+          leftValue={305000}
+          leftText="Inflow"
+          rightValue={538320}
+          rightText="Outflow"
+        />
+        <SimpleStatCard date="2023-06-14T22:52:54.494Z" value={1266680} caption="New Core Unit Reserves" hasEqualSign />
+      </CardsContainer>
+    </div>
+  );
+};
 
 export default CUReserves;
 
@@ -37,3 +49,23 @@ const CardsContainer = styled.div({
   gap: 24,
   marginTop: 24,
 });
+
+const HeaderContainer = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-end',
+});
+
+const CheckContainer = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 16,
+  lineHeight: '22px',
+  color: isLight ? '#231536' : 'red',
+  display: 'flex',
+  marginRight: 2,
+  marginBottom: 1,
+  gap: 10,
+
+  '& span': {
+    padding: 0,
+  },
+}));


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Added the "Include/Exclude Off-Chain Reserves" toggle box (without functionality, just a dump UI)

# What solved
- Should add a "Include/Exclude Off-Chain Reserves" toggle box