### PR TITLE
Add position in mobile

### DIFF
--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
@@ -283,7 +283,7 @@ const BasicModalExtended = styled(BasicModal)({
   maxHeight: 748,
   height: 'calc(100% - 64px)',
   marginTop: 64,
-  marginBottom: 64,
+  marginBottom: 0,
   overflowY: 'auto',
   '::-webkit-scrollbar': {
     width: '1px',
@@ -292,6 +292,7 @@ const BasicModalExtended = styled(BasicModal)({
   outline: 'none',
   transform: 'translateX(-50%)',
   [lightTheme.breakpoints.up('table_834')]: {
+    marginBottom: 64,
     width: 770,
     maxHeight: 813,
   },


### PR DESCRIPTION
# Ticket

https://trello.com/c/8lQtM5Hz/276-user-story-finance-homepage-expense-categories-access

# What solved
✅ The modal is displayed T the end of the page.
✅  All text is displayed with lower letters. 


# Description
Add only marginTop when is mobile
