### PR TITLE
Add the function to give space elements

### DIFF
--- a/src/stories/components/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
+++ b/src/stories/components/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
@@ -30,7 +30,7 @@ const AccordionCategory: React.FC<Props> = ({ style, category, expanded, handleC
   return (
     <TransactionHistoryContainer style={style}>
       <Accordion expanded={expanded} onChange={handleOnchange}>
-        <AccordionSummary isLight={isLight}>{category.name}</AccordionSummary>
+        <AccordionSummary isLight={isLight}>{pascalCaseToNormalString(category.name)}</AccordionSummary>
 
         <AccordionDetails>
           <ItemsStyle isLight={isLight}>


### PR DESCRIPTION
# Ticket

https://trello.com/c/8lQtM5Hz/276-user-story-finance-homepage-expense-categories-access

# What solved
✅The categories display the words without any space between them.

# Description
This is to add some space between words