### PR TITLE
[SES-QC-266] Fix Quarter Carousel Navigation zIndex

### DIFF
--- a/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.tsx
+++ b/src/stories/containers/FinancesOverview/components/QuarterCarousel/QuarterCarousel.tsx
@@ -143,14 +143,14 @@ const ContainerButtonRight = styled.div({
   position: 'absolute',
   top: '35%',
   right: 0,
-  zIndex: 4,
+  zIndex: 3,
 });
 
 const ContainerButtonLeft = styled.div({
   marginLeft: -15,
   position: 'absolute',
   top: '35%',
-  zIndex: 4,
+  zIndex: 3,
 });
 
 const WrapperMobile = styled.div({


### PR DESCRIPTION
# Ticket
https://trello.com/c/kUYUN01m/266-qc-round-v-100-r

# Description
Decrease the navigation arrows of the Quarter Carouser in the Finances page to prevent the arrow from going over the navbar

# What solved
- **Steps to Reproduce:** Scroll down till the navigation arrows of the Quarterly Carouser are in the same position of the navbar **Expected Output:** The arrows should be under the navbar **Current Output:** It's displayed over the navbar.  