### PR TITLE
Add correct color dark mode and fix arrow position

### DIFF
--- a/src/stories/components/CustomPopover/CustomPopover.tsx
+++ b/src/stories/components/CustomPopover/CustomPopover.tsx
@@ -293,7 +293,7 @@ const ContainerTriangle = styled.div<WithIsLight & { alignArrow?: 'center' | 'ri
       width: 0,
       height: 0,
       borderStyle: 'solid',
-      left: alignArrow === 'center' ? 135 : alignArrow === 'right' ? 257 : 35,
+      left: alignArrow === 'center' ? 135 : alignArrow === 'right' ? 265 : 35,
       borderColor: 'transparent',
       borderWidth: arrowPosition === 'up' ? '0px 8px  16px  8px' : '16px 8px  0px  8px',
       borderBottomColor: isLight ? 'white' : '#000A13',

--- a/src/stories/components/CustomPopover/CustomPopover.tsx
+++ b/src/stories/components/CustomPopover/CustomPopover.tsx
@@ -293,7 +293,7 @@ const ContainerTriangle = styled.div<WithIsLight & { alignArrow?: 'center' | 'ri
       width: 0,
       height: 0,
       borderStyle: 'solid',
-      left: alignArrow === 'center' ? 135 : alignArrow === 'right' ? 265 : 35,
+      left: alignArrow === 'center' ? 135 : alignArrow === 'right' ? 275 : 35,
       borderColor: 'transparent',
       borderWidth: arrowPosition === 'up' ? '0px 8px  16px  8px' : '16px 8px  0px  8px',
       borderBottomColor: isLight ? 'white' : '#000A13',

--- a/src/stories/components/TransparencyCard/TransparencyCard.tsx
+++ b/src/stories/components/TransparencyCard/TransparencyCard.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import lightTheme from '../../../../styles/theme/light';
 import { useThemeContext } from '../../../core/context/ThemeContext';
 import type { CardSpacingSize } from '../AdvancedInnerTable/AdvancedInnerTable';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   header: JSX.Element | string;
@@ -38,7 +39,7 @@ export const TransparencyCard: React.FC<Props> = ({ cardSpacingSize = 'large', .
               key={header.toString()}
               hasIcon={header !== 'Target Balance' || (header === 'Target Balance' && props.itemType === 'total')}
             >
-              <Label hasIcon={header === 'Target Balance'} isTotal={totalsStyle}>
+              <Label hasIcon={header === 'Target Balance'} isTotal={totalsStyle} isLight={isLight}>
                 {header}
               </Label>
               <div
@@ -102,20 +103,22 @@ const Row = styled.div<{ hasIcon?: boolean; height?: string }>(({ hasIcon = fals
   },
 }));
 
-const Label = styled.div<{ hasIcon?: boolean; height?: string; isTotal: boolean }>(({ hasIcon = false, isTotal }) => ({
-  display: 'flex',
+const Label = styled.div<WithIsLight & { hasIcon?: boolean; height?: string; isTotal: boolean }>(
+  ({ hasIcon = false, isTotal, isLight }) => ({
+    display: 'flex',
 
-  alignItems: hasIcon ? 'flex-start' : 'center',
-  color: isTotal ? '#434358' : '#708390',
-  fontFamily: 'Inter, sans-serif',
-  fontWeight: 600,
-  fontSize: '12px',
-  lineHeight: '15px',
-  height: '37px',
-  letterSpacing: '1px',
-  textTransform: 'uppercase',
-  minWidth: 132,
-}));
+    alignItems: hasIcon ? 'flex-start' : 'center',
+    color: isLight ? (isTotal ? '#434358' : '#708390') : isTotal ? '#D2D4EF' : '#708390',
+    fontFamily: 'Inter, sans-serif',
+    fontWeight: 600,
+    fontSize: '12px',
+    lineHeight: '15px',
+    height: '37px',
+    letterSpacing: '1px',
+    textTransform: 'uppercase',
+    minWidth: 132,
+  })
+);
 
 const ContainerLine = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   display: 'flex',

--- a/src/stories/components/TransparencyCard/TransparencyCard.tsx
+++ b/src/stories/components/TransparencyCard/TransparencyCard.tsx
@@ -108,7 +108,7 @@ const Label = styled.div<WithIsLight & { hasIcon?: boolean; height?: string; isT
     display: 'flex',
 
     alignItems: hasIcon ? 'flex-start' : 'center',
-    color: isLight ? (isTotal ? '#434358' : '#708390') : isTotal ? '#D2D4EF' : '#708390',
+    color: isLight ? (isTotal ? '#434358' : '#708390') : isTotal ? '#9FAFB9' : '#708390',
     fontFamily: 'Inter, sans-serif',
     fontWeight: 600,
     fontSize: '12px',

--- a/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
+++ b/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
@@ -177,12 +177,12 @@ const ExtendedCustomPopover = styled(CustomPopover)<{
     marginLeft: -45,
     marginTop: marginTopPopoverPosition ? 16 : -25,
     ...(hasNotSpaceRight && {
-      marginLeft: 63,
+      marginLeft: 53,
       marginTop: 15,
     }),
     ...(hasNotDownRight && {
-      marginLeft: 63,
-      marginTop: -20,
+      marginLeft: 53,
+      marginTop: -22,
     }),
   },
 }));

--- a/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
+++ b/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
@@ -177,11 +177,11 @@ const ExtendedCustomPopover = styled(CustomPopover)<{
     marginLeft: -45,
     marginTop: marginTopPopoverPosition ? 16 : -25,
     ...(hasNotSpaceRight && {
-      marginLeft: 53,
+      marginLeft: 45,
       marginTop: 15,
     }),
     ...(hasNotDownRight && {
-      marginLeft: 53,
+      marginLeft: 45,
       marginTop: -22,
     }),
   },


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅The change was made but in dark mode, the text (Totals) is barely visible. Check the font color in dark mode.
✅ Resolution: 1194, the tooltip is cut off on the right side
✅ The tooltip should be displayed. It is a little bit difficult to see the modal. 

# Actions
Add the correct color dark mode and fix the arrow position