### PR TITLE
Add center arrow when is mobile and not real device

### DIFF
--- a/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
+++ b/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
@@ -24,8 +24,9 @@ interface Props {
 const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, name }) => {
   const refElementShowPopover = useRef<HTMLDivElement>(null);
   const leaveTimeoutRef = useRef<NodeJS.Timeout>();
-
   const [isOpen, setIsOpen] = useState(false);
+  const isMobileResolution = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+  const { lockScroll, unlockScroll } = useScrollLock();
   const { isLight } = useThemeContext();
 
   const [marginTopPopoverPosition, setMarginTopPopoverPosition] = useState<boolean>(false);
@@ -52,9 +53,6 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
   useEffect(() => {
     clearTimeout(leaveTimeoutRef.current);
   }, []);
-
-  const isMobileResolution = useMediaQuery(lightTheme.breakpoints.down('table_834'));
-  const { lockScroll, unlockScroll } = useScrollLock();
 
   let md;
   if (typeof window !== 'undefined') {
@@ -83,28 +81,84 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
   }, [isOpen]);
   return (
     <Container>
-      <Title style={{ marginRight: 8 }}>{title}</Title>
-      <ExtendedCustomPopover
-        hasNotDownRight={hasNotDownRight}
-        marginTopPopoverPosition={marginTopPopoverPosition}
-        onClose={handleClose}
-        alignArrow={hasNotSpaceRight || hasNotDownRight ? 'right' : undefined}
-        handleNotSpaceRight={handleNotSpaceRight}
-        hasNotSpaceRight={hasNotSpaceRight}
-        handleShowPopoverWhenNotSpace={handleShowPopoverWhenNotSpace}
-        refElementShowPopover={refElementShowPopover}
-        widthArrow
-        id="information"
-        popupStyle={{
-          padding: 10,
-        }}
-        title={<HeaderToolTip description={description} link={link} mipNumber={mipNumber} name={name} />}
-        leaveOnChildrenMouseOut
-      >
-        <ContainerInfoIcon className="advance-table--transparency-card_icon_hidden" onClick={handleOnClick}>
-          <IconPosition />
-        </ContainerInfoIcon>
-      </ExtendedCustomPopover>
+      {!isMobileResolution && (
+        <>
+          <Title style={{ marginRight: 8 }}>{title}</Title>
+          <ExtendedCustomPopover
+            hasNotDownRight={hasNotDownRight}
+            marginTopPopoverPosition={marginTopPopoverPosition}
+            onClose={handleClose}
+            alignArrow={hasNotSpaceRight || hasNotDownRight ? 'right' : undefined}
+            handleNotSpaceRight={handleNotSpaceRight}
+            hasNotSpaceRight={hasNotSpaceRight}
+            handleShowPopoverWhenNotSpace={handleShowPopoverWhenNotSpace}
+            refElementShowPopover={refElementShowPopover}
+            widthArrow
+            id="information"
+            popupStyle={{
+              padding: 10,
+            }}
+            title={<HeaderToolTip description={description} link={link} mipNumber={mipNumber} name={name} />}
+            leaveOnChildrenMouseOut
+          >
+            <ContainerInfoIcon className="advance-table--transparency-card_icon_hidden" onClick={handleOnClick}>
+              <IconPosition />
+            </ContainerInfoIcon>
+          </ExtendedCustomPopover>
+        </>
+      )}
+      {isMobileResolution && !isMobileDevice && (
+        <>
+          <Title style={{ marginRight: 8 }}>{title}</Title>
+          <ExtendedCustomPopoverMobile
+            hasNotDownRight={hasNotDownRight}
+            marginTopPopoverPosition={marginTopPopoverPosition}
+            onClose={handleClose}
+            alignArrow={'center'}
+            handleNotSpaceRight={handleNotSpaceRight}
+            hasNotSpaceRight={hasNotSpaceRight}
+            handleShowPopoverWhenNotSpace={handleShowPopoverWhenNotSpace}
+            refElementShowPopover={refElementShowPopover}
+            widthArrow
+            id="information"
+            popupStyle={{
+              padding: 10,
+            }}
+            title={<HeaderToolTip description={description} link={link} mipNumber={mipNumber} name={name} />}
+            leaveOnChildrenMouseOut
+          >
+            <ContainerInfoIcon className="advance-table--transparency-card_icon_hidden" onClick={handleOnClick}>
+              <IconPosition />
+            </ContainerInfoIcon>
+          </ExtendedCustomPopoverMobile>
+        </>
+      )}
+      {isMobileResolution && isMobileDevice && (
+        <>
+          <Title style={{ marginRight: 8 }}>{title}</Title>
+          <ExtendedCustomPopover
+            hasNotDownRight={hasNotDownRight}
+            marginTopPopoverPosition={marginTopPopoverPosition}
+            onClose={handleClose}
+            alignArrow={hasNotSpaceRight || hasNotDownRight ? 'right' : undefined}
+            handleNotSpaceRight={handleNotSpaceRight}
+            hasNotSpaceRight={hasNotSpaceRight}
+            handleShowPopoverWhenNotSpace={handleShowPopoverWhenNotSpace}
+            refElementShowPopover={refElementShowPopover}
+            widthArrow
+            id="information"
+            popupStyle={{
+              padding: 10,
+            }}
+            title={<HeaderToolTip description={description} link={link} mipNumber={mipNumber} name={name} />}
+            leaveOnChildrenMouseOut
+          >
+            <ContainerInfoIcon className="advance-table--transparency-card_icon_hidden" onClick={handleOnClick}>
+              <IconPosition />
+            </ContainerInfoIcon>
+          </ExtendedCustomPopover>
+        </>
+      )}
       {isMobileResolution && isOpen && isMobileDevice && (
         <ModalSheet>
           <ModalSheetValueContent
@@ -144,6 +198,15 @@ const ExtendedCustomPopover = styled(CustomPopover)<{
     }),
   },
 }));
+
+const ExtendedCustomPopoverMobile = styled(ExtendedCustomPopover)({
+  '.MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded': {
+    [lightTheme.breakpoints.down('table_834')]: {
+      left: '0px!important',
+      marginLeft: -4,
+    },
+  },
+});
 
 export const ContainerInfoIcon = styled.div({
   display: 'flex',


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅Should show green bars: Least important forecasts should be displayed as green bars with approximately 50% opacity. These bars represent situations where the forecast is well below the budget cap.(percent > 0 && percent <= 90)
✅Should show: When users hover over the dotted line of each forecast/budget cap bar, a tooltip should appear providing relevant information about that specific bar.
✅Should Add responsive and dark mode for the view


# Actions
Add a center arrow when is mobile and not a real device