### PR TITLE
[SES-QC-266] Fix Auditor View on navigation issue

### DIFF
--- a/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -109,9 +109,9 @@ export const AdvancedInnerTable: React.FC<AdvancedInnerTableProps> = ({
       ? [items[items.length - 1], ...items.slice(0, items.length - 1)]
       : items;
 
-  cardItems = cardItems.filter((x) => !x.hideMobile);
+  cardItems = cardItems?.filter((x) => !x.hideMobile);
 
-  return items.length > 0 ? (
+  return items?.length > 0 ? (
     <>
       <TableWrapper>
         <Container isLight={isLight} style={style} className={className}>


### PR DESCRIPTION
# Ticket
https://trello.com/c/kUYUN01m/266-qc-round-v-100-r

# Description
When navigating between the core units under specific circumstances the page crash

# What solved
-  Auditor view, SES core unit: http://46.101.104.232:82/core-unit/SES/finances/reports?section=expense-report&view=auditor&forecast-account=incubation-program&breakdownView=default&actual-account=permanent-team. **Expected Output:** - **Current Output:** Changing the core unit, an error is displayed (the view crash). **Visual Proof:** [crash.webm](https://trello.com/1/cards/643fb08255b18a0d27d36be9/attachments/647743c81ae0d4e0b873d1a6/download/cinnamon-2023-05-31T122225%2B0200.webm).