### PR TITLE
Add dark mode and fix header

### DIFF
--- a/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
+++ b/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
@@ -23,6 +23,8 @@ interface Props {
 
 const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, name }) => {
   const refElementShowPopover = useRef<HTMLDivElement>(null);
+  const leaveTimeoutRef = useRef<NodeJS.Timeout>();
+
   const [isOpen, setIsOpen] = useState(false);
   const { isLight } = useThemeContext();
 
@@ -41,11 +43,15 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
     }
   };
   const handleClose = () => {
-    setHasNotSpaceRight(false);
-    setHasNotDownRight(false);
+    clearTimeout(leaveTimeoutRef.current);
+    leaveTimeoutRef.current = setTimeout(() => {
+      setHasNotSpaceRight(false);
+      setHasNotDownRight(false);
+    }, 400);
   };
-
-  console.log({ hasNotSpaceRight });
+  useEffect(() => {
+    clearTimeout(leaveTimeoutRef.current);
+  }, []);
 
   const isMobileResolution = useMediaQuery(lightTheme.breakpoints.down('table_834'));
   const { lockScroll, unlockScroll } = useScrollLock();

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
@@ -118,7 +118,7 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
             description="1 Month Budget Cap"
             link={source.url}
             mipNumber={source.code}
-            title={secondMonth.toFormat('MMMM')}
+            title={thirdMonth.toFormat('MMMM')}
             name={source.title}
           />
         ),
@@ -154,7 +154,7 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
         hidden: true,
       },
     ];
-  }, [firstMonth, secondMonth, wallets]);
+  }, [firstMonth, secondMonth, thirdMonth, wallets]);
 
   const mainTableItems = useMemo(() => {
     const result: InnerTableRow[] = [];

--- a/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
+++ b/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
@@ -4,14 +4,17 @@ import type { BudgetStatementWalletDto, SourceDto } from '@ses/core/models/dto/c
 const COLORS_BAR = {
   COLOR_GREEN: '#B6EDE7',
   COLOR_GREEN_DARK: '#06554C',
+  COLOR_GREEN_DARK_HOVER: '#6EDBD0',
   COLOR_GREEN_HOVER: '#1AAB9B',
   COLOR_GRAY: '#D1DEE6',
   COLOR_GRAY_STRONG: '#9FAFB9',
   COLOR_YELLOW: '#FEDB88',
   COLOR_YELLOW_DARK: '#FDC134',
   COLOR_YELLOW_HOVER: '#FDC134',
+  COLOR_YELLOW_DARK_HOVER: '#FEDB88',
   COLOR_RED: '#F77249',
   COLOR_RED_DARK: '#EB4714',
+  COLOR_RED_DARK_HOVER: '#F99374',
   COLOR_RED_HOVER: '#EB4714',
 };
 
@@ -43,7 +46,7 @@ export const getProgressiveBarColor = (
         ? COLORS_BAR.COLOR_GREEN_HOVER
         : COLORS_BAR.COLOR_GREEN
       : isHover
-      ? 'red'
+      ? COLORS_BAR.COLOR_GREEN_DARK_HOVER
       : COLORS_BAR.COLOR_GREEN_DARK;
   }
 
@@ -53,7 +56,7 @@ export const getProgressiveBarColor = (
         ? COLORS_BAR.COLOR_YELLOW_HOVER
         : COLORS_BAR.COLOR_YELLOW
       : isHover
-      ? 'red'
+      ? COLORS_BAR.COLOR_YELLOW_DARK_HOVER
       : COLORS_BAR.COLOR_YELLOW_DARK;
   }
 
@@ -63,7 +66,7 @@ export const getProgressiveBarColor = (
         ? COLORS_BAR.COLOR_RED_HOVER
         : COLORS_BAR.COLOR_RED
       : isHover
-      ? 'red'
+      ? COLORS_BAR.COLOR_RED_DARK_HOVER
       : COLORS_BAR.COLOR_RED_DARK;
   }
   return color;


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅Should show a tooltip for the budget caps beside {Month} header column, when the user hovers over the icon
✅Should the month columns should display the next 3 months after the month that you are in
✅ Should move the dotted line to the left of the horizontal bar graph to make it clear that the forecast is more than 100% of the budget cap.
✅Should show the correct values forecast and budget cap, for the new component

# Actions
Add dark mode and fix the header
Add delay for close popover
