### PR TITLE
Add condition hidden % values negative

### DIFF
--- a/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
+++ b/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
@@ -31,7 +31,7 @@ const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, mon
         </SeverityDistinction>
       </RowMonthDescription>
       <RowPercentBudgetCap>
-        {value > 0 ? <Percent isLight={isLight}>{valueShowPercent}%</Percent> : <div />}
+        {value >= 0 ? <Percent isLight={isLight}>{valueShowPercent}%</Percent> : <div />}
         <Description isLight={isLight}>of budget cap forecasted</Description>
       </RowPercentBudgetCap>
       <RowAbsoluteNumbers>

--- a/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
+++ b/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
@@ -17,6 +17,7 @@ const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, mon
   const { isLight } = useThemeContext();
   const expenditureLevel = getExpenditureLevelForecast(value, relativeValue);
   const percent = percentageRespectTo(value, relativeValue);
+  const valueShowPercent = Math.trunc(percent) === 0 && value !== 0 ? '-' : Math.trunc(percent);
 
   return (
     <ContainerInside>
@@ -30,7 +31,7 @@ const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, mon
         </SeverityDistinction>
       </RowMonthDescription>
       <RowPercentBudgetCap>
-        <Percent isLight={isLight}>{Math.trunc(percent) === 0 && value !== 0 ? '-' : Math.trunc(percent)}%</Percent>
+        {value > 0 ? <Percent isLight={isLight}>{valueShowPercent}%</Percent> : <div />}
         <Description isLight={isLight}>of budget cap forecasted</Description>
       </RowPercentBudgetCap>
       <RowAbsoluteNumbers>

--- a/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
+++ b/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
@@ -30,10 +30,12 @@ const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, mon
           {expenditureLevel === '0' ? '0' : expenditureLevel}
         </SeverityDistinction>
       </RowMonthDescription>
-      <RowPercentBudgetCap>
-        {value >= 0 ? <Percent isLight={isLight}>{valueShowPercent}%</Percent> : <div />}
-        <Description isLight={isLight}>of budget cap forecasted</Description>
-      </RowPercentBudgetCap>
+      {value >= 0 && (
+        <RowPercentBudgetCap>
+          <Percent isLight={isLight}>{valueShowPercent}%</Percent>
+          <Description isLight={isLight}>of budget cap forecasted</Description>
+        </RowPercentBudgetCap>
+      )}
       <RowAbsoluteNumbers>
         <Forecast>
           <Value isLight={isLight}>{usLocalizedNumber(value)}</Value>


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved

✅SAS core unit. Breakdown. **Expected Output:** In case of negative numbers, let’s just hide the % row. **Current Output:** The forecast and the percent are displayed with a negative value.  **Visual Proof:** 

# Actions

Add condition hidden % values negative