### PR TITLE
Fix popover don't show

### DIFF
--- a/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
+++ b/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
@@ -46,6 +46,7 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
   };
   const handleClose = () => {
     clearTimeout(leaveTimeoutRef.current);
+    setIsOpen(false);
     leaveTimeoutRef.current = setTimeout(() => {
       setHasNotSpaceRight(false);
       setHasNotDownRight(false);
@@ -78,9 +79,17 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
     };
   }, [isMobileDevice, isOpen, lockScroll, unlockScroll]);
 
-  const handleOnClick = useCallback(() => {
-    setIsOpen(!isOpen);
-  }, [isOpen]);
+  const handleOnClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      setIsOpen(!isOpen);
+    },
+    [isOpen]
+  );
+
+  const handleCloseOverLay = () => {
+    setIsOpen(false);
+  };
   return (
     <Container>
       {!isMobileResolution && (
@@ -159,7 +168,9 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
           />
         </ModalSheet>
       )}
-      {isMobileResolution && isOpen && isMobileDevice && <ContainerOverlay isLight={isLight} onClick={handleOnClick} />}
+      {isMobileResolution && isOpen && isMobileDevice && (
+        <ContainerOverlay isLight={isLight} onClick={handleCloseOverLay} />
+      )}
     </Container>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
@@ -25,11 +25,13 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
   const monthFormatted = month?.toFormat('MMMM') || '3 Months Budget Cap';
   const [hover, setHover] = useState(false);
 
-  const handleMouseOver = () => {
+  const handleMouseOver = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     setHover(true);
   };
 
-  const handleMouseOut = () => {
+  const handleMouseOut = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     setHover(false);
   };
   const barColor = getProgressiveBarColor(value, relativeValue, isLight, hover);
@@ -44,6 +46,7 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
       <ContainerBar>
         <BudgetBar isLight={isLight}>{<BarPercent width={percent} color={barColor} />}</BudgetBar>
         <CustomPopover
+          leaveOnChildrenMouseOut
           popoverStyle={{
             border: `1px solid ${borderColor}`,
             boxShadow: isLight
@@ -56,8 +59,13 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
           title={<PopoverForecastDescription relativeValue={relativeValue} value={value} month={monthFormatted} />}
         >
           <ContainerRelative>
-            <ContendBarForSpace onMouseEnter={handleMouseOver} onMouseOut={handleMouseOut} displacement={displacement}>
-              <VerticalBar onMouseEnter={handleMouseOver} onMouseOut={handleMouseOut} />
+            <ContendBarForSpace
+              onMouseEnter={handleMouseOver}
+              onMouseOut={handleMouseOut}
+              displacement={displacement}
+              onClick={handleMouseOver}
+            >
+              <VerticalBar onMouseEnter={handleMouseOver} onMouseOut={handleMouseOut} onClick={handleMouseOver} />
             </ContendBarForSpace>
           </ContainerRelative>
         </CustomPopover>

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLineMobile.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLineMobile.tsx
@@ -25,11 +25,13 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
   const monthFormatted = month?.toFormat('MMMM') || '3 Months Budget Cap';
   const [hover, setHover] = useState(false);
 
-  const handleMouseOver = () => {
+  const handleMouseOver = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     setHover(true);
   };
 
-  const handleMouseOut = () => {
+  const handleMouseOut = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     setHover(false);
   };
   const barColor = getProgressiveBarColor(value, relativeValue, isLight, hover);
@@ -38,6 +40,7 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
   const borderColor = getBorderColor(value, relativeValue, isLight);
   return (
     <CustomPopover
+      leaveOnChildrenMouseOut
       popoverStyle={{
         border: `1px solid ${borderColor}`,
         boxShadow: isLight
@@ -46,10 +49,10 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
         background: isLight ? 'white' : '#000A13',
         borderRadius: '6px',
       }}
-      id="mouse-over-information"
+      id="information"
       title={<PopoverForecastDescription relativeValue={relativeValue} value={value} month={monthFormatted} />}
     >
-      <Container onMouseEnter={handleMouseOver} onMouseOut={handleMouseOut}>
+      <Container onClick={handleMouseOver} onMouseEnter={handleMouseOver} onMouseOut={handleMouseOut}>
         <Forecast isLight={isLight} isTotal={isTotal} isNegative={value < 0}>
           {usLocalizedNumber(value)}
         </Forecast>

--- a/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
+++ b/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
@@ -106,10 +106,17 @@ export const RenderNumberWithIcon = (data: TargetBalanceTooltipInformation) => {
     };
   }, [isMobileDevice, isOpen, lockScroll, unlockScroll]);
 
-  const handleOnClick = useCallback(() => {
-    setIsOpen(!isOpen);
-  }, [isOpen]);
+  const handleOnClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      setIsOpen(!isOpen);
+    },
+    [isOpen]
+  );
 
