### PR TITLE
[SES-268] Replace the table by expandable cards

### DIFF
--- a/src/stories/components/AdvanceTable/AdvanceTable.tsx
+++ b/src/stories/components/AdvanceTable/AdvanceTable.tsx
@@ -50,6 +50,18 @@ const AdvanceTable: React.FC<TableProps> = ({
           return null;
         }
 
+        // add the colIndex and rowIndex
+        extendedRow = {
+          ...extendedRow,
+          cells: [
+            ...extendedRow.cells.map((cell, colIndex) => ({
+              ...cell,
+              rowIndex,
+              colIndex,
+            })),
+          ],
+        };
+
         return <DefaultCard cardProps={extendedRow.rowToCardConfig} row={extendedRow} key={`card-${rowIndex}`} />;
       })}
     </div>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
@@ -1,5 +1,6 @@
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
-import ExpensesComparison, { EXPENSES_COMPARISON_TABLE_HEADER } from './ExpensesComparison';
+import { buildRow } from '../../useAccountsSnapshot';
+import ExpensesComparison from './ExpensesComparison';
 import type { RowProps } from '@ses/components/AdvanceTable/types';
 import type { ComponentMeta } from '@storybook/react';
 import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
@@ -16,172 +17,10 @@ export default {
 } as ComponentMeta<typeof ExpensesComparison>;
 
 const rows = [
-  {
-    render: ({ children }) => <tr style={{ background: 'rgba(236, 239, 249, 0.5)' }}>{children}</tr>,
-    cellPadding: {
-      table_834: '18.5px 8px',
-      desktop_1194: '17.4px 16px',
-    },
-    cells: [
-      {
-        value: 'MAY-2023',
-        defaultRenderer: 'boldText',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
-        isCardHeader: true,
-      },
-      {
-        value: '221,503.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
-      },
-      {
-        value: '240,000.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
-      },
-      {
-        value: '8.35%',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
-      },
-      {
-        value: '221,504.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
-      },
-      {
-        value: '0.00%',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
-      },
-    ],
-  },
-  {
-    cellPadding: {
-      table_834: '18.5px 8px',
-      desktop_1194: '17.4px 16px',
-    },
-    cells: [
-      {
-        value: 'APR-2023',
-        defaultRenderer: 'boldText',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
-        isCardHeader: true,
-      },
-      {
-        value: '171,503.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
-      },
-      {
-        value: '170,000.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
-      },
-      {
-        value: '-0.88%',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
-      },
-      {
-        value: '171,500,00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
-      },
-      {
-        value: '0.00%',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
-      },
-    ],
-  },
-  {
-    cellPadding: {
-      table_834: '18.5px 8px',
-      desktop_1194: '17.4px 16px',
-    },
-    cells: [
-      {
-        value: 'MAR-2023',
-        defaultRenderer: 'boldText',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
-        isCardHeader: true,
-      },
-      {
-        value: '288,503.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
-      },
-      {
-        value: '280,000.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
-      },
-      {
-        value: '-2,95%',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
-      },
-      {
-        value: '288,300.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
-      },
-      {
-        value: '-0.07%',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
-      },
-    ],
-  },
-  {
-    cellPadding: {
-      table_834: '17px 8px 18.5px',
-      desktop_1194: '17.4px 16px',
-    },
-    cells: [
-      {
-        value: 'Totals',
-        defaultRenderer: 'boldText',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
-        isCardHeader: true,
-      },
-      {
-        value: '681,509.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
-      },
-      {
-        value: '681,509.00 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
-      },
-      {
-        value: '1.25%',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
-      },
-      {
-        value: '681,304.25 DAI',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
-      },
-      {
-        value: '-0.03%',
-        defaultRenderer: 'number',
-        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
-      },
-    ],
-    extraProps: {
-      isBold: true,
-    },
-    border: {
-      top: true,
-    },
-    rowToCardConfig: {
-      type: 'total',
-    },
-  },
+  buildRow(['MAY-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%', '221,504.00 DAI', '0.00%'], true, false),
+  buildRow(['APR-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%', '171,500,00 DAI', '0.00%'], false, false),
+  buildRow(['MAR-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%', '288,300.00 DAI', '-0.07%'], false, false),
+  buildRow(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%', '681,304.25 DAI', '-0.03%'], false, true),
 ] as RowProps[];
 
 const variantsArgs = [{}];
@@ -191,6 +30,18 @@ export const [[LightMode, DarkMode]] = createThemeModeVariants(() => <ExpensesCo
 LightMode.parameters = {
   figma: {
     component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18675%3A213452',
+        options: {
+          componentStyle: {
+            width: 343,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
       834: {
         component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18595%3A254055',
         options: {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparisonRowCard/ExpensesComparisonRowCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparisonRowCard/ExpensesComparisonRowCard.tsx
@@ -1,0 +1,216 @@
+import styled from '@emotion/styled';
+import MuiAccordion from '@mui/material/Accordion';
+import MuiAccordionDetails from '@mui/material/AccordionDetails';
+import MuiAccordionSummary from '@mui/material/AccordionSummary';
+import BasicTHCell from '@ses/components/AdvanceTable/BuiltIn/Cells/BasicTHCell';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import React from 'react';
+import type { AccordionProps } from '@mui/material/Accordion';
+import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
+import type { GenericCell, RowProps } from '@ses/components/AdvanceTable/types';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface ExpensesComparisonRowCardProps {
+  row: RowProps;
+  expandable?: boolean;
+}
+
+const ExpensesComparisonRowCard: React.FC<ExpensesComparisonRowCardProps> = ({ row, expandable = true }) => {
+  const { isLight } = useThemeContext();
+  const [expanded, setExpanded] = React.useState<boolean>(!expandable);
+
+  return (
+    <Container>
+      <Accordion expanded={expanded} onChange={() => expandable && setExpanded(!expanded)}>
+        <Summary isExpandable={expandable}>
+          {row.cells[0].value === 'Totals' ? (
+            <Totals isLight={isLight}>3 Month Totals</Totals>
+          ) : (
+            <MonthHeader isLight={isLight}>{row.cells[0].value as React.ReactNode}</MonthHeader>
+          )}
+
+          {expandable &&
+            (expanded ? (
+              <svg width="12" height="2" viewBox="0 0 12 2" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M5.25729 1.70945C5.25729 1.70945 5.58837 1.70945 5.99678 1.70945C6.40521 1.70945 6.73628 1.70945 6.73628 1.70945V1.71373H10.4338C10.8422 1.71373 11.1733 1.39394 11.1733 0.999442C11.1733 0.604956 10.8422 0.285156 10.4338 0.285156H6.73628V0.289442C6.73628 0.289442 6.40521 0.289442 5.99678 0.289442C5.58837 0.289442 5.25729 0.289442 5.25729 0.289442V0.285156H1.55981C1.1514 0.285156 0.820312 0.604956 0.820312 0.999442C0.820312 1.39394 1.1514 1.71373 1.55981 1.71373H5.25729V1.70945Z"
+                  fill={isLight ? '#546978' : 'red'}
+                />
+              </svg>
+            ) : (
+              <svg width="12" height="10" viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M5.25729 9.28571C5.25729 9.68021 5.58837 10 5.99678 10C6.40521 10 6.73628 9.68021 6.73628 9.28571V5.71429H10.4338C10.8422 5.71429 11.1733 5.3945 11.1733 5C11.1733 4.60551 10.8422 4.28571 10.4338 4.28571H6.73628V0.714286C6.73628 0.3198 6.40521 0 5.99678 0C5.58837 0 5.25729 0.3198 5.25729 0.714286V4.28571H1.55981C1.1514 4.28571 0.820312 4.60551 0.820312 5C0.820312 5.3945 1.1514 5.71429 1.55981 5.71429H5.25729V9.28571Z"
+                  fill={isLight ? '#546978' : 'red'}
+                />
+              </svg>
+            ))}
+        </Summary>
+        <AccordionDetails>
+          <Reported>
+            <Item>
+              <BasicTHCell
+                as="div"
+                cell={{
+                  value: 'Reported actuals',
+                  cellPadding: 0,
+                }}
+              />
+              <Value isLight={isLight}>{row.cells[1].value as React.ReactNode}</Value>
+            </Item>
+            <NetExpenseTransactions isLight={isLight}>Net Expense Transactions</NetExpenseTransactions>
+          </Reported>
+          <BorderedContainer isLight={isLight}>
+            {/* on chain only */}
+            <Item>
+              <BasicTHCell
+                as="div"
+                cell={{
+                  ...(row.cells[2].inherit ?? ({} as GenericCell)),
+                  cellPadding: 0,
+                }}
+              />
+              <Value isLight={isLight}>{row.cells[2].value as React.ReactNode}</Value>
+            </Item>
+            {/* difference */}
+            <Item marginTop={21}>
+              <BasicTHCell
+                as="div"
+                cell={{
+                  ...(row.cells[3].inherit ?? ({} as GenericCell)),
+                  border: undefined,
+                  cellPadding: 0,
+                }}
+              />
+              <Value isLight={isLight}>{row.cells[3].value as React.ReactNode}</Value>
+            </Item>
+            <HorizontalDivider isLight={isLight} />
+            {/* including off-chain */}
+            <Item>
+              <BasicTHCell
+                as="div"
+                cell={{
+                  ...(row.cells[4].inherit ?? ({} as GenericCell)),
+                  cellPadding: 0,
+                }}
+              />
+              <Value isLight={isLight}>{row.cells[4].value as React.ReactNode}</Value>
+            </Item>
+            {/* difference */}
+            <Item marginTop={20}>
+              <BasicTHCell
+                as="div"
+                cell={{
+                  ...(row.cells[5].inherit ?? ({} as GenericCell)),
+                  cellPadding: 0,
+                }}
+              />
+              <Value isLight={isLight}>{row.cells[5].value as React.ReactNode}</Value>
+            </Item>
+          </BorderedContainer>
+        </AccordionDetails>
+      </Accordion>
+    </Container>
+  );
+};
+
+export default ExpensesComparisonRowCard;
+
+const Container = styled.div({
+  marginBottom: 8,
+});
+
+const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters elevation={0} square {...props} />)({
+  borderRadius: '6px',
+  boxShadow: '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)',
+});
+
+const Summary = styled((props: AccordionSummaryProps) => <MuiAccordionSummary {...props} />)<{ isExpandable: boolean }>(
+  ({ isExpandable }) => ({
+    minHeight: 'auto',
+
+    '&[aria-expanded="true"]': {
+      padding: isExpandable ? '8.5px 10px 8.5px 16px' : 16,
+    },
+
+    '&[aria-expanded="false"]': {
+      padding: '8.5px 10px 8.5px 16px',
+    },
+
+    '& .MuiAccordionSummary-content': {
+      margin: 0,
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+  })
+);
+
+const AccordionDetails = styled(MuiAccordionDetails)(() => ({
+  padding: '0 0 14px',
+}));
+
+const Totals = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 700,
+  fontSize: 14,
+  lineHeight: '17px',
+  color: isLight ? '#231536' : 'red',
+}));
+
+const MonthHeader = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 600,
+  fontSize: 12,
+  lineHeight: '15px',
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  color: isLight ? '#434358' : 'red',
+}));
+
+const Reported = styled.div({
+  margin: '8px 8px 16px',
+});
+
+const Item = styled.div<{ marginTop?: number }>(({ marginTop = 0 }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '0 8px',
+  marginTop,
+}));
+
+const Value = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 700,
+  fontSize: 14,
+  lineHeight: '17px',
+  letterSpacing: 0.3,
+  fontFeatureSettings: "'tnum' on, 'lnum' on",
+  color: isLight ? '#231536' : 'red',
+}));
+
+const NetExpenseTransactions = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 600,
+  fontSize: 14,
+  lineHeight: '17px',
+  textAlign: 'center',
+  color: isLight ? '#231536' : 'red',
+  marginTop: 16,
+}));
+
+const BorderedContainer = styled.div<WithIsLight>(({ isLight }) => ({
+  margin: '0 8px',
+  padding: '12px 0px 7px',
+  display: 'flex',
+  flexDirection: 'column',
+  borderRadius: 6,
+  border: `1px solid ${isLight ? '#D4D9E1' : 'red'}`,
+
+  '& > div': {
+    // items
+    padding: '0 7px',
+  },
+}));
+
+const HorizontalDivider = styled.div<WithIsLight>(({ isLight }) => ({
+  width: '100%',
+  borderTop: `1px solid ${isLight ? '#D4D9E1' : 'red'}`,
+  margin: '14px 0 22px',
+}));

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -1,177 +1,80 @@
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { EXPENSES_COMPARISON_TABLE_HEADER } from './components/ExpensesComparison/ExpensesComparison';
-import type { RowProps } from '@ses/components/AdvanceTable/types';
+import ExpensesComparisonRowCard from './components/ExpensesComparisonRowCard/ExpensesComparisonRowCard';
+import type { CardRenderProps, RowProps } from '@ses/components/AdvanceTable/types';
+
+export const buildRow = (
+  values: [string, string, string, string, string, string],
+  isCurrentMonth = false,
+  isTotal = false
+): RowProps =>
+  ({
+    ...(isCurrentMonth
+      ? { render: ({ children }) => <tr style={{ background: 'rgba(236, 239, 249, 0.5)' }}>{children}</tr> }
+      : {}),
+    cellPadding: {
+      table_834: isTotal ? '17px 8px 18.5px' : '18.5px 8px',
+      desktop_1194: '17.4px 16px',
+    },
+    rowToCardConfig: {
+      render: (props: CardRenderProps) => (
+        <ExpensesComparisonRowCard row={{ cells: props.cells ?? [] }} expandable={!!props.cells?.[0].rowIndex} />
+      ),
+      ...(isTotal ? { type: 'total' } : {}),
+    },
+    ...(isTotal
+      ? {
+          extraProps: {
+            isBold: true,
+          },
+          border: {
+            top: true,
+          },
+        }
+      : {}),
+    cells: [
+      {
+        value: values[0],
+        defaultRenderer: 'boldText',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
+        isCardHeader: true,
+      },
+      {
+        value: values[1],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
+      },
+      {
+        value: values[2],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
+      },
+      {
+        value: values[3],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
+      },
+      {
+        value: values[4],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
+      },
+      {
+        value: values[5],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
+      },
+    ],
+  } as RowProps);
 
 const useAccountsSnapshot = () => {
   const { isLight } = useThemeContext();
 
   const expensesComparisonRows = [
-    {
-      render: ({ children }) => <tr style={{ background: 'rgba(236, 239, 249, 0.5)' }}>{children}</tr>,
-      cellPadding: {
-        table_834: '18.5px 8px',
-        desktop_1194: '17.4px 16px',
-      },
-      cells: [
-        {
-          value: 'MAY-2023',
-          defaultRenderer: 'boldText',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
-          isCardHeader: true,
-        },
-        {
-          value: '221,503.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
-        },
-        {
-          value: '240,000.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
-        },
-        {
-          value: '8.35%',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
-        },
-        {
-          value: '221,504.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
-        },
-        {
-          value: '0.00%',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
-        },
-      ],
-    },
-    {
-      cellPadding: {
-        table_834: '18.5px 8px',
-        desktop_1194: '17.4px 16px',
-      },
-      cells: [
-        {
-          value: 'APR-2023',
-          defaultRenderer: 'boldText',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
-          isCardHeader: true,
-        },
-        {
-          value: '171,503.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
-        },
-        {
-          value: '170,000.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
-        },
-        {
-          value: '-0.88%',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
-        },
-        {
-          value: '171,500,00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
-        },
-        {
-          value: '0.00%',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
-        },
-      ],
-    },
-    {
-      cellPadding: {
-        table_834: '18.5px 8px',
-        desktop_1194: '17.4px 16px',
-      },
-      cells: [
-        {
-          value: 'MAR-2023',
-          defaultRenderer: 'boldText',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
-          isCardHeader: true,
-        },
-        {
-          value: '288,503.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
-        },
-        {
-          value: '280,000.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
-        },
-        {
-          value: '-2,95%',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
-        },
-        {
-          value: '288,300.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
-        },
-        {
-          value: '-0.07%',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
-        },
-      ],
-    },
-    {
-      cellPadding: {
-        table_834: '17px 8px 18.5px',
-        desktop_1194: '17.4px 16px',
-      },
-      cells: [
-        {
-          value: 'Totals',
-          defaultRenderer: 'boldText',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
-          isCardHeader: true,
-        },
-        {
-          value: '681,509.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
-        },
-        {
-          value: '681,509.00 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
-        },
-        {
-          value: '1.25%',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
-        },
-        {
-          value: '681,304.25 DAI',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
-        },
-        {
-          value: '-0.03%',
-          defaultRenderer: 'number',
-          inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
-        },
-      ],
-      extraProps: {
-        isBold: true,
-      },
-      border: {
-        top: true,
-      },
-      rowToCardConfig: {
-        type: 'total',
-      },
-    },
+    buildRow(['MAY-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%', '221,504.00 DAI', '0.00%'], true, false),
+    buildRow(['APR-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%', '171,500,00 DAI', '0.00%'], false, false),
+    buildRow(['MAR-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%', '288,300.00 DAI', '-0.07%'], false, false),
+    buildRow(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%', '681,304.25 DAI', '-0.03%'], false, true),
   ] as RowProps[];
 
   return {


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Add the capability to transform the table into cards in the "Reported Expenses Comparison" section

# What solved
- Should show the exhibit five rows as cards instead of a table in mobile (Reported Expenses Comparison) 
- Should replace the table in the "Reported Expenses Comparison" section by expandable cards 