### PR TITLE
[SES-268] Integrate Funding Overview section with the API

### DIFF
--- a/src/core/models/dto/snapshotAccountDTO.ts
+++ b/src/core/models/dto/snapshotAccountDTO.ts
@@ -40,8 +40,8 @@ export interface SnapshotAccount {
 
 export interface Snapshots {
   id: string;
-  start: string;
-  end: string;
+  start: string | null;
+  end: string | null;
   ownerType: string;
   ownerId: string;
   snapshotAccount: SnapshotAccount[];

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -12,11 +12,12 @@ interface AccountsSnapshotProps {
 }
 
 const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotOwner }) => {
-  const { expensesComparisonRows, includeOffChain, toggleIncludeOffChain } = useAccountsSnapshot(snapshot);
+  const { expensesComparisonRows, includeOffChain, toggleIncludeOffChain, startDate, endDate, mainBalance } =
+    useAccountsSnapshot(snapshot);
 
   return (
     <Wrapper>
-      <FundingOverview snapshotOwner={snapshotOwner} />
+      <FundingOverview snapshotOwner={snapshotOwner} startDate={startDate} endDate={endDate} balance={mainBalance} />
       <CUReserves
         snapshotOwner={snapshotOwner}
         includeOffChain={includeOffChain}

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
@@ -10,7 +10,7 @@ import OutlinedCard from './OutlinedCard';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface SimpleStatCardProps {
-  date: string;
+  date?: string;
   value: number;
   caption: string;
   hasEqualSign?: boolean;
@@ -30,7 +30,7 @@ const SimpleStatCard: React.FC<SimpleStatCardProps> = ({
   return (
     <Card>
       <Date isLight={isLight} align={hasEqualSign ? 'right' : 'left'}>
-        {DateTime.fromISO(date).toFormat('d MMM y')}
+        {date ? DateTime.fromISO(date).toFormat('d MMM y') : 'N/A'}
       </Date>
 
       <ContentWrapper>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
@@ -11,6 +11,14 @@ export default {
 const variantsArgs = [
   {
     snapshotOwner: 'SES Core Unit',
+    startDate: '2023-05-12T22:52:54.494Z',
+    endDate: '2023-06-14T22:52:54.494Z',
+    balance: {
+      initialBalance: 3685648,
+      newBalance: 3743328,
+      inflow: 300000,
+      outflow: 242320,
+    },
   },
 ];
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -1,38 +1,45 @@
 import styled from '@emotion/styled';
 import lightTheme from '@ses/styles/theme/light';
+import { DateTime } from 'luxon';
 import React from 'react';
 import FundChangeCard from '../Cards/FundChangeCard';
 import SimpleStatCard from '../Cards/SimpleStatCard';
 import CurrencyPicker from '../CurrencyPicker/CurrencyPicker';
 import SectionHeader from '../SectionHeader/SectionHeader';
 import TransactionHistory from '../TransactionHistory/TransactionHistory';
+import type { SnapshotAccountBalance } from '@ses/core/models/dto/snapshotAccountDTO';
 
 interface FundingOverviewProps {
   snapshotOwner: string;
+  startDate?: string;
+  endDate?: string;
+  balance: SnapshotAccountBalance;
 }
 
-const FundingOverview: React.FC<FundingOverviewProps> = ({ snapshotOwner }) => (
+const FundingOverview: React.FC<FundingOverviewProps> = ({ snapshotOwner, startDate, endDate, balance }) => (
   <div>
     <HeaderContainer>
       <SectionHeader
         title="MakerDAO Funding Overview"
-        subtitle={`Totals funds made available to the ${snapshotOwner} over its entire lifetime, since June 2021.`}
+        subtitle={`Totals funds made available to the ${snapshotOwner} over its entire lifetime${
+          startDate ? `, since ${DateTime.fromISO(startDate).toFormat('LLLL yyyy')}` : ''
+        }.`}
         tooltip={'pending...'}
       />
       <CurrencyPicker />
     </HeaderContainer>
 
     <CardsContainer>
-      <SimpleStatCard date="2023-05-12T22:52:54.494Z" value={3685648} caption="Initial Lifetime Balance" />
+      <SimpleStatCard date={startDate} value={balance.initialBalance} caption="Initial Lifetime Balance" />
       <FundChangeCard
-        netChange={57680}
-        leftValue={300000}
+        netChange={balance.inflow - balance.outflow}
+        leftValue={balance.inflow}
         leftText="Extra Funds Made Available"
-        rightValue={242320}
+        rightValue={balance.outflow}
         rightValueColor="green"
         rightText="Funds Returned via DSSBlow"
       />
-      <SimpleStatCard date="2023-06-14T22:52:54.494Z" value={3743328} caption="New Lifetime Balance" hasEqualSign />
+      <SimpleStatCard date={endDate} value={balance.newBalance} caption="New Lifetime Balance" hasEqualSign />
     </CardsContainer>
 
     <TransactionHistory />

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import ExpensesComparisonRowCard from './components/Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCard';
 import { EXPENSES_COMPARISON_TABLE_HEADER } from './components/ExpensesComparison/ExpensesComparison';
 import type { CardRenderProps, RowProps } from '@ses/components/AdvanceTable/types';
-import type { Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
+import type { SnapshotAccountBalance, Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
 
 const RenderCurrentMonthRow: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { isLight } = useThemeContext();
@@ -76,12 +76,29 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
   const { isLight } = useThemeContext();
 
   const [includeOffChain, setIncludeOffChain] = useState<boolean>(false);
-
   const toggleIncludeOffChain = () => setIncludeOffChain(!includeOffChain);
 
-  // TODO: process the snapshot object
-  console.log(snapshot);
+  const startDate = snapshot.start ?? undefined;
+  const endDate = snapshot.end ?? undefined;
 
+  const mainAccount = snapshot.snapshotAccount.find(
+    (account) => account.groupAccountId === null && account.upstreamAccountId === null
+  );
+
+  if (!mainAccount) throw new Error('Maker Protocol Wallet not found');
+
+  // the balance is for now the last entry
+  const mainBalance =
+    mainAccount.snapshotAccountBalance.length > 0
+      ? mainAccount.snapshotAccountBalance[mainAccount.snapshotAccountBalance.length - 1]
+      : ({
+          inflow: 0,
+          outflow: 0,
+          initialBalance: 0,
+          newBalance: 0,
+        } as SnapshotAccountBalance);
+
+  // mocked data for the "Reported Expenses Comparison" table
   const expensesComparisonRows = [
     buildRow(['MAY-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%', '221,504.00 DAI', '0.00%'], true, false),
     buildRow(['APR-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%', '171,500,00 DAI', '0.00%'], false, false),
@@ -94,6 +111,9 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
     expensesComparisonRows,
     includeOffChain,
     toggleIncludeOffChain,
+    startDate,
+    endDate,
+    mainBalance,
   };
 };
 


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Integrate the cards of the funding overview section with the API

# What solved
- Should show the actual values coming from the API in the "MakerDAO Funding Overview" section (cards) 