### PR TITLE
[SES-QA-277] Fix: makerburn link

### DIFF
--- a/src/stories/containers/CUAbout/CuAboutContainer.tsx
+++ b/src/stories/containers/CUAbout/CuAboutContainer.tsx
@@ -145,7 +145,7 @@ const CuAboutContainer = ({ code, coreUnits, cuAbout }: Props) => {
               {isEnabled('FEATURE_CARD_NAVIGATION') && (
                 <ContainerScroll>
                   <ContainerCard>
-                    <CardExpenses queryStrings={queryStrings} code={cuAbout.shortCode} auditors={cuAbout.auditors} />
+                    <CardExpenses queryStrings={queryStrings} code={cuAbout.code} auditors={cuAbout.auditors} />
                   </ContainerCard>
                   {!(table834 || phone || LessPhone) && (
                     <ContainerCard>


### PR DESCRIPTION
# Ticket
https://trello.com/c/FEo923dc/277-qa-bug-finding-r

# Description
The Makerburn link on the CU about was fixed

# What solved
- The link View on-chain transfers to PE Core Unit on makerburn.com within the “Expenses” Box directs to an outdated link.