### PR TITLE
[SES-268] On and Off Chain reserves cards

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
     "cSpell.words": [
         "actuals",
+        "Blockie",
+        "Blockies",
         "Formik",
         "gtag",
         "jhon",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mobile-detect": "^1.4.5",
     "next": "12.1.6",
     "react": "18.1.0",
+    "react-18-blockies": "^1.0.6",
     "react-cookie": "^4.1.1",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "18.1.0",

--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -120,6 +120,7 @@ const dictionary = [
   'Feedblack',
   'Coldirion',
   'Gnosis',
+  'Blockies',
 ];
 
 module.exports = dictionary;

--- a/src/core/utils/string.ts
+++ b/src/core/utils/string.ts
@@ -16,11 +16,11 @@ export const getMipTitle = (title: string) => {
   return pieces;
 };
 
-export const formatAddressForOutput = (address: string | undefined) => {
+export const formatAddressForOutput = (address: string | undefined, startChars = 5, endChars = 5, divider = '..') => {
   if (!address) {
     return '';
   }
-  return `${address.slice(0, 5)}..${address.slice(address.length - 5, address.length)}`;
+  return `${address.slice(0, startChars)}${divider}${address.slice(address.length - endChars, address.length)}`;
 };
 
 export const capitalizeWord = (word: string) =>

--- a/src/stories/components/CopyIcon/CopyIcon.tsx
+++ b/src/stories/components/CopyIcon/CopyIcon.tsx
@@ -41,7 +41,7 @@ const CopyIcon: React.FC<CopyIconProps> = ({
         }}
       >
         <CopyToClipboard text={text} onCopy={() => setPopoverText(defaultCopyTooltip)}>
-          <ClipBoard width={width} height={height} />
+          <ClipBoard width={width} height={height} onClick={(e: React.MouseEvent) => e.stopPropagation()} />
         </CopyToClipboard>
       </CustomPopover>
     </IconContainer>

--- a/src/stories/components/svg/ClipBoard.tsx
+++ b/src/stories/components/svg/ClipBoard.tsx
@@ -1,24 +1,15 @@
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import * as React from 'react';
 
-interface Props {
+interface Props extends React.HTMLAttributes<SVGElement> {
   width?: number;
   height?: number;
-  onClick?: () => void;
 }
 
-const ClipBoard: React.FC<Props> = ({ height = 17, width = 17, onClick, ...props }) => {
+const ClipBoard: React.FC<Props> = ({ height = 17, width = 17, ...props }) => {
   const { isLight } = useThemeContext();
   return (
-    <svg
-      width={width}
-      height={height}
-      viewBox="0 0 17 17"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      {...props}
-      onClick={onClick}
-    >
+    <svg width={width} height={height} viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
       <path
         fillRule="evenodd"
         clipRule="evenodd"

--- a/src/stories/components/svg/information.tsx
+++ b/src/stories/components/svg/information.tsx
@@ -11,7 +11,7 @@ interface Props {
 const Information: React.FC<Props> = ({ height = 15, width = 15, style, ...props }) => {
   const { isLight } = useThemeContext();
   return (
-    <ContainerSVg
+    <ContainerSVG
       style={style}
       isLight={isLight}
       width={height}
@@ -29,13 +29,13 @@ const Information: React.FC<Props> = ({ height = 15, width = 15, style, ...props
         d="M8 1.5c-3.107 0-6 2.893-6 6s2.893 6 6 6 6-2.893 6-6-2.893-6-6-6zm-7.5 6a7.5 7.5 0 1115 0 7.5 7.5 0 01-15 0z"
       />
       <path d="M8 12a.75.75 0 01-.75-.75V7.5a.75.75 0 011.5 0v3.75A.75.75 0 018 12zM8 5.25a.75.75 0 110-1.5.75.75 0 010 1.5z" />
-    </ContainerSVg>
+    </ContainerSVG>
   );
 };
 
 export default Information;
 
-const ContainerSVg = styled.svg<{ isLight?: boolean }>(({ isLight }) => ({
+const ContainerSVG = styled.svg<{ isLight?: boolean }>(({ isLight }) => ({
   fill: isLight ? '#9FAFB9' : '#787A9B',
   ':hover': {
     fill: '#447AFB',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -75,6 +75,36 @@ const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode }) => {
           />
         </ReservesCardsContainer>
       </Subsection>
+
+      <Subsection isDisabled>
+        <SectionHeader
+          title="Off Chain Reserves"
+          subtitle={`Unspent off-chain reserves accessible to the ${coreUnitCode} Core Unit.`}
+          tooltip={'pending...'}
+          isSubsection
+        />
+
+        <ReservesCardsContainer>
+          <ReserveCard
+            name="Payment Processor"
+            isGroup
+            initialBalance={100000}
+            inflow={300000}
+            outflow={300000}
+            newBalance={0}
+          />
+          <ReserveCard
+            // temporary disable as this is a WIP
+            // eslint-disable-next-line spellcheck/spell-checker
+            name="Coinbase Account"
+            isGroup
+            initialBalance={500000}
+            inflow={300000}
+            outflow={250000}
+            newBalance={550680}
+          />
+        </ReservesCardsContainer>
+      </Subsection>
     </div>
   );
 };
@@ -107,9 +137,10 @@ const CheckContainer = styled.div<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const Subsection = styled.div({
+const Subsection = styled.div<{ isDisabled?: boolean }>(({ isDisabled = false }) => ({
   marginTop: 24,
-});
+  opacity: isDisabled ? 0.3 : 1,
+}));
 
 const ReservesCardsContainer = styled.div({
   display: 'flex',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -3,6 +3,7 @@ import Checkbox from '@mui/material/Checkbox';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import React from 'react';
 import FundChangeCard from '../Cards/FundChangeCard';
+import ReserveCard from '../Cards/ReserveCard/ReserveCard';
 import SimpleStatCard from '../Cards/SimpleStatCard';
 import SectionHeader from '../SectionHeader/SectionHeader';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -38,6 +39,42 @@ const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode }) => {
         />
         <SimpleStatCard date="2023-06-14T22:52:54.494Z" value={1266680} caption="New Core Unit Reserves" hasEqualSign />
       </CardsContainer>
+
+      <Subsection>
+        <SectionHeader
+          title="On Chain Reserves"
+          subtitle={`Unspent on-chain reserves to the ${coreUnitCode} Core Unit.`}
+          tooltip={'pending...'}
+          isSubsection
+        />
+
+        <ReservesCardsContainer>
+          <ReserveCard
+            name="DSS Vest"
+            isGroup
+            initialBalance={100000}
+            inflow={300000}
+            outflow={300000}
+            newBalance={100000}
+          />
+          <ReserveCard
+            name="Auditor"
+            address={'0x23b554585a4ef8482'}
+            initialBalance={500000}
+            inflow={300000}
+            outflow={250000}
+            newBalance={550000}
+          />
+          <ReserveCard
+            name="Operational"
+            isGroup
+            initialBalance={900000}
+            inflow={250000}
+            outflow={50000}
+            newBalance={1100000}
+          />
+        </ReservesCardsContainer>
+      </Subsection>
     </div>
   );
 };
@@ -69,3 +106,13 @@ const CheckContainer = styled.div<WithIsLight>(({ isLight }) => ({
     padding: 0,
   },
 }));
+
+const Subsection = styled.div({
+  marginTop: 24,
+});
+
+const ReservesCardsContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  marginTop: 24,
+});

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard/ReserveCard.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard/ReserveCard.stories.tsx
@@ -1,0 +1,89 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import ReserveCard from './ReserveCard';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/CUTransparencyReport/Accounts Snapshot/Reserve Card',
+  component: ReserveCard,
+} as ComponentMeta<typeof ReserveCard>;
+
+const variantsArgs = [
+  {
+    name: 'DSS Vest',
+    isGroup: true,
+    initialBalance: 100000,
+    inflow: 300000,
+    outflow: 300000,
+    newBalance: 100000,
+  },
+];
+
+export const [[GroupLightMode, GroupDarkMode]] = createThemeModeVariants(ReserveCard, variantsArgs);
+
+GroupLightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18675%3A213129',
+        options: {
+          componentStyle: {
+            width: 343,
+          },
+          style: {
+            top: -2,
+            left: -6,
+          },
+        },
+      },
+      834: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18595%3A253864',
+        options: {
+          componentStyle: {
+            width: 770,
+          },
+          style: {
+            top: -21,
+            left: -40,
+          },
+        },
+      },
+      1194: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18569%3A236029',
+        options: {
+          componentStyle: {
+            width: 1130,
+          },
+          style: {
+            top: -22,
+            left: -40,
+          },
+        },
+      },
+      1280: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18569%3A231259',
+        options: {
+          componentStyle: {
+            width: 1184,
+          },
+          style: {
+            top: -22,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18569%3A222422',
+        options: {
+          componentStyle: {
+            width: 1312,
+          },
+          style: {
+            top: -22,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard/ReserveCard.tsx
@@ -1,0 +1,320 @@
+import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
+import MuiAccordion from '@mui/material/Accordion';
+import MuiAccordionDetails from '@mui/material/AccordionDetails';
+import MuiAccordionSummary from '@mui/material/AccordionSummary';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import WalletInfo from '../../WalletInfo/WalletInfo';
+import type { AccordionProps } from '@mui/material/Accordion';
+import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface ReserveCardProps {
+  name: string;
+  address?: string;
+  isGroup?: boolean;
+  initialBalance: number;
+  inflow: number;
+  outflow: number;
+  newBalance: number;
+  currency?: 'DAI' | 'ETH' | 'MKR';
+}
+
+const ReserveCard: React.FC<ReserveCardProps> = ({
+  name,
+  address,
+  isGroup = false,
+  initialBalance,
+  inflow,
+  outflow,
+  newBalance,
+  currency = 'DAI',
+}) => {
+  const { isLight } = useThemeContext();
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+  const [expanded, setExpanded] = React.useState<boolean>(false);
+
+  const SVG = (
+    <Arrow
+      isExpanded={expanded}
+      width="10"
+      height="6"
+      viewBox="0 0 10 6"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4.69339 5.86308C4.85404 6.04564 5.14598 6.04564 5.30664 5.86308L9.90358 0.639524C10.1255 0.38735 9.93978 0 9.59696 0H0.403059C0.0602253 0 -0.125491 0.38735 0.0964331 0.639525L4.69339 5.86308Z"
+        fill={isLight ? '#546978' : 'red'}
+      />
+    </Arrow>
+  );
+
+  return (
+    <Accordion onChange={() => setExpanded(!expanded)}>
+      <Card isLight={isLight}>
+        <NameContainer>
+          {isGroup ? <Name isLight={isLight}>{name}</Name> : <WalletInfo name={name} address={address ?? ''} />}
+          {isMobile && SVG}
+        </NameContainer>
+        <InitialBalance>
+          <Header isLight={isLight}>Initial Balance</Header>
+          <Value isLight={isLight}>
+            {usLocalizedNumber(initialBalance)} <Currency isLight={isLight}>{currency}</Currency>
+          </Value>
+        </InitialBalance>
+        <Inflow isLight={isLight}>
+          <Header isLight={isLight}>Inflow</Header>
+          <Value isLight={isLight}>
+            + {usLocalizedNumber(inflow)} <Currency isLight={isLight}>{currency}</Currency>
+          </Value>
+        </Inflow>
+        <Outflow isLight={isLight}>
+          <Header isLight={isLight}>Outflow</Header>
+          <Value isLight={isLight}>
+            - {usLocalizedNumber(outflow)} <Currency isLight={isLight}>{currency}</Currency>
+          </Value>
+        </Outflow>
+        <NewBalance>
+          <Header isLight={isLight}>New Balance</Header>
+          <Value isLight={isLight}>
+            {usLocalizedNumber(newBalance)} <Currency isLight={isLight}>{currency}</Currency>
+          </Value>
+        </NewBalance>
+        {!isMobile && <ArrowContainer>{SVG}</ArrowContainer>}
+      </Card>
+      <TransactionContainer>transaction list</TransactionContainer>
+    </Accordion>
+  );
+};
+
+export default ReserveCard;
+
+const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters elevation={0} square {...props} />)({
+  backgroundColor: 'transparent',
+  marginBottom: 8,
+  borderRadius: '6px',
+
+  '&:before': {
+    display: 'none',
+  },
+});
+
+const Card = styled((props: AccordionSummaryProps) => <MuiAccordionSummary {...props} />)<WithIsLight>(
+  ({ isLight }) => ({
+    padding: '16px 24px 24px',
+    background: isLight ? '#ffffff' : 'red',
+    boxShadow: isLight ? '0px 4px 6px rgba(196, 196, 196, 0.25)' : 'red',
+    borderRadius: 6,
+
+    [lightTheme.breakpoints.up('table_834')]: {
+      padding: 0,
+    },
+
+    '& .MuiAccordionSummary-content': {
+      margin: 0,
+      width: '100%',
+      flexDirection: 'column',
+
+      [lightTheme.breakpoints.up('table_834')]: {
+        flexDirection: 'row',
+        alignItems: 'center',
+      },
+    },
+  })
+);
+
+const TransactionContainer = styled(MuiAccordionDetails)(() => ({
+  padding: '0 0 14px',
+  background: 'red',
+}));
+
+const NameContainer = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    width: '22.7%',
+    padding: '0 16px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: '18.7%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: '18.9%',
+  },
+});
+
+const Name = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 700,
+  fontSize: 16,
+  lineHeight: '19px',
+  color: isLight ? '#231536' : 'red',
+
+  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
+    fontSize: 14,
+    lineHeight: '17px',
+  },
+}));
+
+const InitialBalance = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginTop: 24,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    flexDirection: 'column',
+    marginTop: 0,
+    justifyContent: 'normal',
+    alignItems: 'normal',
+    padding: '16px 8px',
+    width: '17.1%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: 16,
+    width: '18.1%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: '18.3%',
+  },
+});
+
+const Header = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 14,
+  lineHeight: '17px',
+  color: isLight ? '#708390' : 'red',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    fontSize: 11,
+    lineHeight: '13px',
+    marginBottom: 8,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    fontSize: 12,
+    lineHeight: '15px',
+  },
+}));
+
+const Value = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 700,
+  fontSize: 14,
+  lineHeight: '17px',
+  color: isLight ? '#231536' : 'red',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    fontSize: 16,
+    lineHeight: '19px',
+  },
+}));
+
+const Currency = styled.span<WithIsLight>(({ isLight }) => ({
+  fontWeight: 600,
+  fontSize: 12,
+  lineHeight: '15px',
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  color: isLight ? '#9FAFB9' : 'red',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    fontSize: 14,
+    lineHeight: '17px',
+  },
+}));
+
+const Inflow = styled.div<WithIsLight>(({ isLight }) => ({
+  marginLeft: -16,
+  marginRight: -16,
+  marginTop: 8,
+  padding: '8px 16px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  background: isLight ? 'rgba(236, 239, 249, 0.5)' : 'red',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    flexDirection: 'column',
+    margin: 8,
+    padding: 8,
+    justifyContent: 'normal',
+    alignItems: 'normal',
+    width: '16%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '8px 16px',
+    margin: '8px 16px',
+    width: '15.9%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    width: '16.2%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: '16.5%',
+  },
+}));
+
+const Outflow = styled(Inflow)({});
+
+const NewBalance = styled(InitialBalance)({
+  marginTop: 8,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    padding: '16px 8px',
+    marginLeft: 'auto',
+
+    '& > div': {
+      textAlign: 'right',
+    },
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: 16,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    padding: '16px 32px 16px 16px',
+    width: 'auto',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    padding: '16px 64px 16px 16px',
+  },
+});
+
+const ArrowContainer = styled.div({
+  width: 47,
+  display: 'flex',
+  alignItems: 'center',
+  padding: '8px 18.5px',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: 72,
+    justifyContent: 'center',
+  },
+});
+
+const Arrow = styled.svg<{ isExpanded: boolean }>(({ isExpanded }) => ({
+  transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+  transition: 'transform 0.2s ease-in-out',
+  marginTop: -2,
+  marginRight: -5,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: 16,
+    height: 10,
+    marginRight: 0,
+  },
+}));

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.stories.tsx
@@ -1,0 +1,61 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import WalletInfo from './WalletInfo';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/CUTransparencyReport/Accounts Snapshot/WalletInfo',
+  component: WalletInfo,
+} as ComponentMeta<typeof WalletInfo>;
+
+const variantsArgs = [
+  {
+    name: 'Auditor',
+    address: '0x232b567890123456789012345678901234568482',
+  },
+];
+
+export const [[LightMode, DarkMode]] = createThemeModeVariants(WalletInfo, variantsArgs);
+
+LightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18675%3A213212',
+        options: {
+          componentStyle: {
+            width: 212,
+          },
+          style: {
+            top: -19,
+            left: 0,
+          },
+        },
+      },
+      834: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18595%3A253927',
+        options: {
+          componentStyle: {
+            width: 175,
+          },
+          style: {
+            top: -18,
+            left: -16,
+          },
+        },
+      },
+      1194: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18569%3A236092',
+        options: {
+          componentStyle: {
+            width: 212,
+          },
+          style: {
+            top: -19,
+            left: -16,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.tsx
@@ -1,0 +1,104 @@
+import styled from '@emotion/styled';
+import CopyIcon from '@ses/components/CopyIcon/CopyIcon';
+import Information from '@ses/components/svg/information';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { formatAddressForOutput } from '@ses/core/utils/string';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import Blockies from 'react-18-blockies';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface WalletInfoProps {
+  name: string;
+  address: string;
+}
+
+const WalletInfo: React.FC<WalletInfoProps> = ({ name, address }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Container>
+      <BlockiesContainer>
+        <Blockies seed={address ?? name} size={10} scale={3} />
+      </BlockiesContainer>
+      <InfoContainer>
+        <NameContainer>
+          <Name isLight={isLight}>{name}</Name>
+          <InfoIcon isLight={isLight} />
+        </NameContainer>
+        <AddressContainer>
+          <Address isLight={isLight} href={`https://etherscan.io/address/${address}`} target="_blank">
+            {formatAddressForOutput(address, 6, 4, '...')}
+          </Address>
+          <CopyIcon text={address ?? ''} defaultTooltip="Copy Address" />
+        </AddressContainer>
+      </InfoContainer>
+    </Container>
+  );
+};
+
+export default WalletInfo;
+
+const Container = styled.div({
+  display: 'flex',
+});
+
+const BlockiesContainer = styled.div({
+  width: 32,
+  height: 32,
+  borderRadius: '50%',
+  marginRight: 16,
+  marginTop: 2,
+  overflow: 'hidden',
+  background: 'gray',
+
+  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
+    marginTop: 1,
+  },
+});
+
+const InfoContainer = styled.div({});
+
+const NameContainer = styled.div({
+  display: 'flex',
+});
+
+const Name = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 700,
+  fontSize: 16,
+  lineHeight: '19px',
+  color: isLight ? '#231536' : 'red',
+  marginBottom: 4,
+  marginRight: 8.5,
+
+  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
+    fontSize: 14,
+    lineHeight: '17px',
+    marginBottom: 6,
+  },
+}));
+
+const InfoIcon = styled(Information)<WithIsLight>(({ isLight }) => ({
+  fill: isLight ? '#D1DEE6' : 'red',
+  marginTop: 1,
+}));
+
+const AddressContainer = styled.div({
+  display: 'flex',
+});
+
+const Address = styled.a<WithIsLight>(({ isLight }) => ({
+  fontSize: 14,
+  lineHeight: '17px',
+  color: isLight ? '#447AFB' : 'red',
+  marginRight: 17,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    marginRight: 2,
+  },
+
+  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
+    fontSize: 12,
+    lineHeight: '15px',
+  },
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -11831,6 +11831,11 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+react-18-blockies@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-18-blockies/-/react-18-blockies-1.0.6.tgz#595367c6657d33a1edba3d3ba1dcef0b895c13f4"
+  integrity sha512-MPdEdfYm8wO2XEdTDEpwIJJBE0/zdkmZqGbEcypK6EV+nKeqE4qGs6XfBAs6VcrSkZ0ssu8jZNd0qXrplruVqg==
+
 react-cookie@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-4.1.1.tgz#832e134ad720e0de3e03deaceaab179c4061a19d"


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Added on chain and off reserves subsections

# What solved
- Should add the "On-Chain Reserves" sub section in the Total Core Unit Reserves section and display title, subtitle, and three expandable rows (DSS Vest, Auditor, Operational) with four columns (Initial Balance, Inflow, Outflow, New Balance) 
- Should make the "On-Chain Reserves" cards responsive
- Should add the "Off-Chain Reserves" sub section in the Total Core Unit Reserves section and Show one row (Payment Processor) with four columns (Initial Balance, Inflow, Outflow, New Balance)