### PR TITLE
[SES-268] Integrate on chain reserve cards with the API

### DIFF
--- a/src/core/businessLogic/builders/accountSnapshot/accountSnapshotBuilder.ts
+++ b/src/core/businessLogic/builders/accountSnapshot/accountSnapshotBuilder.ts
@@ -1,0 +1,66 @@
+import type {
+  SnapshotAccount,
+  SnapshotAccountBalance,
+  SnapshotAccountTransaction,
+} from '@ses/core/models/dto/snapshotAccountDTO';
+
+export class SnapshotAccountBuilder {
+  private readonly _snapshotAccount: SnapshotAccount;
+
+  constructor() {
+    this._snapshotAccount = {
+      id: '',
+      accountLabel: '',
+      accountType: '',
+      accountAddress: '',
+      groupAccountId: '',
+      upstreamAccountId: '',
+      snapshotAccountTransaction: [] as SnapshotAccountTransaction[],
+      snapshotAccountBalance: [] as SnapshotAccountBalance[],
+    };
+  }
+
+  withId(id: string): SnapshotAccountBuilder {
+    this._snapshotAccount.id = id;
+    return this;
+  }
+
+  withAccountLabel(accountLabel: string): SnapshotAccountBuilder {
+    this._snapshotAccount.accountLabel = accountLabel;
+    return this;
+  }
+
+  withAccountType(accountType: string): SnapshotAccountBuilder {
+    this._snapshotAccount.accountType = accountType;
+    return this;
+  }
+
+  withAccountAddress(accountAddress: string): SnapshotAccountBuilder {
+    this._snapshotAccount.accountAddress = accountAddress;
+    return this;
+  }
+
+  withGroupAccountId(groupAccountId: string): SnapshotAccountBuilder {
+    this._snapshotAccount.groupAccountId = groupAccountId;
+    return this;
+  }
+
+  withUpstreamAccountId(upstreamAccountId: string): SnapshotAccountBuilder {
+    this._snapshotAccount.upstreamAccountId = upstreamAccountId;
+    return this;
+  }
+
+  addSnapshotAccountTransaction(snapshotAccountTransaction: SnapshotAccountTransaction): SnapshotAccountBuilder {
+    this._snapshotAccount.snapshotAccountTransaction.push(snapshotAccountTransaction);
+    return this;
+  }
+
+  addSnapshotAccountBalance(snapshotAccountBalance: SnapshotAccountBalance): SnapshotAccountBuilder {
+    this._snapshotAccount.snapshotAccountBalance.push(snapshotAccountBalance);
+    return this;
+  }
+
+  build(): SnapshotAccount {
+    return this._snapshotAccount;
+  }
+}

--- a/src/core/businessLogic/builders/accountSnapshot/snapshotAccountBalanceBuilder.ts
+++ b/src/core/businessLogic/builders/accountSnapshot/snapshotAccountBalanceBuilder.ts
@@ -1,0 +1,50 @@
+import type { SnapshotAccountBalance, Token } from '@ses/core/models/dto/snapshotAccountDTO';
+
+export class SnapshotAccountBalanceBuilder {
+  private readonly _snapshotAccountBalance: SnapshotAccountBalance;
+
+  constructor() {
+    this._snapshotAccountBalance = {
+      id: '',
+      token: 'DAI',
+      initialBalance: 0,
+      newBalance: 0,
+      inflow: 0,
+      outflow: 0,
+    };
+  }
+
+  withId(id: string): SnapshotAccountBalanceBuilder {
+    this._snapshotAccountBalance.id = id;
+    return this;
+  }
+
+  withToken(token: Token): SnapshotAccountBalanceBuilder {
+    this._snapshotAccountBalance.token = token;
+    return this;
+  }
+
+  withInitialBalance(initialBalance: number): SnapshotAccountBalanceBuilder {
+    this._snapshotAccountBalance.initialBalance = initialBalance;
+    return this;
+  }
+
+  withNewBalance(newBalance: number): SnapshotAccountBalanceBuilder {
+    this._snapshotAccountBalance.newBalance = newBalance;
+    return this;
+  }
+
+  withInflow(inflow: number): SnapshotAccountBalanceBuilder {
+    this._snapshotAccountBalance.inflow = inflow;
+    return this;
+  }
+
+  withOutflow(outflow: number): SnapshotAccountBalanceBuilder {
+    this._snapshotAccountBalance.outflow = outflow;
+    return this;
+  }
+
+  build(): SnapshotAccountBalance {
+    return this._snapshotAccountBalance;
+  }
+}

