### PR TITLE
Add correct way get info popover

### DIFF
--- a/src/stories/components/CustomPopover/CustomPopover.tsx
+++ b/src/stories/components/CustomPopover/CustomPopover.tsx
@@ -9,7 +9,7 @@ import type { PopoverOrigin } from '@mui/material';
 import type { SxProps } from '@mui/material/styles';
 import type { PopoverPaperType, WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { CSSProperties } from 'react';
-type ArrowPosition = 'up' | 'down' | 'rightUp' | 'none';
+type ArrowPosition = 'up' | 'down' | 'none';
 type PopoverActions = {
   type: ArrowPosition;
   payload: HTMLElement | null;
@@ -48,17 +48,8 @@ const updateStatePositionPopoverReducer = (
         ...state,
         anchorEl: payload,
         popoverPosition: {
-          vertical: 'top',
+          vertical: 'bottom',
           horizontal: 'left',
-        },
-      };
-    case 'rightUp':
-      return {
-        ...state,
-        anchorEl: payload,
-        popoverPosition: {
-          vertical: 'top',
-          horizontal: 'right',
         },
       };
     case 'none': {
@@ -149,17 +140,11 @@ export const CustomPopover = ({
       let arrowPosition = 'up' as ArrowPosition;
       if (refElementShowPopover) {
         const elementPosition = refElementShowPopover?.current?.getBoundingClientRect().top;
-        const elementPositionRight = refElementShowPopover?.current?.getBoundingClientRect().right;
         const windowPosition = window.innerHeight;
-        const windowPositionRight = window.innerWidth;
         const distance = windowPosition - (elementPosition || 0);
-        const distanceRight = windowPositionRight - (elementPositionRight || 0);
         // TODO: Change hard code to real height of Popover
         if (distance < 285) {
           arrowPosition = 'down';
-        }
-        if (distanceRight < 305) {
-          arrowPosition = 'rightUp';
         }
       }
       const wrapper = getPageWrapper();

--- a/src/stories/components/CustomPopover/CustomPopover.tsx
+++ b/src/stories/components/CustomPopover/CustomPopover.tsx
@@ -101,6 +101,8 @@ interface CustomPopoverProps extends React.PropsWithChildren {
   closeOnClick?: boolean;
   onClose?: () => void;
   handleNotSpaceRight?: (value: string) => void;
+  distanceBottom?: number;
+  distanceRight?: number;
 }
 
 export const PopoverPaperStyle = (isLight: boolean) => ({
@@ -131,12 +133,15 @@ export const CustomPopover = ({
   handleShowPopoverWhenNotSpace,
   handleNotSpaceRight,
   closeOnClick = true,
+  distanceBottom = 285,
+  distanceRight = 305,
   onClose,
   ...props
 }: CustomPopoverProps) => {
   const [state, dispatch] = useReducer(updateStatePositionPopoverReducer, InitialState);
   const { isLight } = useThemeContext();
   const refPopoverComponent = useRef<HTMLDivElement>(null);
+
   const [leaveTimeout, setLeaveTimeout] = React.useState<NodeJS.Timeout>();
   const isArrowPositionUp =
     isEqual(state.popoverPosition, ArrowUp) ||
@@ -173,13 +178,13 @@ export const CustomPopover = ({
         const distance = window.innerHeight - (elementPosition || 0);
 
         // TODO: Change hard code to real height of Popover
-        if (distance < 285) {
+        if (distance < distanceBottom) {
           arrowPosition = 'down';
         }
-        if (elementPositionRight < 305) {
+        if (elementPositionRight < distanceRight) {
           arrowPosition = 'arrowUp';
         }
-        if (distance < 285 && elementPositionRight < 305) {
+        if (distance < distanceBottom && elementPositionRight < distanceRight) {
           arrowPosition = 'arrowDown';
         }
       }
@@ -195,7 +200,15 @@ export const CustomPopover = ({
       handleShowPopoverWhenNotSpace?.(arrowPosition === 'up');
       handleNotSpaceRight?.(arrowPosition);
     },
-    [leaveTimeout, refElementShowPopover, handleShowPopoverWhenNotSpace, handleNotSpaceRight, handlePopoverClose]
+    [
+      leaveTimeout,
+      refElementShowPopover,
+      handleShowPopoverWhenNotSpace,
+      handleNotSpaceRight,
+      distanceBottom,
+      distanceRight,
+      handlePopoverClose,
+    ]
   );
 
   return (

--- a/src/stories/components/CustomPopover/CustomPopover.tsx
+++ b/src/stories/components/CustomPopover/CustomPopover.tsx
@@ -9,7 +9,7 @@ import type { PopoverOrigin } from '@mui/material';
 import type { SxProps } from '@mui/material/styles';
 import type { PopoverPaperType, WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { CSSProperties } from 'react';
-type ArrowPosition = 'up' | 'down' | 'none';
+type ArrowPosition = 'up' | 'down' | 'arrowUp' | 'arrowDown' | 'none';
 type PopoverActions = {
   type: ArrowPosition;
   payload: HTMLElement | null;
@@ -52,6 +52,24 @@ const updateStatePositionPopoverReducer = (
           horizontal: 'left',
         },
       };
+    case 'arrowUp':
+      return {
+        ...state,
+        anchorEl: payload,
+        popoverPosition: {
+          vertical: 'top',
+          horizontal: 'right',
+        },
+      };
+    case 'arrowDown':
+      return {
+        ...state,
+        anchorEl: payload,
+        popoverPosition: {
+          vertical: 'bottom',
+          horizontal: 'right',
+        },
+      };
     case 'none': {
       return {
         ...state,
@@ -82,6 +100,7 @@ interface CustomPopoverProps extends React.PropsWithChildren {
   refElementShowPopover?: React.RefObject<HTMLDivElement>;
   closeOnClick?: boolean;
   onClose?: () => void;
+  handleNotSpaceRight?: (value: string) => void;
 }
 
 export const PopoverPaperStyle = (isLight: boolean) => ({
@@ -110,6 +129,7 @@ export const CustomPopover = ({
   className,
   refElementShowPopover,
   handleShowPopoverWhenNotSpace,
+  handleNotSpaceRight,
   closeOnClick = true,
   onClose,
   ...props
@@ -118,7 +138,12 @@ export const CustomPopover = ({
   const { isLight } = useThemeContext();
   const refPopoverComponent = useRef<HTMLDivElement>(null);
   const [leaveTimeout, setLeaveTimeout] = React.useState<NodeJS.Timeout>();
-  const isArrowPositionUp = isEqual(state.popoverPosition, ArrowUp);
+  const isArrowPositionUp =
+    isEqual(state.popoverPosition, ArrowUp) ||
+    isEqual(state.popoverPosition, {
+      vertical: 'top',
+      horizontal: 'right',
+    });
   const handlePopoverClose = useCallback(() => {
     dispatch({
       type: 'none',
@@ -138,26 +163,39 @@ export const CustomPopover = ({
       clearTimeout(leaveTimeout);
 
       let arrowPosition = 'up' as ArrowPosition;
+      let elementPositionRight;
       if (refElementShowPopover) {
         const elementPosition = refElementShowPopover?.current?.getBoundingClientRect().top;
-        const windowPosition = window.innerHeight;
-        const distance = windowPosition - (elementPosition || 0);
+
+        const position = refElementShowPopover?.current?.getBoundingClientRect().right;
+
+        elementPositionRight = window.innerWidth - (position || 0);
+        const distance = window.innerHeight - (elementPosition || 0);
+
         // TODO: Change hard code to real height of Popover
         if (distance < 285) {
           arrowPosition = 'down';
+        }
+        if (elementPositionRight < 305) {
+          arrowPosition = 'arrowUp';
+        }
+        if (distance < 285 && elementPositionRight < 305) {
+          arrowPosition = 'arrowDown';
         }
       }
       const wrapper = getPageWrapper();
       if (wrapper) {
         wrapper.onscroll = handlePopoverClose;
       }
+
       dispatch({
         type: arrowPosition,
         payload: event.currentTarget,
       });
       handleShowPopoverWhenNotSpace?.(arrowPosition === 'up');
+      handleNotSpaceRight?.(arrowPosition);
     },
-    [leaveTimeout, refElementShowPopover, handleShowPopoverWhenNotSpace, handlePopoverClose]
+    [leaveTimeout, refElementShowPopover, handleShowPopoverWhenNotSpace, handleNotSpaceRight, handlePopoverClose]
   );
 
   return (
@@ -205,6 +243,7 @@ export const CustomPopover = ({
           style={{
             borderRadius: '6px',
             pointerEvents: 'all',
+
             ...props.popupStyle,
           }}
         >

--- a/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
+++ b/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
@@ -27,9 +27,25 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
   const { isLight } = useThemeContext();
 
   const [marginTopPopoverPosition, setMarginTopPopoverPosition] = useState<boolean>(false);
+  const [hasNotSpaceRight, setHasNotSpaceRight] = useState<boolean>(false);
+  const [hasNotDownRight, setHasNotDownRight] = useState<boolean>(false);
   const handleShowPopoverWhenNotSpace = (value: boolean) => {
     setMarginTopPopoverPosition(value);
   };
+  const handleNotSpaceRight = (value: string) => {
+    if (value === 'arrowUp') {
+      setHasNotSpaceRight(!hasNotSpaceRight);
+    }
+    if (value === 'arrowDown') {
+      setHasNotDownRight(!hasNotDownRight);
+    }
+  };
+  const handleClose = () => {
+    setHasNotSpaceRight(false);
+    setHasNotDownRight(false);
+  };
+
+  console.log({ hasNotSpaceRight });
 
   const isMobileResolution = useMediaQuery(lightTheme.breakpoints.down('table_834'));
   const { lockScroll, unlockScroll } = useScrollLock();
@@ -63,18 +79,15 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
     <Container>
       <Title style={{ marginRight: 8 }}>{title}</Title>
       <ExtendedCustomPopover
-        hasNotSpaceRight={true}
+        hasNotDownRight={hasNotDownRight}
+        marginTopPopoverPosition={marginTopPopoverPosition}
+        onClose={handleClose}
+        alignArrow={hasNotSpaceRight || hasNotDownRight ? 'right' : undefined}
+        handleNotSpaceRight={handleNotSpaceRight}
+        hasNotSpaceRight={hasNotSpaceRight}
         handleShowPopoverWhenNotSpace={handleShowPopoverWhenNotSpace}
         refElementShowPopover={refElementShowPopover}
-        sxProps={{
-          '.MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded': {
-            overflowX: 'unset',
-            overflowY: 'unset',
-            marginTop: marginTopPopoverPosition ? 2 : -3,
-          },
-        }}
         widthArrow
-        hasSpacePositionArrow={marginTopPopoverPosition}
         id="information"
         popupStyle={{
           padding: 10,
@@ -105,24 +118,26 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
 
 export default HeaderWithIcon;
 
-const ExtendedCustomPopover = styled(CustomPopover)<{ hasSpacePositionArrow?: boolean; hasNotSpaceRight?: boolean }>(
-  ({ hasSpacePositionArrow, hasNotSpaceRight }) => ({
-    '& > div': {
-      [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-        marginLeft: -45,
-        marginTop: 16,
-      },
-      [lightTheme.breakpoints.up('desktop_1194')]: {
-        marginLeft: -42,
-        ...(hasNotSpaceRight && {
-          marginRight: -348,
-          marginTop: 40,
-        }),
-        marginTop: hasSpacePositionArrow ? -18 : 18,
-      },
-    },
-  })
-);
+const ExtendedCustomPopover = styled(CustomPopover)<{
+  hasNotDownRight: boolean;
+  hasNotSpaceRight?: boolean;
+  marginTopPopoverPosition?: boolean;
+}>(({ hasNotSpaceRight, marginTopPopoverPosition, hasNotDownRight }) => ({
+  '.MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded': {
+    overflowX: 'unset',
+    overflowY: 'unset',
+    marginLeft: -45,
+    marginTop: marginTopPopoverPosition ? 16 : -25,
+    ...(hasNotSpaceRight && {
+      marginLeft: 63,
+      marginTop: 15,
+    }),
+    ...(hasNotDownRight && {
+      marginLeft: 63,
+      marginTop: -20,
+    }),
+  },
+}));
 
 export const ContainerInfoIcon = styled.div({
   display: 'flex',

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
@@ -14,11 +14,11 @@ import {
   getForecastSumForMonths,
   getForecastSumOfMonthsOnWallet,
   getTotalQuarterlyBudgetCapOnBudgetStatement,
-  getTransferRequestTargetBalanceColumn,
   getWalletMonthlyBudget,
 } from '../../utils/budgetStatementsUtils';
 
 import { FORECAST_BREAKDOWN_QUERY_PARAM } from '../../utils/constants';
+import { getTransferRequestSource } from '../../utils/forecastHelper';
 import { getBreakdownItemsForWallet, getForecastBreakdownColumns } from '../../utils/forecastTableHelpers';
 import HeaderWithIcon from '../HeaderWithIcon/HeaderWithIcon';
 import ProgressiveIndicator from './ProgresiveIndicator';
@@ -74,7 +74,7 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
   }, [selectedBreakdown, headerIds]);
 
   const mainTableColumns: InnerTableColumn[] = useMemo(() => {
-    const headersValuesToolTip = getTransferRequestTargetBalanceColumn(wallets[0]);
+    const source = getTransferRequestSource(wallets[0]);
     return [
       {
         header: 'Wallet',
@@ -88,10 +88,10 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
         header: (
           <HeaderWithIcon
             description="1 Month Budget Cap"
-            link={headersValuesToolTip.target?.source.url}
-            mipNumber={headersValuesToolTip.target?.source.code}
-            title={firstMonth.toFormat('MMMM')}
-            name={headersValuesToolTip.target?.source?.title}
+            link={source.url || ''}
+            mipNumber={source.code || ''}
+            title={firstMonth.toFormat('MMMM') || ''}
+            name={source.title || ''}
           />
         ),
 
@@ -102,10 +102,10 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
         header: (
           <HeaderWithIcon
             description="1 Month Budget Cap"
-            link={headersValuesToolTip.target?.source.url}
-            mipNumber={headersValuesToolTip.target?.source.code}
+            link={source.url}
+            mipNumber={source.code}
             title={secondMonth.toFormat('MMMM')}
-            name={headersValuesToolTip.target?.source?.title}
+            name={source?.title}
           />
         ),
 
@@ -116,10 +116,10 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
         header: (
           <HeaderWithIcon
             description="1 Month Budget Cap"
-            link={headersValuesToolTip.target?.source.url}
-            mipNumber={headersValuesToolTip.target?.source.code}
-            title={thirdMonth.toFormat('MMMM')}
-            name={headersValuesToolTip.target?.source.title}
+            link={source.url}
+            mipNumber={source.code}
+            title={secondMonth.toFormat('MMMM')}
+            name={source.title}
           />
         ),
         type: 'custom',
@@ -138,10 +138,10 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
         header: (
           <HeaderWithIcon
             description="3 Month Budget Caps"
-            link={headersValuesToolTip.target?.source.url}
-            mipNumber={headersValuesToolTip.target?.source.code}
+            link={source.url}
+            mipNumber={source.code}
             title="Totals"
-            name={headersValuesToolTip.target?.source.title}
+            name={source?.title}
           />
         ),
         type: 'custom',
@@ -154,7 +154,7 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
         hidden: true,
       },
     ];
-  }, [firstMonth, secondMonth, thirdMonth, wallets]);
+  }, [firstMonth, secondMonth, wallets]);
 
   const mainTableItems = useMemo(() => {
     const result: InnerTableRow[] = [];

--- a/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
+++ b/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
@@ -1,5 +1,6 @@
 import { ExpenditureLevel } from '@ses/core/enums/expenditureLevelEnum';
 import { percentageRespectTo } from '@ses/core/utils/math';
+import type { BudgetStatementWalletDto, SourceDto } from '@ses/core/models/dto/coreUnitDTO';
 const COLORS_BAR = {
   COLOR_GREEN: '#B6EDE7',
   COLOR_GREEN_DARK: '#06554C',
@@ -121,10 +122,20 @@ export const getBorderColor = (value: number, valueRelative: number, isLight: bo
   }
   return color;
 };
-
 export const getPercentFullBar = (forecast: number, budgetCap: number): number => {
   if (forecast && !budgetCap) return 100;
   if (budgetCap && !forecast) return 0;
   const percent = percentageRespectTo(forecast, budgetCap);
   return percent;
+};
+
+export const getTransferRequestSource = (wallet: BudgetStatementWalletDto): SourceDto => {
+  const resultDefault = {
+    code: '',
+    url: '',
+    title: '',
+  } as SourceDto;
+  const firstElementWithData = wallet?.budgetStatementTransferRequest?.find((item) => item.target.source);
+  if (!firstElementWithData) return resultDefault;
+  return firstElementWithData.target.source;
 };


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅Should the tooltip contain a link to the relevant MIP (Maker Improvement Proposal)
✅Should all other forecast numbers within the forecast breakdown (non-totals), we will also include The budget cap for the specific month.
✅Should all other forecast numbers within the forecast breakdown (non-totals), we will also include: A dotted line that expresses 100% of the budget cap reached.**PR**https://github.com/makerdao-ses/ecosystem-dashboard/pull/778

# Actions
Add the correct way to get info tooltip

Add hard code for the size tooltip
Add size as props