### PR TITLE
[SES-268] Implement group transaction list

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
@@ -270,6 +270,7 @@ const NetChangeMessage = styled.div<WithIsLight>(({ isLight }) => ({
   lineHeight: '15px',
   color: isLight ? '#D1DEE6' : '#405361',
   margin: '4px 10px 3px 0',
+  whiteSpace: 'nowrap',
 
   [lightTheme.breakpoints.up('table_834')]: {
     fontSize: 14,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -7,6 +7,7 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
+import TransactionList from '../TransactionList/TransactionList';
 import WalletInfo from '../WalletInfo/WalletInfo';
 import type { AccordionProps } from '@mui/material/Accordion';
 import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
@@ -93,7 +94,9 @@ const ReserveCard: React.FC<ReserveCardProps> = ({
         </NewBalance>
         {!isMobile && <ArrowContainer>{SVG}</ArrowContainer>}
       </Card>
-      <TransactionContainer>transaction list</TransactionContainer>
+      <TransactionContainer>
+        <TransactionList showGroup={true} />
+      </TransactionContainer>
     </Accordion>
   );
 };
@@ -118,9 +121,16 @@ const Card = styled((props: AccordionSummaryProps) => <MuiAccordionSummary {...p
       ? '0px 4px 6px rgba(196, 196, 196, 0.25)'
       : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
     borderRadius: 6,
+    zIndex: 1,
 
     [lightTheme.breakpoints.up('table_834')]: {
       padding: 0,
+    },
+
+    '&.Mui-expanded': {
+      [lightTheme.breakpoints.down('table_834')]: {
+        borderRadius: '6px 6px 0 0',
+      },
     },
 
     '& .MuiAccordionSummary-content': {
@@ -137,8 +147,11 @@ const Card = styled((props: AccordionSummaryProps) => <MuiAccordionSummary {...p
 );
 
 const TransactionContainer = styled(MuiAccordionDetails)(() => ({
-  padding: '0 0 14px',
-  background: 'red',
+  padding: 0,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    marginBottom: 24,
+  },
 }));
 
 const NameContainer = styled.div({
@@ -308,7 +321,7 @@ const NewBalance = styled(InitialBalance)({
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    padding: '16px 64px 16px 16px',
+    padding: '16px 32px 16px 16px',
   },
 });
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
@@ -1,0 +1,233 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import GreenArrowDown from '../SVG/GreenArrowDown';
+import RedArrowUp from '../SVG/RedArrowUp';
+import WalletInfo from '../WalletInfo/WalletInfo';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+const GroupItem: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <GroupItemContainer isLight={isLight}>
+      <WalletContainer>
+        <WalletInfo name={'Stream #13'} address={'0x232b54886a238482'} />
+      </WalletContainer>
+      <InitialBalance>
+        <Label isLight={isLight}>Initial Balance</Label>
+        <Value isLight={isLight}>
+          {usLocalizedNumber(153480)} <Currency isLight={isLight}>DAI</Currency>
+        </Value>
+      </InitialBalance>
+      <Inflow>
+        <Label isLight={isLight}>
+          <GreenArrowDown width={16} height={16} /> Inflow
+        </Label>
+        <ValueContainer>
+          <GreenArrowDown width={16} height={16} />
+          <Value isLight={isLight}>
+            <Sign>{'+'}</Sign>
+            {usLocalizedNumber(150000)} <Currency isLight={isLight}>DAI</Currency>
+          </Value>
+        </ValueContainer>
+      </Inflow>
+      <Outflow>
+        <Label isLight={isLight}>
+          <RedArrowUp width={16} height={16} />
+          Outflow
+        </Label>
+        <ValueContainer>
+          <RedArrowUp width={16} height={16} />
+          <Value isLight={isLight}>
+            <Sign>{'-'}</Sign>
+            {usLocalizedNumber(300000)} <Currency isLight={isLight}>DAI</Currency>
+          </Value>
+        </ValueContainer>
+      </Outflow>
+      <NewBalance>
+        <Label isLight={isLight}>New Balance</Label>
+        <Value isLight={isLight}>
+          <span>{usLocalizedNumber(100000)}</span> <Currency isLight={isLight}>DAI</Currency>
+        </Value>
+      </NewBalance>
+    </GroupItemContainer>
+  );
+};
+
+export default GroupItem;
+
+const GroupItemContainer = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '16px 16px 24px',
+  borderRadius: 6,
+  overflow: 'hidden',
+  background: isLight ? '#F5F6FB' : '#26313F',
+  boxShadow: isLight
+    ? '0px 4px 6px rgba(196, 196, 196, 0.25)'
+    : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    background: isLight ? '#F5F6FB' : '#283341',
+    flexDirection: 'row',
+    padding: '16px 32px 16px 16px',
+    borderRadius: 0,
+    boxShadow: 'none',
+
+    '&:hover': {
+      background: isLight ? '#F6F8F9' : '#1F2931',
+    },
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '16px 56px 16px 16px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '16px 64px 16px 20px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    padding: '16px 80px 16px 20px',
+  },
+}));
+
+const WalletContainer = styled.div({
+  marginBottom: 24,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    marginBottom: 0,
+    width: '40.5%',
+
+    '& > div': {
+      marginTop: 0,
+    },
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    width: '39.5%',
+  },
+});
+
+const InitialBalance = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    display: 'none',
+  },
+});
+
+const Label = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  fontSize: 14,
+  lineHeight: '17px',
+  color: isLight ? '#708390' : '#708390',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    fontSize: 11,
+    lineHeight: '13px',
+
+    '& > svg': {
+      display: 'none',
+    },
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    fontSize: 12,
+    lineHeight: '15px',
+  },
+}));
+
+const ValueContainer = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+
+  '& > svg': {
+    display: 'none',
+  },
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    '& > svg': {
+      display: 'inline-block',
+    },
+  },
+});
+
+const Value = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: 4,
+  fontWeight: 700,
+  fontSize: 14,
+  lineHeight: '17px',
+
+  '&, & > span:first-of-type': {
+    color: isLight ? '#231536' : '#D2D4EF',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    fontSize: 16,
+    lineHeight: '19px',
+  },
+}));
+
+const Sign = styled.span({
+  fontWeight: 700,
+  fontSize: 14,
+  lineHeight: '17px',
+});
+
+const Currency = styled.span<WithIsLight>(({ isLight }) => ({
+  fontWeight: 600,
+  fontSize: 12,
+  lineHeight: '15px',
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  color: isLight ? '#9FAFB9' : '#9FAFB9',
+}));
+
+const Inflow = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginTop: 16,
+  marginBottom: 12,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    margin: 0,
+    flexDirection: 'column',
+    justifyContent: 'normal',
+    gap: 8,
+    width: '20.5%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    width: '21.5%',
+  },
+});
+
+const Outflow = styled(Inflow)({
+  marginTop: 12,
+  marginBottom: 16,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    margin: 0,
+  },
+});
+
+const NewBalance = styled(InitialBalance)({
+  [lightTheme.breakpoints.up('table_834')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'normal',
+    marginLeft: 'auto',
+    alignItems: 'flex-end',
+    gap: 8,
+  },
+});

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionAmount.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionAmount.tsx
@@ -85,6 +85,10 @@ const Currency = styled.span<WithIsLight>(({ isLight }) => ({
   textTransform: 'uppercase',
   color: isLight ? '#9FAFB9' : '#546978',
 
+  [lightTheme.breakpoints.up('table_834')]: {
+    color: '#9FAFB9',
+  },
+
   [lightTheme.breakpoints.up('desktop_1194')]: {
     fontSize: 14,
     lineHeight: '17px',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
@@ -6,7 +6,7 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import React, { useState } from 'react';
 import AccordionArrow from '../AccordionArrow/AccordionArrow';
-import Transaction from '../Transaction/Transaction';
+import TransactionList from '../TransactionList/TransactionList';
 import type { AccordionProps } from '@mui/material/Accordion';
 import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -25,46 +25,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ defaultExpanded
       <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)}>
         <AccordionSummary isLight={isLight}>View Transaction History</AccordionSummary>
         <AccordionDetails>
-          <TransactionContainer isLight={isLight}>
-            <Transaction
-              name={'DSS Blow'}
-              date={'2023-04-17T11:36:05.188Z'}
-              toDate={null}
-              txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
-              counterPartyName={'Auditor Wallet'}
-              counterPartyAddress={'0x232b5483e5a5cd22188482'}
-              amount={-1153480}
-            />
-            <Transaction
-              isIncomingTransaction={false}
-              name={'DSS Vest'}
-              date={'2023-04-15T11:36:05.188Z'}
-              toDate={'2023-05-15T11:36:05.188Z'}
-              txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
-              counterPartyName={'Stream #14'}
-              counterPartyAddress={'0x232b5483e5a5cd22188482'}
-              amount={153480}
-            />
-            <Transaction
-              name={'DSS Blow'}
-              date={'2023-03-28T17:32:05.188Z'}
-              toDate={null}
-              txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
-              counterPartyName={'Auditor Wallet'}
-              counterPartyAddress={'0x232b5483e5a5cd22188482'}
-              amount={-1153480}
-            />
-            <Transaction
-              isIncomingTransaction={false}
-              name={'Direct Transaction'}
-              date={'2023-03-28T09:45:05.188Z'}
-              toDate={null}
-              txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
-              counterPartyName={'Auditor Wallet'}
-              counterPartyAddress={'0x232b5483e5a5cd22188482'}
-              amount={153480}
-            />
-          </TransactionContainer>
+          <TransactionList />
         </AccordionDetails>
       </Accordion>
     </TransactionHistoryContainer>
@@ -92,6 +53,7 @@ const AccordionSummary = styled((props: AccordionSummaryProps) => (
   paddingLeft: 16,
   paddingRight: 8,
   minHeight: 'auto',
+  zIndex: 1,
 
   '&.Mui-expanded': {
     [lightTheme.breakpoints.down('table_834')]: {
@@ -131,36 +93,4 @@ const AccordionSummary = styled((props: AccordionSummaryProps) => (
 
 const AccordionDetails = styled(MuiAccordionDetails)({
   padding: 0,
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    padding: '0 24px',
-  },
-
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    padding: '0 32px',
-  },
-
-  [lightTheme.breakpoints.up('desktop_1280')]: {
-    padding: '0 40px',
-  },
-
-  [lightTheme.breakpoints.up('desktop_1440')]: {
-    padding: '0 56px',
-  },
 });
-
-const TransactionContainer = styled.div<WithIsLight>(({ isLight }) => ({
-  borderRadius: '0 0 6px 6px',
-  background: isLight ? '#ECEFF9' : '#38364D',
-  padding: 8,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    padding: 0,
-    background: isLight ? '#FBFBFB' : '#162530',
-    boxShadow: isLight ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)' : 'none',
-    gap: 0,
-  },
-}));

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
@@ -1,0 +1,114 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import GroupItem from '../GroupItem/GroupItem';
+import Transaction from '../Transaction/Transaction';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+const TransactionList: React.FC<{ showGroup?: boolean }> = ({ showGroup = false }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <TransactionListContainer isLight={isLight}>
+      <TransactionCard isLight={isLight}>
+        {showGroup && <GroupItem />}
+
+        <Transaction
+          name={'DSS Blow'}
+          date={'2023-04-17T11:36:05.188Z'}
+          toDate={null}
+          txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
+          counterPartyName={'Auditor Wallet'}
+          counterPartyAddress={'0x232b5483e5a5cd22188482'}
+          amount={-1153480}
+        />
+        <Transaction
+          isIncomingTransaction={false}
+          name={'DSS Vest'}
+          date={'2023-04-15T11:36:05.188Z'}
+          toDate={'2023-05-15T11:36:05.188Z'}
+          txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
+          counterPartyName={'Stream #14'}
+          counterPartyAddress={'0x232b5483e5a5cd22188482'}
+          amount={153480}
+        />
+        <Transaction
+          name={'DSS Blow'}
+          date={'2023-03-28T17:32:05.188Z'}
+          toDate={null}
+          txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
+          counterPartyName={'Auditor Wallet'}
+          counterPartyAddress={'0x232b5483e5a5cd22188482'}
+          amount={-1153480}
+        />
+        <Transaction
+          isIncomingTransaction={false}
+          name={'Direct Transaction'}
+          date={'2023-03-28T09:45:05.188Z'}
+          toDate={null}
+          txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
+          counterPartyName={'Auditor Wallet'}
+          counterPartyAddress={'0x232b5483e5a5cd22188482'}
+          amount={153480}
+        />
+      </TransactionCard>
+    </TransactionListContainer>
+  );
+};
+
+export default TransactionList;
+
+const TransactionListContainer = styled.div<WithIsLight>(({ isLight }) => ({
+  padding: 0,
+  position: 'relative',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    padding: '0 24px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '0 32px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    padding: '0 40px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    padding: '0 56px',
+  },
+
+  '&:before': {
+    content: '""',
+    display: 'block',
+    width: '100%',
+    height: 17,
+    position: 'absolute',
+    top: -7,
+    left: 0,
+    opacity: 0.6,
+    filter: 'blur(7.5px)',
+    borderRadius: '0px 0px 6px 6px',
+    background: isLight
+      ? 'linear-gradient(0deg, rgba(219, 227, 237, 0.2), rgba(219, 227, 237, 0.2)), linear-gradient(180deg, rgba(190, 190, 190, 0.64) 0%, rgba(190, 190, 190, 0) 100%)'
+      : 'linear-gradient(0deg, rgba(3, 16, 32, 0.2), rgba(3, 16, 32, 0.2)), linear-gradient(180deg, rgba(0, 32, 202, 0.64) 0%, rgba(64, 85, 200, 0) 100%)',
+  },
+}));
+
+const TransactionCard = styled.div<WithIsLight>(({ isLight }) => ({
+  borderRadius: '0 0 6px 6px',
+  background: isLight ? '#ECEFF9' : '#38364D',
+  overflow: 'hidden',
+  padding: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    padding: 0,
+    background: isLight ? '#FBFBFB' : '#162530',
+    boxShadow: isLight ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)' : 'none',
+    gap: 0,
+  },
+}));


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Created a transaction list with group support for the on/off chain reserves cards and reused in the transaction history

# What solved
- Should support multiple groups and corresponding wallets (e.g., "Stream 14" and its corresponding wallet) and transactions when the cards in the "On/Off Chain reserves" are expanded