--- a/src/core/businessLogic/builders/accountSnapshot/snapshotAccountTransactionBuilder.ts
+++ b/src/core/businessLogic/builders/accountSnapshot/snapshotAccountTransactionBuilder.ts
@@ -1,0 +1,56 @@
+import type { SnapshotAccountTransaction, Token } from '@ses/core/models/dto/snapshotAccountDTO';
+
+export class SnapshotAccountTransactionBuilder {
+  private readonly _snapshotAccountTransaction: SnapshotAccountTransaction;
+
+  constructor() {
+    this._snapshotAccountTransaction = {
+      id: '',
+      block: 0,
+      timestamp: '',
+      tx_hash: '',
+      token: 'DAI',
+      counterParty: '',
+      amount: 0,
+    };
+  }
+
+  withId(id: string): SnapshotAccountTransactionBuilder {
+    this._snapshotAccountTransaction.id = id;
+    return this;
+  }
+
+  withBlock(block: number): SnapshotAccountTransactionBuilder {
+    this._snapshotAccountTransaction.block = block;
+    return this;
+  }
+
+  withTimestamp(timestamp: string): SnapshotAccountTransactionBuilder {
+    this._snapshotAccountTransaction.timestamp = timestamp;
+    return this;
+  }
+
+  withTxHash(txHash: string): SnapshotAccountTransactionBuilder {
+    this._snapshotAccountTransaction.tx_hash = txHash;
+    return this;
+  }
+
+  withToken(token: Token): SnapshotAccountTransactionBuilder {
+    this._snapshotAccountTransaction.token = token;
+    return this;
+  }
+
+  withCounterParty(counterParty: string): SnapshotAccountTransactionBuilder {
+    this._snapshotAccountTransaction.counterParty = counterParty;
+    return this;
+  }
+
+  withAmount(amount: number): SnapshotAccountTransactionBuilder {
+    this._snapshotAccountTransaction.amount = amount;
+    return this;
+  }
+
+  build(): SnapshotAccountTransaction {
+    return this._snapshotAccountTransaction;
+  }
+}

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -20,6 +20,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
     endDate,
     mainBalance,
     cuReservesBalance,
+    onChainAccounts,
   } = useAccountsSnapshot(snapshot);
 
   return (
@@ -32,6 +33,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
         startDate={startDate}
         endDate={endDate}
         balance={cuReservesBalance}
+        accounts={onChainAccounts}
       />
       <ExpensesComparison rows={expensesComparisonRows} />
     </Wrapper>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.stories.tsx
@@ -1,3 +1,5 @@
+import { SnapshotAccountBuilder } from '@ses/core/businessLogic/builders/accountSnapshot/accountSnapshotBuilder';
+import { SnapshotAccountBalanceBuilder } from '@ses/core/businessLogic/builders/accountSnapshot/snapshotAccountBalanceBuilder';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import CUReserves from './CUReserves';
 import type { ComponentMeta } from '@storybook/react';
@@ -13,12 +15,54 @@ const variantsArgs = [
     snapshotOwner: 'SES Core Unit',
     startDate: '2023-05-12T22:52:54.494Z',
     endDate: '2023-06-14T22:52:54.494Z',
-    balance: {
-      initialBalance: 1500000,
-      newBalance: 1266680,
-      inflow: 305000,
-      outflow: 538320,
-    },
+    balance: new SnapshotAccountBalanceBuilder()
+      .withInitialBalance(1500000)
+      .withNewBalance(1266680)
+      .withInflow(305000)
+      .withOutflow(-538320)
+      .build(),
+    accounts: [
+      new SnapshotAccountBuilder()
+        .withId('1')
+        .withAccountLabel('DSS Vest')
+        .withAccountType('group')
+        .addSnapshotAccountBalance(
+          new SnapshotAccountBalanceBuilder()
+            .withInitialBalance(100000)
+            .withNewBalance(100000)
+            .withInflow(300000)
+            .withOutflow(-300000)
+            .build()
+        )
+        .build(),
+      new SnapshotAccountBuilder()
+        .withId('2')
+        .withAccountLabel('Auditor')
+        .withAccountType('singular')
+        .withAccountAddress('0x23b554585a4ef8482')
+        .addSnapshotAccountBalance(
+          new SnapshotAccountBalanceBuilder()
+            .withInitialBalance(500000)
+            .withNewBalance(550000)
+            .withInflow(300000)
+            .withOutflow(-250000)
+            .build()
+        )
+        .build(),
+      new SnapshotAccountBuilder()
+        .withId('3')
+        .withAccountLabel('Operational')
+        .withAccountType('group')
+        .addSnapshotAccountBalance(
+          new SnapshotAccountBalanceBuilder()
+            .withInitialBalance(900000)
+            .withNewBalance(1100000)
+            .withInflow(250000)
+            .withOutflow(-50000)
+            .build()
+        )
+        .build(),
+    ],
   },
 ];
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -7,7 +7,7 @@ import FundChangeCard from '../Cards/FundChangeCard';
 import ReserveCard from '../Cards/ReserveCard';
 import SimpleStatCard from '../Cards/SimpleStatCard';
 import SectionHeader from '../SectionHeader/SectionHeader';
