### PR TITLE
Add expanded all behaviors

### DIFF
--- a/src/core/models/dto/expenseCategoriesDTO.ts
+++ b/src/core/models/dto/expenseCategoriesDTO.ts
@@ -15,3 +15,5 @@ export interface ParsedExpenseCategory {
   // only for top-level categories
   subcategories: Omit<ParsedExpenseCategory, 'subcategories'>[];
 }
+
+export type ParsedExpenseCategoryWithExpanded = ParsedExpenseCategory & { isExpanded: boolean };

--- a/src/stories/components/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
+++ b/src/stories/components/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
@@ -10,19 +10,25 @@ import React from 'react';
 
 import type { AccordionProps } from '@mui/material/Accordion';
 import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
-import type { ParsedExpenseCategory } from '@ses/core/models/dto/expenseCategoriesDTO';
+import type { ParsedExpenseCategoryWithExpanded } from '@ses/core/models/dto/expenseCategoriesDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   style?: React.CSSProperties;
-  category: ParsedExpenseCategory;
+  category: ParsedExpenseCategoryWithExpanded;
+  expanded: boolean;
+  handleChangeItemAccordion: (categoryId: string, expanded: boolean) => void;
 }
 
-const AccordionCategory: React.FC<Props> = ({ style, category }) => {
+const AccordionCategory: React.FC<Props> = ({ style, category, expanded, handleChangeItemAccordion }) => {
   const { isLight } = useThemeContext();
+  const handleOnchange = (event: React.SyntheticEvent, expanded: boolean) => {
+    handleChangeItemAccordion(category.id, expanded);
+  };
+
   return (
     <TransactionHistoryContainer style={style}>
-      <Accordion>
+      <Accordion expanded={expanded} onChange={handleOnchange}>
         <AccordionSummary isLight={isLight}>{category.name}</AccordionSummary>
 
         <AccordionDetails>

--- a/src/stories/components/BasicModal/CategoryItem/CategoryItem.tsx
+++ b/src/stories/components/BasicModal/CategoryItem/CategoryItem.tsx
@@ -1,17 +1,19 @@
 import styled from '@emotion/styled';
 import React from 'react';
 import AccordionCategory from './ArrowAccordionCategory';
-import type { ParsedExpenseCategory } from '@ses/core/models/dto/expenseCategoriesDTO';
+import type { ParsedExpenseCategoryWithExpanded } from '@ses/core/models/dto/expenseCategoriesDTO';
 interface Props {
   isOpen?: boolean;
   onChange?: () => void;
   className?: string;
-  category: ParsedExpenseCategory;
+  category: ParsedExpenseCategoryWithExpanded;
+  expanded: boolean;
+  handleChangeItemAccordion: (id: string, expanded: boolean) => void;
 }
 
-const CategoryItem: React.FC<Props> = ({ category, className }) => (
+const CategoryItem: React.FC<Props> = ({ category, className, expanded, handleChangeItemAccordion }) => (
   <Container className={className}>
-    <AccordionCategory category={category} />
+    <AccordionCategory category={category} expanded={expanded} handleChangeItemAccordion={handleChangeItemAccordion} />
   </Container>
 );
 

--- a/src/stories/components/BasicModal/ContainerModal.tsx
+++ b/src/stories/components/BasicModal/ContainerModal.tsx
@@ -344,7 +344,7 @@ const StyledClose = styled(Close)({
 });
 
 const SimpleBarStyled = styled(SimpleBar)({
-  height: 748,
+  maxHeight: 748,
   '.simplebar-scrollbar::before': {
     width: 4,
     height: 64,
@@ -353,12 +353,12 @@ const SimpleBarStyled = styled(SimpleBar)({
     borderRadius: 20,
   },
   [lightTheme.breakpoints.up('table_834')]: {
-    height: 813,
+    maxHeight: 813,
     '.simplebar-scrollbar::before': {
       width: 6,
     },
   },
-  [lightTheme.breakpoints.up('table_834')]: {
-    height: 847,
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    maxHeight: 847,
   },
 });

--- a/src/stories/components/BasicModal/ContainerModal.tsx
+++ b/src/stories/components/BasicModal/ContainerModal.tsx
@@ -6,16 +6,17 @@ import SimpleBar from 'simplebar-react';
 import { Close } from '../svg/close';
 import CategoryItem from './CategoryItem/CategoryItem';
 import CheckBoxDescription from './ChekBoxDescription/ChekBoxDescription';
-import type { ParsedExpenseCategory } from '@ses/core/models/dto/expenseCategoriesDTO';
+import type { ParsedExpenseCategoryWithExpanded } from '@ses/core/models/dto/expenseCategoriesDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
-  headCountCategories: ParsedExpenseCategory[];
-  noHeadCountCategories: ParsedExpenseCategory[];
+  headCountCategories: ParsedExpenseCategoryWithExpanded[];
+  noHeadCountCategories: ParsedExpenseCategoryWithExpanded[];
   isCheckedExpandedAll?: boolean;
   setIsCheckedExpandedAll: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleCloseModal: () => void;
   isSomeOpen?: boolean;
+  handleChangeItemAccordion: (id: string, expanded: boolean) => void;
 }
 
 const ContainerModal: React.FC<Props> = ({
@@ -25,6 +26,7 @@ const ContainerModal: React.FC<Props> = ({
   setIsCheckedExpandedAll,
   handleCloseModal,
   isSomeOpen = false,
+  handleChangeItemAccordion,
 }) => {
   const { isLight } = useThemeContext();
   return (
@@ -51,7 +53,12 @@ const ContainerModal: React.FC<Props> = ({
           <Line isLight={isLight} />
           <HeadCountList>
             {headCountCategories?.map((item) => (
-              <CategoryItem key={item.name} category={item} />
+              <CategoryItem
+                key={item.name}
+                category={item}
+                expanded={item.isExpanded}
+                handleChangeItemAccordion={handleChangeItemAccordion}
+              />
             ))}
           </HeadCountList>
           <NoHeadCount isLight={isLight}>Non-Headcount Expense Categories</NoHeadCount>
@@ -62,7 +69,12 @@ const ContainerModal: React.FC<Props> = ({
                 ?.slice(0, noHeadCountCategories.length / 2)
 
                 .map((item) => (
-                  <CategoryItem category={item} key={item.name} />
+                  <CategoryItem
+                    category={item}
+                    key={item.name}
+                    expanded={item.isExpanded}
+                    handleChangeItemAccordion={handleChangeItemAccordion}
+                  />
                 ))}
             </ContainerPar>
             <ContainerOdd>
@@ -70,7 +82,12 @@ const ContainerModal: React.FC<Props> = ({
                 ?.slice(noHeadCountCategories.length / 2, noHeadCountCategories.length)
 
                 .map((item) => (
-                  <CategoryItem category={item} key={item.name} />
+                  <CategoryItem
+                    category={item}
+                    key={item.name}
+                    expanded={item.isExpanded}
+                    handleChangeItemAccordion={handleChangeItemAccordion}
+                  />
                 ))}
             </ContainerOdd>
           </ContainerTowColumns>

--- a/src/stories/components/BasicModal/ContainerModal.tsx
+++ b/src/stories/components/BasicModal/ContainerModal.tsx
@@ -47,7 +47,7 @@ const ContainerModal: React.FC<Props> = ({
         </ContainerDescription>
       </Header>
 
-      <SimpleBarStyled scrollbarMaxSize={32}>
+      <SimpleBarStyled>
         <InsideModal>
           <HeadCount isLight={isLight}>Headcount Expense Categories</HeadCount>
           <Line isLight={isLight} />

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
@@ -61,6 +61,7 @@ const FinancesOverviewContainer: React.FC<FinancesOverviewContainerProps> = ({
     notHeadCountCategory,
     handleCheckedExpandedAll,
     checkOut,
+    handleChangeItemAccordion,
   } = useFinancesOverview(
     quarterExpenses,
     monthlyExpenses,
@@ -137,6 +138,7 @@ const FinancesOverviewContainer: React.FC<FinancesOverviewContainerProps> = ({
           isCheckedExpandedAll={checkOut}
           handleCloseModal={handleCloseModal}
           setIsCheckedExpandedAll={handleCheckedExpandedAll}
+          handleChangeItemAccordion={handleChangeItemAccordion}
         />
       </BasicModalExtended>
     </PageWrapper>

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
@@ -281,7 +281,7 @@ const BasicModalExtended = styled(BasicModal)({
   left: '50%',
   borderRadius: 16,
   maxHeight: 748,
-  height: '100%',
+  height: 'calc(100% - 64px)',
   marginTop: 64,
   marginBottom: 64,
   overflowY: 'auto',

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
@@ -288,7 +288,8 @@ const BasicModalExtended = styled(BasicModal)({
   '::-webkit-scrollbar': {
     width: '1px',
   },
-
+  // This to hidden border in safari
+  outline: 'none',
   transform: 'translateX(-50%)',
   [lightTheme.breakpoints.up('table_834')]: {
     width: 770,

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
@@ -278,17 +278,27 @@ const BreakdownTableColumn = styled.div({
 
 const BasicModalExtended = styled(BasicModal)({
   position: 'absolute',
-  top: '64px',
   left: '50%',
+  borderRadius: 16,
+  maxHeight: 748,
+  height: '100%',
+  marginTop: 64,
+  marginBottom: 64,
+  overflowY: 'auto',
+  '::-webkit-scrollbar': {
+    width: '1px',
+  },
+
   transform: 'translateX(-50%)',
+  [lightTheme.breakpoints.up('table_834')]: {
+    width: 770,
+    maxHeight: 813,
+  },
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    top: '175px',
     width: 1114,
+    maxHeight: 847,
   },
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: 1184,
-  },
-  [lightTheme.breakpoints.up('desktop_1440')]: {
     width: 1184,
   },
 });


### PR DESCRIPTION
# Ticket

https://trello.com/c/8lQtM5Hz/276-user-story-finance-homepage-expense-categories-access

# What solved
✅Should the modal have the "expand all categories" functionality to expand/collapse the categories


# Description
This adds to the behavior of expanded all when the checkbox is select