### PR TITLE
[SES-268] Add owner subtitle according to the data from the API

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -8,15 +8,20 @@ import type { Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
 
 interface AccountsSnapshotProps {
   snapshot: Snapshots;
+  snapshotOwner: string;
 }
 
-const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot }) => {
+const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotOwner }) => {
   const { expensesComparisonRows, includeOffChain, toggleIncludeOffChain } = useAccountsSnapshot(snapshot);
 
   return (
     <Wrapper>
-      <FundingOverview coreUnitCode="SES" />
-      <CUReserves coreUnitCode="SES" includeOffChain={includeOffChain} toggleIncludeOffChain={toggleIncludeOffChain} />
+      <FundingOverview snapshotOwner={snapshotOwner} />
+      <CUReserves
+        snapshotOwner={snapshotOwner}
+        includeOffChain={includeOffChain}
+        toggleIncludeOffChain={toggleIncludeOffChain}
+      />
       <ExpensesComparison rows={expensesComparisonRows} />
     </Wrapper>
   );

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/TemporaryContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/TemporaryContainer.tsx
@@ -10,9 +10,10 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface TemporaryContainerProps {
   snapshot: Snapshots;
+  snapshotOwner: string;
 }
 
-const TemporaryContainer: React.FC<TemporaryContainerProps> = ({ snapshot }) => {
+const TemporaryContainer: React.FC<TemporaryContainerProps> = ({ snapshot, snapshotOwner }) => {
   const { isLight } = useThemeContext();
 
   return (
@@ -20,7 +21,7 @@ const TemporaryContainer: React.FC<TemporaryContainerProps> = ({ snapshot }) => 
       <Container>
         <Title isLight={isLight}>Account Snapshot</Title>
 
-        <AccountsSnapshot snapshot={snapshot} />
+        <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} />
       </Container>
     </PageContainer>
   );

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
@@ -39,7 +39,35 @@ export const accountsSnapshotQuery = (filter: SnapshotFilter) => ({
       }
     }
   `,
-  filter,
+  filter: {
+    filter,
+  },
+});
+
+export const coreUnitShortCodeQuery = (id: string) => ({
+  query: gql`
+    query CoreUnits($filter: CoreUnitFilter) {
+      coreUnits(filter: $filter) {
+        shortCode
+      }
+    }
+  `,
+  filter: {
+    filter: { id },
+  },
+});
+
+export const teamShortCodeQuery = (id: string) => ({
+  query: gql`
+    query Teams($filter: TeamFilter) {
+      teams(filter: $filter) {
+        shortCode
+      }
+    }
+  `,
+  filter: {
+    filter: { id },
+  },
 });
 
 export const fetchAccountsSnapshot = async (ownerType: string, ownerId: string): Promise<Snapshots[]> => {
@@ -52,7 +80,57 @@ export const fetchAccountsSnapshot = async (ownerType: string, ownerId: string):
     snapshots: Snapshots[];
   }>(GRAPHQL_ENDPOINT, query, filter);
 
-  console.log(res);
-
   return res.snapshots;
+};
+
+interface CoreUnitResponse {
+  coreUnits: {
+    shortCode: string;
+  }[];
+}
+
+interface TeamResponse {
+  teams: {
+    shortCode: string;
+  }[];
+}
+
+const getCoreUnitShortCode = async (ownerId: string): Promise<string> => {
+  const { query, filter } = coreUnitShortCodeQuery(ownerId);
+  const res = await request<CoreUnitResponse>(GRAPHQL_ENDPOINT, query, filter);
+  if (res && res.coreUnits && res.coreUnits[0] && res.coreUnits[0].shortCode) {
+    return res.coreUnits[0].shortCode;
+  }
+  return 'UNKNOWN';
+};
+
+const getTeamsShortCode = async (ownerId: string): Promise<string> => {
+  const { query, filter } = teamShortCodeQuery(ownerId);
+  const res = await request<TeamResponse>(GRAPHQL_ENDPOINT, query, filter);
+  if (res && res.teams && res.teams[0] && res.teams[0].shortCode) {
+    return res.teams[0].shortCode;
+  }
+  return 'UNKNOWN';
+};
+
+export const generateSnapshotOwnerString = async (ownerType: string, ownerId: string): Promise<string> => {
+  try {
+    switch (ownerType) {
+      case 'CoreUnitDraft': {
+        const shortCode = await getCoreUnitShortCode(ownerId);
+        return `${shortCode} Core Unit`;
+      }
+      case 'DelegatesDraft':
+        return 'Recognized Delegates';
+      case 'EcosystemActorDraft': {
+        const shortCode = await getTeamsShortCode(ownerId);
+        return `${shortCode} Ecosystem Actor`;
+      }
+      default:
+        // TODO: add the correct phrase
+        return `<<PENDING: ${ownerType}, ${ownerId}>>`;
+    }
+  } catch (error) {
+    return ownerType;
+  }
 };

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -10,12 +10,12 @@ import SectionHeader from '../SectionHeader/SectionHeader';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface CUReservesProps {
-  coreUnitCode: string;
+  snapshotOwner: string;
   includeOffChain: boolean;
   toggleIncludeOffChain: () => void;
 }
 
-const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode, includeOffChain, toggleIncludeOffChain }) => {
+const CUReserves: React.FC<CUReservesProps> = ({ snapshotOwner, includeOffChain, toggleIncludeOffChain }) => {
   const { isLight } = useThemeContext();
 
   return (
@@ -23,7 +23,7 @@ const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode, includeOffChain, 
       <HeaderContainer>
         <SectionHeader
           title="Total Core Unit Reserves"
-          subtitle={`On-chain and off-chain reserves accessible to the ${coreUnitCode} Core Unit.`}
+          subtitle={`On-chain and off-chain reserves accessible to the ${snapshotOwner}.`}
           tooltip={'pending...'}
         />
         <CheckContainer isLight={isLight}>
@@ -53,7 +53,7 @@ const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode, includeOffChain, 
       <OnChainSubsection>
         <SectionHeader
           title="On Chain Reserves"
-          subtitle={`Unspent on-chain reserves to the ${coreUnitCode} Core Unit.`}
+          subtitle={`Unspent on-chain reserves to the ${snapshotOwner}.`}
           tooltip={'pending...'}
           isSubsection
         />
@@ -89,7 +89,7 @@ const CUReserves: React.FC<CUReservesProps> = ({ coreUnitCode, includeOffChain, 
       <OffChainSubsection isDisabled={!includeOffChain}>
         <SectionHeader
           title="Off Chain Reserves"
-          subtitle={`Unspent off-chain reserves to the ${coreUnitCode} Core Unit.`}
+          subtitle={`Unspent off-chain reserves to the ${snapshotOwner}.`}
           tooltip={'pending...'}
           isSubsection
         />

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -8,15 +8,15 @@ import SectionHeader from '../SectionHeader/SectionHeader';
 import TransactionHistory from '../TransactionHistory/TransactionHistory';
 
 interface FundingOverviewProps {
-  coreUnitCode: string;
+  snapshotOwner: string;
 }
 
-const FundingOverview: React.FC<FundingOverviewProps> = ({ coreUnitCode }) => (
+const FundingOverview: React.FC<FundingOverviewProps> = ({ snapshotOwner }) => (
   <div>
     <HeaderContainer>
       <SectionHeader
         title="MakerDAO Funding Overview"
-        subtitle={`Totals funds made available to the ${coreUnitCode} Core Unit over its entire lifetime, since June 2021.`}
+        subtitle={`Totals funds made available to the ${snapshotOwner} over its entire lifetime, since June 2021.`}
         tooltip={'pending...'}
       />
       <CurrencyPicker />


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Show the right subtitle according to the data coming from the API. Note that the general message is still to be defined.

# What solved
- Should create the right subtitle label according to the owner type requested