-import type { SnapshotAccountBalance } from '@ses/core/models/dto/snapshotAccountDTO';
+import type { SnapshotAccount, SnapshotAccountBalance } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface CUReservesProps {
@@ -16,7 +16,8 @@ interface CUReservesProps {
   toggleIncludeOffChain: () => void;
   startDate?: string;
   endDate?: string;
-  balance: SnapshotAccountBalance;
+  balance?: SnapshotAccountBalance;
+  accounts?: SnapshotAccount[];
 }
 
 const CUReserves: React.FC<CUReservesProps> = ({
@@ -26,6 +27,7 @@ const CUReserves: React.FC<CUReservesProps> = ({
   startDate,
   endDate,
   balance,
+  accounts,
 }) => {
   const { isLight } = useThemeContext();
 
@@ -44,17 +46,17 @@ const CUReserves: React.FC<CUReservesProps> = ({
       </HeaderContainer>
 
       <CardsContainer>
-        <SimpleStatCard date={startDate} value={balance.initialBalance} caption="Initial Core Unit Reserves" />
+        <SimpleStatCard date={startDate} value={balance?.initialBalance} caption="Initial Core Unit Reserves" />
         <FundChangeCard
-          netChange={balance.inflow - balance.outflow}
-          leftValue={balance.inflow}
+          netChange={balance?.inflow && balance?.outflow ? balance.outflow - balance.inflow * -1 : undefined}
+          leftValue={balance?.inflow}
           leftText="Inflow"
-          rightValue={balance.outflow}
+          rightValue={balance?.outflow ? balance?.outflow * -1 : undefined}
           rightText="Outflow"
         />
         <SimpleStatCard
           date={endDate}
-          value={balance.newBalance}
+          value={balance?.newBalance}
           caption="New Core Unit Reserves"
           hasEqualSign
           isReserves
@@ -70,30 +72,22 @@ const CUReserves: React.FC<CUReservesProps> = ({
         />
 
         <ReservesCardsContainer>
-          <ReserveCard
-            name="DSS Vest"
-            isGroup
-            initialBalance={100000}
-            inflow={300000}
-            outflow={300000}
-            newBalance={100000}
-          />
-          <ReserveCard
-            name="Auditor"
-            address={'0x23b554585a4ef8482'}
-            initialBalance={500000}
-            inflow={300000}
-            outflow={250000}
-            newBalance={550000}
-          />
-          <ReserveCard
-            name="Operational"
-            isGroup
-            initialBalance={900000}
-            inflow={250000}
-            outflow={50000}
-            newBalance={1100000}
-          />
+          {accounts?.map((account) => (
+            <ReserveCard
+              key={account.id}
+              name={account.accountLabel}
+              isGroup={account.accountType !== 'singular'}
+              address={account.accountAddress}
+              initialBalance={account.snapshotAccountBalance?.[0]?.initialBalance}
+              inflow={account.snapshotAccountBalance?.[0]?.inflow}
+              outflow={
+                account.snapshotAccountBalance?.[0]?.outflow
+                  ? account.snapshotAccountBalance?.[0]?.outflow * -1
+                  : account.snapshotAccountBalance?.[0]?.outflow
+              }
+              newBalance={account.snapshotAccountBalance?.[0]?.newBalance}
+            />
+          ))}
         </ReservesCardsContainer>
       </OnChainSubsection>
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
@@ -10,11 +10,11 @@ import type { ValueColor } from '../NumberWithSignCard/NumberWithSignCard';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface FundChangeCardProps {
-  netChange: number;
-  leftValue: number;
+  netChange?: number;
+  leftValue?: number;
   leftValueColor?: ValueColor;
   leftText: string;
-  rightValue: number;
+  rightValue?: number;
   rightValueColor?: ValueColor;
   rightText: string;
 }
@@ -40,8 +40,14 @@ const FundChangeCard: React.FC<FundChangeCardProps> = ({
         </LeftArrowContainer>
         <ChangeContent>
           <Value isLight={isLight}>
-            {netChange > 0 && '+'}
-            {usLocalizedNumber(Math.round(netChange))} <span>DAI</span>
+            {netChange !== undefined ? (
+              <>
+                {netChange > 0 && '+'}
+                {usLocalizedNumber(Math.round(netChange))} <span>DAI</span>
+              </>
+            ) : (
+              'N/A'
+            )}
           </Value>
           <NetChangeMessage isLight={isLight}>Net Change</NetChangeMessage>
         </ChangeContent>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
@@ -11,7 +11,7 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface SimpleStatCardProps {
   date?: string;
-  value: number;
+  value?: number;
   caption: string;
   hasEqualSign?: boolean;
   isReserves?: boolean;
@@ -41,7 +41,13 @@ const SimpleStatCard: React.FC<SimpleStatCardProps> = ({
         )}
         <Wrapper>
           <Value isLight={isLight}>
-            {usLocalizedNumber(Math.round(value))} <span>DAI</span>
+            {value !== undefined ? (
+              <>
+                {usLocalizedNumber(Math.round(value))} <span>DAI</span>
+              </>
+            ) : (
+              'N/A'
+            )}
           </Value>
           <Caption isLight={isLight} position={hasEqualSign ? 'right' : 'left'} isReserves={isReserves}>
             {caption}

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
@@ -14,9 +14,9 @@ const CommonArgs = {
   endDate: '2023-06-14T22:52:54.494Z',
   balance: {
     initialBalance: 3685648,
-    newBalance: 3743328,
+    newBalance: -3743328,
     inflow: 300000,
-    outflow: 242320,
+    outflow: -242320,
   },
 };
 const variantsArgs = [

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -13,7 +13,7 @@ interface FundingOverviewProps {
   snapshotOwner: string;
   startDate?: string;
   endDate?: string;
-  balance: SnapshotAccountBalance;
+  balance?: SnapshotAccountBalance;
 
   // Only used for storybook
   defaultExpanded?: boolean;
@@ -39,16 +39,21 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({
     </HeaderContainer>
 
     <CardsContainer>
-      <SimpleStatCard date={startDate} value={balance.initialBalance} caption="Initial Lifetime Balance" />
+      <SimpleStatCard date={startDate} value={balance?.initialBalance} caption="Initial Lifetime Balance" />
       <FundChangeCard
-        netChange={balance.inflow - balance.outflow}
-        leftValue={balance.inflow}
+        netChange={balance?.inflow && balance?.outflow ? balance.outflow * -1 - balance.inflow : undefined}
+        leftValue={balance?.outflow ? balance?.outflow * -1 : undefined}
         leftText="Extra Funds Made Available"
-        rightValue={balance.outflow}
+        rightValue={balance?.inflow}
         rightValueColor="green"
         rightText="Funds Returned via DSSBlow"
       />
-      <SimpleStatCard date={endDate} value={balance.newBalance} caption="New Lifetime Balance" hasEqualSign />
+      <SimpleStatCard
+        date={endDate}
+        value={balance?.newBalance ? balance.newBalance * -1 : balance?.newBalance}
+        caption="New Lifetime Balance"
+        hasEqualSign
+      />
     </CardsContainer>
 
     <TransactionHistory defaultExpanded={defaultExpanded} />

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCard.tsx
@@ -8,7 +8,7 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 export type ValueColor = 'normal' | 'green';
 
 interface NumberWithSignCardProps {
-  value: number;
+  value?: number;
   text: string;
   sign: 'positive' | 'negative';
   valueColor?: ValueColor;
@@ -48,7 +48,13 @@ const NumberWithSignCard: React.FC<NumberWithSignCardProps> = ({ value, sign, te
       </SignContainer>
       <Card isLight={isLight} sign={sign}>
         <Value isLight={isLight} valueColor={valueColor}>
-          {usLocalizedNumber(Math.round(value))} <span>DAI</span>
+          {value !== undefined ? (
+            <>
+              {usLocalizedNumber(Math.round(value))} <span>DAI</span>
+            </>
+          ) : (
+            'N/A'
+          )}
         </Value>
         <Text isLight={isLight}>{text}</Text>
       </Card>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.tsx
@@ -54,6 +54,7 @@ const Container = styled.div({
 const BlockiesContainer = styled.div({
   width: 32,
   height: 32,
+  minWidth: 32,
   borderRadius: '50%',
   marginRight: 16,
   marginTop: 2,
@@ -89,6 +90,7 @@ const Name = styled.div<WithIsLight>(({ isLight }) => ({
 const InfoIcon = styled(Information)<WithIsLight>(({ isLight }) => ({
   fill: isLight ? '#D1DEE6' : '#7C6B95',
   marginTop: 1,
+  minWidth: 15,
 }));
 
 const AddressContainer = styled.div({

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -3,14 +3,7 @@ import { useState } from 'react';
 import ExpensesComparisonRowCard from './components/Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCard';
 import { EXPENSES_COMPARISON_TABLE_HEADER } from './components/ExpensesComparison/ExpensesComparison';
 import type { CardRenderProps, RowProps } from '@ses/components/AdvanceTable/types';
-import type { SnapshotAccountBalance, Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
-
-const EMPTY_BALANCE = {
-  inflow: 0,
-  outflow: 0,
-  initialBalance: 0,
-  newBalance: 0,
-} as SnapshotAccountBalance;
+import type { SnapshotAccount, Snapshots, Token } from '@ses/core/models/dto/snapshotAccountDTO';
 
 const RenderCurrentMonthRow: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { isLight } = useThemeContext();
@@ -82,6 +75,10 @@ export const buildRow = (
 const useAccountsSnapshot = (snapshot: Snapshots) => {
   const { isLight } = useThemeContext();
 
+  // TODO: the `setSelectedTo` is not used yet, but it will be used to filter the data
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [selectedToken, setSelectedToken] = useState<Token>('DAI');
+
   const [includeOffChain, setIncludeOffChain] = useState<boolean>(false);
   const toggleIncludeOffChain = () => setIncludeOffChain(!includeOffChain);
 
@@ -91,25 +88,31 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
   const mainAccount = snapshot.snapshotAccount.find(
     (account) => account.groupAccountId === null && account.upstreamAccountId === null
   );
-
   if (!mainAccount) throw new Error('Maker Protocol Wallet not found');
-
-  // the balance is for now the last entry
-  const mainBalance =
-    mainAccount.snapshotAccountBalance.length > 0
-      ? mainAccount.snapshotAccountBalance[mainAccount.snapshotAccountBalance.length - 1]
-      : EMPTY_BALANCE;
+  const mainBalance = mainAccount.snapshotAccountBalance.find((balance) => balance.token === selectedToken);
 
   // cu reserves balance
   const cuReservesAccount = snapshot.snapshotAccount.find(
     (account) => account.groupAccountId === null && account.upstreamAccountId === mainAccount.id
   );
+  const cuReservesBalance = cuReservesAccount?.snapshotAccountBalance?.find(
+    (balance) => balance.token === selectedToken
+  );
 
-  const cuReservesBalance =
-    (cuReservesAccount?.snapshotAccountBalance?.length ?? 0) > 0
-      ? cuReservesAccount?.snapshotAccountBalance?.[cuReservesAccount?.snapshotAccountBalance?.length - 1] ??
-        EMPTY_BALANCE
-      : EMPTY_BALANCE;
+  // on chain
+  const onChainAccount = snapshot.snapshotAccount.filter(
+    (account) => account.groupAccountId === cuReservesAccount?.id && account.upstreamAccountId === mainAccount.id
+  )?.[0];
+
+  const onChainAccounts = snapshot.snapshotAccount
+    .filter((account) => account.groupAccountId === onChainAccount?.id)
+    .map(
+      (account) =>
+        ({
+          ...account,
+          snapshotAccountBalance: account.snapshotAccountBalance.filter((balance) => balance.token === selectedToken),
+        } as SnapshotAccount)
+    );
 
   // mocked data for the "Reported Expenses Comparison" table
   const expensesComparisonRows = [
@@ -128,6 +131,7 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
     endDate,
     mainBalance,
     cuReservesBalance,
+    onChainAccounts,
   };
 };
 


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Render the On Chain reserves cards according to the data coming from the API

# What solved
- Should render the "On chain reserves" cards based on the data coming from the API (each card with the correct data)