+  const handleOnclose = () => {
+    setIsOpen(false);
+  };
   return (
     <BiggerContainer>
       <PopoverContainer>
@@ -117,6 +124,7 @@ export const RenderNumberWithIcon = (data: TargetBalanceTooltipInformation) => {
           <Container>
             {showIconToolTip && (
               <ExtendedCustomPopover
+                onClose={handleOnclose}
                 handleShowPopoverWhenNotSpace={handleShowPopoverWhenNotSpace}
                 refElementShowPopover={hrefPopoverElement}
                 sxProps={{
@@ -144,7 +152,7 @@ export const RenderNumberWithIcon = (data: TargetBalanceTooltipInformation) => {
                 }
                 leaveOnChildrenMouseOut
               >
-                <ContainerInfoIcon>
+                <ContainerInfoIcon onClick={handleOnClick}>
                   <IconPosition />
                 </ContainerInfoIcon>
               </ExtendedCustomPopover>
@@ -189,12 +197,12 @@ export const RenderNumberWithIcon = (data: TargetBalanceTooltipInformation) => {
                 }
                 leaveOnChildrenMouseOut
               >
-                <ContainerInfoIcon>
+                <ContainerInfoIcon onClick={handleOnClick}>
                   <IconPosition />
                 </ContainerInfoIcon>
               </ExtendedCustomPopover>
             )}
-            <ContainerInformation>
+            <ContainerInformation onClick={handleOnClick}>
               <ContainerNumberCell value={data.balance} />
               <ContainerStyleMonths>{data.months}</ContainerStyleMonths>
             </ContainerInformation>
@@ -211,7 +219,7 @@ export const RenderNumberWithIcon = (data: TargetBalanceTooltipInformation) => {
                 </ContainerInfoIcon>
               )}
 
-              <ContainerInformation>
+              <ContainerInformation onClick={handleOnClick}>
                 <ContainerNumberCell value={data.balance} />
                 <ContainerStyleMonths>{data.months}</ContainerStyleMonths>
               </ContainerInformation>
@@ -231,7 +239,7 @@ export const RenderNumberWithIcon = (data: TargetBalanceTooltipInformation) => {
           />
         </ModalSheet>
       )}
-      {isMobileResolution && isOpen && isMobileDevice && <ContainerOverlay isLight={isLight} onClick={handleOnClick} />}
+      {isMobileResolution && isOpen && isMobileDevice && <ContainerOverlay isLight={isLight} onClick={handleOnclose} />}
     </BiggerContainer>
   );
 };

--- a/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
+++ b/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
@@ -69,7 +69,7 @@ export const renderLinksWithToken = (address: string) => (
 
 export interface WithIsLightAndClick {
   isLight: boolean;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 export const RenderNumberWithIcon = (data: TargetBalanceTooltipInformation) => {


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅It is hard to touch the tooltip area
✅Hovering/clicking on the bars, the tooltip should be displayed. The touch area should be the actual number,  budget number, and bars. **Current Output:** The tooltip still missing. 
✅ Hovering over the 2 last values from the Totals column. **Expected Output:** The tooltip should be visible. **Current Output:** When the values are closer to the bottom, the tooltip is not displayed

# Actions
Fix popover don't show