### PR TITLE
Add 100 percent height in the mobile

### DIFF
--- a/src/stories/components/BasicModal/ContainerModal.tsx
+++ b/src/stories/components/BasicModal/ContainerModal.tsx
@@ -103,7 +103,6 @@ export default ContainerModal;
 const Container = styled.div<WithIsLight & { isSomeOpen?: boolean }>(({ isLight, isSomeOpen }) => ({
   display: 'flex',
   flexDirection: 'column',
-  paddingBottom: 27,
   overflowY: 'auto',
 
   '::-webkit-scrollbar': {


### PR DESCRIPTION
# Ticket

https://trello.com/c/8lQtM5Hz/276-user-story-finance-homepage-expense-categories-access

# What solved
✅This made modal in mobile 100%

# Description
This is for mobile 100% height