### PR TITLE
Delete the cero and percent when forecast and not budgets

### DIFF
--- a/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
+++ b/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
@@ -17,7 +17,7 @@ const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, mon
   const { isLight } = useThemeContext();
   const expenditureLevel = getExpenditureLevelForecast(value, relativeValue);
   const percent = percentageRespectTo(value, relativeValue);
-  const valueShowPercent = Math.trunc(percent) === 0 && value !== 0 ? '-' : Math.trunc(percent);
+  const valueShowPercent = Math.trunc(percent) === 0 && value !== 0 ? '-' : `${Math.trunc(percent)}%`;
 
   return (
     <ContainerInside>
@@ -27,12 +27,12 @@ const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, mon
           isLight={isLight}
           levelExpenditure={expenditureLevel === '0' ? ExpenditureLevel.OVERBUDGET : expenditureLevel}
         >
-          {expenditureLevel === '0' ? '0' : expenditureLevel}
+          {expenditureLevel === '0' ? '' : expenditureLevel}
         </SeverityDistinction>
       </RowMonthDescription>
       {value >= 0 && (
         <RowPercentBudgetCap>
-          <Percent isLight={isLight}>{valueShowPercent}%</Percent>
+          <Percent isLight={isLight}>{valueShowPercent}</Percent>
           <Description isLight={isLight}>of budget cap forecasted</Description>
         </RowPercentBudgetCap>
       )}


### PR DESCRIPTION
# Ticket

https://trello.com/c/xdQq44PQ/267-feature-auditorimprovements-v2

# What solved
✅ **Expected Output:** Let’s just hide the % row and the 0 on the top right. **Current Output:** It's displayed a "-" in the percent and a 0 on the top right. 

# Actions
Delete the cero and percent when forecast and not budget cap