### PR TITLE
Move popover when arrow have different position

### DIFF
--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/BarWithDottedLine.tsx
@@ -45,7 +45,8 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
       </Forecast>
       <ContainerBar>
         <BudgetBar isLight={isLight}>{<BarPercent width={percent} color={barColor} />}</BudgetBar>
-        <CustomPopover
+        <StyledPopover
+          displacement={displacement}
           leaveOnChildrenMouseOut
           popoverStyle={{
             border: `1px solid ${borderColor}`,
@@ -68,7 +69,7 @@ const BarWithDottedLineMobile: React.FC<Props> = ({ value, relativeValue, month,
               <VerticalBar onMouseEnter={handleMouseOver} onMouseOut={handleMouseOut} onClick={handleMouseOver} />
             </ContendBarForSpace>
           </ContainerRelative>
-        </CustomPopover>
+        </StyledPopover>
       </ContainerBar>
       <BudgetCap isLight={isLight}>{usLocalizedNumber(relativeValue, 2)}</BudgetCap>
     </Container>
@@ -156,3 +157,11 @@ const Forecast = styled.div<WithIsLight & { isTotal: boolean; isNegative?: boole
     color: isLight ? (isNegative ? '#F75524' : '#231536') : isNegative ? '#F75524' : '#D2D4EF',
   })
 );
+
+const StyledPopover = styled(CustomPopover)<{ displacement: number }>(({ displacement }) => ({
+  '.MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded': {
+    overflowX: 'unset',
+    overflowY: 'unset',
+    marginLeft: -displacement,
+  },
+}));


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅Example core unit. **Expected Output:**The tooltip should be displayed properly having into account the dots' position.  **Current Output:** The tooltip is displayed a little bit far from the dots.  

# Actions
Move popover when arrow have different position

