### PR TITLE
Fix popover as core unit chart

### DIFF
--- a/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
+++ b/src/stories/containers/TransparencyReport/components/HeaderWithIcon/HeaderWithIcon.tsx
@@ -151,9 +151,11 @@ const HeaderWithIcon: React.FC<Props> = ({ title, description, mipNumber, link, 
       {isMobileResolution && isMobileDevice && (
         <>
           <Title style={{ marginRight: 8 }}>{title}</Title>
-          <ContainerInfoIcon className="advance-table--transparency-card_icon_hidden" onClick={handleOnClick}>
-            <IconPosition />
-          </ContainerInfoIcon>
+          {showPopover && (
+            <ContainerInfoIcon className="advance-table--transparency-card_icon_hidden" onClick={handleOnClick}>
+              <IconPosition />
+            </ContainerInfoIcon>
+          )}
         </>
       )}
       {isMobileResolution && isOpen && isMobileDevice && (

--- a/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
+++ b/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
@@ -17,6 +17,7 @@ const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, mon
   const { isLight } = useThemeContext();
   const expenditureLevel = getExpenditureLevelForecast(value, relativeValue);
   const percent = percentageRespectTo(value, relativeValue);
+
   return (
     <ContainerInside>
       <RowMonthDescription>
@@ -29,7 +30,7 @@ const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, mon
         </SeverityDistinction>
       </RowMonthDescription>
       <RowPercentBudgetCap>
-        <Percent isLight={isLight}>{Math.trunc(percent)}%</Percent>
+        <Percent isLight={isLight}>{Math.trunc(percent) === 0 && value !== 0 ? '-' : Math.trunc(percent)}%</Percent>
         <Description isLight={isLight}>of budget cap forecasted</Description>
       </RowPercentBudgetCap>
       <RowAbsoluteNumbers>


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅Should show the same information when there is no forecast

# Actions
Fix popover as core unit chart