### PR TITLE
Hidden icon cards when is mobile

### DIFF
--- a/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -289,6 +289,9 @@ const TableWrapper = styled.div({
 
 const CardsWrapper = styled.div({
   display: 'block',
+  '& .advance-table--transparency_item .advance-table--transparency-card_icon_hidden': {
+    display: 'none',
+  },
   '@media (min-width: 834px)': {
     display: 'none',
   },

--- a/src/stories/components/TransparencyCard/TransparencyCard.tsx
+++ b/src/stories/components/TransparencyCard/TransparencyCard.tsx
@@ -23,7 +23,9 @@ export const TransparencyCard: React.FC<Props> = ({ cardSpacingSize = 'large', .
       isLight={isLight}
       spacing={cardSpacingSize}
       style={{ marginTop: props.itemType === 'total' ? 24 : 0 }}
-      className="advance-table--transparency-card"
+      className={`advance-table--transparency-card ${
+        props.itemType === 'total' ? 'advance-table--transparency-card_total' : 'advance-table--transparency_item'
+      }`}
     >
       <HeaderWrapper>{props.header}</HeaderWrapper>
       {props.headers.map((header, i) => (

--- a/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
+++ b/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
@@ -44,7 +44,7 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
         title={<HeaderToolTip description={description} link={link} mipNumber={mipNumber} name={name} />}
         leaveOnChildrenMouseOut
       >
-        <ContainerInfoIcon>
+        <ContainerInfoIcon className="advance-table--transparency-card_icon_hidden">
           <IconPosition />
         </ContainerInfoIcon>
       </ExtendedCustomPopover>


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅Should hidden tooltip in the card that are not totals
✅ Should the tooltip show Month: Indicate the specific month for which the forecast and budget cap data is being presented.
✅Should the tooltip show Severity distinction: Include a high/medium/low distinction that matches the color of the bar (red, yellow, or green) to represent the severity of the forecast relative to the budget cap.
✅Should the tooltip show Percent of budget cap: Show the percentage of the budget cap forecasted to be spent for that specific month and year.
✅Should the tooltip show Absolute numbers: Display the absolute values for the forecast and budget cap, allowing users to easily compare the numbers.


# Actions
Hidden icon cards when is mobile