### PR TITLE
[SES-268] Integrated the transaction history with the API

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -19,13 +19,20 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
     startDate,
     endDate,
     mainBalance,
+    transactionHistory,
     cuReservesBalance,
     onChainAccounts,
   } = useAccountsSnapshot(snapshot);
 
   return (
     <Wrapper>
-      <FundingOverview snapshotOwner={snapshotOwner} startDate={startDate} endDate={endDate} balance={mainBalance} />
+      <FundingOverview
+        snapshotOwner={snapshotOwner}
+        startDate={startDate}
+        endDate={endDate}
+        balance={mainBalance}
+        transactionHistory={transactionHistory}
+      />
       <CUReserves
         snapshotOwner={snapshotOwner}
         includeOffChain={includeOffChain}

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
@@ -101,7 +101,7 @@ const getCoreUnitShortCode = async (ownerId: string): Promise<string> => {
   if (res?.coreUnits?.[0]?.shortCode) {
     return res.coreUnits[0].shortCode;
   }
-  return 'UNKNOWN';
+  return '';
 };
 
 const getTeamsShortCode = async (ownerId: string): Promise<string> => {
@@ -110,7 +110,7 @@ const getTeamsShortCode = async (ownerId: string): Promise<string> => {
   if (res?.teams?.[0]?.shortCode) {
     return res.teams[0].shortCode;
   }
-  return 'UNKNOWN';
+  return '';
 };
 
 export const generateSnapshotOwnerString = async (ownerType: string, ownerId: string): Promise<string> => {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
@@ -1,3 +1,4 @@
+import { SnapshotAccountTransactionBuilder } from '@ses/core/businessLogic/builders/accountSnapshot/snapshotAccountTransactionBuilder';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import FundingOverview from './FundingOverview';
 import type { ComponentMeta } from '@storybook/react';
@@ -6,6 +7,11 @@ import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types
 export default {
   title: 'Components/CUTransparencyReport/Accounts Snapshot/Funding Overview',
   component: FundingOverview,
+  parameters: {
+    chromatic: {
+      viewports: [375, 834, 1194, 1280, 1440],
+    },
+  },
 } as ComponentMeta<typeof FundingOverview>;
 
 const CommonArgs = {
@@ -25,6 +31,32 @@ const variantsArgs = [
   },
   {
     ...CommonArgs,
+    transactionHistory: [
+      new SnapshotAccountTransactionBuilder()
+        .withTimestamp('2023-04-17T11:36:05.188Z')
+        .withTxHash('0xe079d59dbf813d2541a345ef4786cc44a8a')
+        .withCounterParty('0x232b5483e5a5cd22188482')
+        .withAmount(-1153480)
+        .build(),
+      new SnapshotAccountTransactionBuilder()
+        .withTimestamp('2023-04-15T11:36:05.188Z')
+        .withTxHash('0xe079d59dbf813d2541a345ef4786cc44a8a')
+        .withCounterParty('0x232b5483e5a5cd22188482')
+        .withAmount(153480)
+        .build(),
+      new SnapshotAccountTransactionBuilder()
+        .withTimestamp('2023-03-28T17:32:05.188Z')
+        .withTxHash('0xe079d59dbf813d2541a345ef4786cc44a8a')
+        .withCounterParty('0x232b5483e5a5cd22188482')
+        .withAmount(-1153480)
+        .build(),
+      new SnapshotAccountTransactionBuilder()
+        .withTimestamp('2023-03-28T09:45:05.188Z')
+        .withTxHash('0xe079d59dbf813d2541a345ef4786cc44a8a')
+        .withCounterParty('0x232b5483e5a5cd22188482')
+        .withAmount(153480)
+        .build(),
+    ],
     defaultExpanded: true,
   },
 ];

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -7,13 +7,14 @@ import SimpleStatCard from '../Cards/SimpleStatCard';
 import CurrencyPicker from '../CurrencyPicker/CurrencyPicker';
 import SectionHeader from '../SectionHeader/SectionHeader';
 import TransactionHistory from '../TransactionHistory/TransactionHistory';
-import type { SnapshotAccountBalance } from '@ses/core/models/dto/snapshotAccountDTO';
+import type { SnapshotAccountBalance, SnapshotAccountTransaction } from '@ses/core/models/dto/snapshotAccountDTO';
 
 interface FundingOverviewProps {
   snapshotOwner: string;
   startDate?: string;
   endDate?: string;
   balance?: SnapshotAccountBalance;
+  transactionHistory: SnapshotAccountTransaction[];
 
   // Only used for storybook
   defaultExpanded?: boolean;
@@ -24,6 +25,7 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({
   startDate,
   endDate,
   balance,
+  transactionHistory,
   defaultExpanded = false,
 }) => (
   <div>
@@ -56,7 +58,7 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({
       />
     </CardsContainer>
 
-    <TransactionHistory defaultExpanded={defaultExpanded} />
+    <TransactionHistory transactionHistory={transactionHistory} defaultExpanded={defaultExpanded} />
   </div>
 );
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
@@ -33,6 +33,8 @@ const Transaction: React.FC<TransactionProps> = ({
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
 
+  isIncomingTransaction = amount > 0;
+
   return isMobile ? (
     <MobileTransaction
       isIncomingTransaction={isIncomingTransaction}

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
@@ -9,14 +9,16 @@ import AccordionArrow from '../AccordionArrow/AccordionArrow';
 import TransactionList from '../TransactionList/TransactionList';
 import type { AccordionProps } from '@mui/material/Accordion';
 import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
+import type { SnapshotAccountTransaction } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface TransactionHistoryProps {
+  transactionHistory: SnapshotAccountTransaction[];
   // Only used for storybook
   defaultExpanded?: boolean;
 }
 
-const TransactionHistory: React.FC<TransactionHistoryProps> = ({ defaultExpanded = false }) => {
+const TransactionHistory: React.FC<TransactionHistoryProps> = ({ transactionHistory, defaultExpanded = false }) => {
   const { isLight } = useThemeContext();
   const [expanded, setExpanded] = useState<boolean>(defaultExpanded);
 
@@ -25,7 +27,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ defaultExpanded
       <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)}>
         <AccordionSummary isLight={isLight}>View Transaction History</AccordionSummary>
         <AccordionDetails>
-          <TransactionList />
+          <TransactionList transactions={transactionHistory} />
         </AccordionDetails>
       </Accordion>
     </TransactionHistoryContainer>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
@@ -4,54 +4,76 @@ import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import GroupItem from '../GroupItem/GroupItem';
 import Transaction from '../Transaction/Transaction';
+import type { SnapshotAccountTransaction } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
-const TransactionList: React.FC<{ showGroup?: boolean }> = ({ showGroup = false }) => {
+interface TransactionListProps {
+  transactions?: SnapshotAccountTransaction[];
+  showGroup?: boolean;
+}
+
+const TransactionList: React.FC<TransactionListProps> = ({ transactions, showGroup = false }) => {
   const { isLight } = useThemeContext();
 
   return (
     <TransactionListContainer isLight={isLight}>
       <TransactionCard isLight={isLight}>
-        {showGroup && <GroupItem />}
-
-        <Transaction
-          name={'DSS Blow'}
-          date={'2023-04-17T11:36:05.188Z'}
-          toDate={null}
-          txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
-          counterPartyName={'Auditor Wallet'}
-          counterPartyAddress={'0x232b5483e5a5cd22188482'}
-          amount={-1153480}
-        />
-        <Transaction
-          isIncomingTransaction={false}
-          name={'DSS Vest'}
-          date={'2023-04-15T11:36:05.188Z'}
-          toDate={'2023-05-15T11:36:05.188Z'}
-          txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
-          counterPartyName={'Stream #14'}
-          counterPartyAddress={'0x232b5483e5a5cd22188482'}
-          amount={153480}
-        />
-        <Transaction
-          name={'DSS Blow'}
-          date={'2023-03-28T17:32:05.188Z'}
-          toDate={null}
-          txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
-          counterPartyName={'Auditor Wallet'}
-          counterPartyAddress={'0x232b5483e5a5cd22188482'}
-          amount={-1153480}
-        />
-        <Transaction
-          isIncomingTransaction={false}
-          name={'Direct Transaction'}
-          date={'2023-03-28T09:45:05.188Z'}
-          toDate={null}
-          txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
-          counterPartyName={'Auditor Wallet'}
-          counterPartyAddress={'0x232b5483e5a5cd22188482'}
-          amount={153480}
-        />
+        {transactions?.map((transaction) => (
+          <Transaction
+            key={transaction.id}
+            name={'Unknown'}
+            date={transaction.timestamp}
+            toDate={null}
+            txHash={transaction.tx_hash}
+            counterPartyName={'Unknown'}
+            counterPartyAddress={transaction.counterParty}
+            amount={transaction.amount}
+          />
+        ))}
+        {/* just kept for development/mock purposes */}
+        {showGroup && (
+          <>
+            <GroupItem />
+            <Transaction
+              name={'DSS Blow'}
+              date={'2023-04-17T11:36:05.188Z'}
+              toDate={null}
+              txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
+              counterPartyName={'Auditor Wallet'}
+              counterPartyAddress={'0x232b5483e5a5cd22188482'}
+              amount={-1153480}
+            />
+            <Transaction
+              isIncomingTransaction={false}
+              name={'DSS Vest'}
+              date={'2023-04-15T11:36:05.188Z'}
+              toDate={'2023-05-15T11:36:05.188Z'}
+              txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
+              counterPartyName={'Stream #14'}
+              counterPartyAddress={'0x232b5483e5a5cd22188482'}
+              amount={153480}
+            />
+            <Transaction
+              name={'DSS Blow'}
+              date={'2023-03-28T17:32:05.188Z'}
+              toDate={null}
+              txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
+              counterPartyName={'Auditor Wallet'}
+              counterPartyAddress={'0x232b5483e5a5cd22188482'}
+              amount={-1153480}
+            />
+            <Transaction
+              isIncomingTransaction={false}
+              name={'Direct Transaction'}
+              date={'2023-03-28T09:45:05.188Z'}
+              toDate={null}
+              txHash={'0xe079d59dbf813d2541a345ef4786cc44a8a'}
+              counterPartyName={'Auditor Wallet'}
+              counterPartyAddress={'0x232b5483e5a5cd22188482'}
+              amount={153480}
+            />
+          </>
+        )}
       </TransactionCard>
     </TransactionListContainer>
   );

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -94,7 +94,6 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
   const transactionHistory = mainAccount.snapshotAccountTransaction.filter(
     (transaction) => transaction.token === selectedToken
   );
-  console.log(transactionHistory);
 
   // cu reserves balance
   const cuReservesAccount = snapshot.snapshotAccount.find(

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -91,6 +91,11 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
   if (!mainAccount) throw new Error('Maker Protocol Wallet not found');
   const mainBalance = mainAccount.snapshotAccountBalance.find((balance) => balance.token === selectedToken);
 
+  const transactionHistory = mainAccount.snapshotAccountTransaction.filter(
+    (transaction) => transaction.token === selectedToken
+  );
+  console.log(transactionHistory);
+
   // cu reserves balance
   const cuReservesAccount = snapshot.snapshotAccount.find(
     (account) => account.groupAccountId === null && account.upstreamAccountId === mainAccount.id
@@ -130,6 +135,7 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
     startDate,
     endDate,
     mainBalance,
+    transactionHistory,
     cuReservesBalance,
     onChainAccounts,
   };


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Render the transactions of the root account coming from the API in the transaction history 

# What solved
- Should show the correct transactions coming from the API in the "View transaction history" subsection of the "MakerDAO Funding Overview" section