### PR TITLE
Delete unnecessary space in mobile

### DIFF
--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
@@ -41,7 +41,7 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
   return (
     <Container>
       <Forecast isLight={isLight} isTotal={isTotal} isNegative={value < 0}>
-        {usLocalizedNumber(value)}
+        {usLocalizedNumber(value, 2)}
       </Forecast>
       <ContainerBar>
         <BudgetBar isLight={isLight}>{<BarPercent width={percent} color={barColor} />}</BudgetBar>
@@ -70,7 +70,7 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
           </ContainerRelative>
         </CustomPopover>
       </ContainerBar>
-      <BudgetCap isLight={isLight}>{usLocalizedNumber(relativeValue)}</BudgetCap>
+      <BudgetCap isLight={isLight}>{usLocalizedNumber(relativeValue, 2)}</BudgetCap>
     </Container>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLineMobile.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLineMobile.tsx
@@ -54,7 +54,7 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
     >
       <Container onClick={handleMouseOver} onMouseEnter={handleMouseOver} onMouseOut={handleMouseOut}>
         <Forecast isLight={isLight} isTotal={isTotal} isNegative={value < 0}>
-          {usLocalizedNumber(value)}
+          {usLocalizedNumber(value, 2)}
         </Forecast>
 
         <ContainerBar>
@@ -66,7 +66,7 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
             </ContendBarForSpace>
           </ContainerRelative>
         </ContainerBar>
-        <BudgetCap isLight={isLight}>{usLocalizedNumber(relativeValue)}</BudgetCap>
+        <BudgetCap isLight={isLight}>{usLocalizedNumber(relativeValue, 2)}</BudgetCap>
       </Container>
     </CustomPopover>
   );

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
@@ -458,6 +458,9 @@ export const ContainerProgressiveIndicator = styled.div({
   flexDirection: 'row',
   justifyContent: 'flex-end',
   [lightTheme.breakpoints.up('table_834')]: {
+    paddingRight: 8,
+  },
+  [lightTheme.breakpoints.up('desktop_1194')]: {
     paddingRight: 16,
   },
 });

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
 import { capitalizeSentence, getWalletWidthForWallets, toKebabCase } from '@ses/core/utils/string';
+import lightTheme from '@ses/styles/theme/light';
 import _ from 'lodash';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -454,7 +455,9 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
 export const ContainerProgressiveIndicator = styled.div({
   display: 'flex',
   flex: 1,
-  paddingRight: 16,
   flexDirection: 'row',
   justifyContent: 'flex-end',
+  [lightTheme.breakpoints.up('table_834')]: {
+    paddingRight: 16,
+  },
 });

--- a/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
+++ b/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
@@ -82,6 +82,8 @@ export const getProgressiveBarColor = (
 
 export const getDisplacementDashLine = (value: number, valueRelative: number): number => {
   if (valueRelative === 0) return 0;
+  if (value === valueRelative) return 0;
+
   const percentToMove = percentageRespectTo(value, valueRelative);
   if (percentToMove < 100) {
     return 0;


### PR DESCRIPTION
# Ticket
https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅ **Expected Output:** The rigth and left paddings should be = 24px. **Current Output:** The right paddings on both tables displays 24px plus other space. 

✅ SAS core unit. Breakdown. **Expected Output:** If the percent is equal to 100, the dots should be displayed at the end. **Current Output:** The percent is equal to 100 but the dots are displayed at the begging of the bar.

# Actions
Delete unnecessary space in mobile
Fix case 100% bars


