### PR TITLE
[SES-268] Integrate the On-chain Reserves with the API

### DIFF
--- a/src/core/models/dto/snapshotAccountDTO.ts
+++ b/src/core/models/dto/snapshotAccountDTO.ts
@@ -1,5 +1,7 @@
 export type Token = 'DAI' | 'ETH' | 'MKR';
 
+export type AccountType = 'singular' | 'group';
+
 export interface SnapshotFilter {
   id?: string;
   start?: string;
@@ -30,7 +32,7 @@ export interface SnapshotAccountBalance {
 export interface SnapshotAccount {
   id: string;
   accountLabel: string;
-  accountType: string;
+  accountType: AccountType;
   accountAddress: string;
   groupAccountId: string;
   upstreamAccountId: string;
@@ -45,4 +47,8 @@ export interface Snapshots {
   ownerType: string;
   ownerId: string;
   snapshotAccount: SnapshotAccount[];
+}
+
+export interface UIReservesData extends SnapshotAccount {
+  groups?: SnapshotAccount[];
 }

--- a/src/core/utils/humanization.ts
+++ b/src/core/utils/humanization.ts
@@ -27,6 +27,7 @@ export const usLocalizedNumber = (num: number, decimalPlace = 0): string =>
     currency: 'USD',
     currencyDisplay: 'symbol',
     minimumFractionDigits: decimalPlace,
+    maximumFractionDigits: decimalPlace,
   });
 
 export const deleteTwoDecimalPLace = (formattedNumber: string) => {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -8,7 +8,7 @@ import type { Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
 
 interface AccountsSnapshotProps {
   snapshot: Snapshots;
-  snapshotOwner: string;
+  snapshotOwner?: string;
 }
 
 const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotOwner }) => {
@@ -21,7 +21,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
     mainBalance,
     transactionHistory,
     cuReservesBalance,
-    onChainAccounts,
+    onChainData,
   } = useAccountsSnapshot(snapshot);
 
   return (
@@ -40,7 +40,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
         startDate={startDate}
         endDate={endDate}
         balance={cuReservesBalance}
-        accounts={onChainAccounts}
+        onChainData={onChainData}
       />
       <ExpensesComparison rows={expensesComparisonRows} />
     </Wrapper>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
@@ -113,7 +113,7 @@ const getTeamsShortCode = async (ownerId: string): Promise<string> => {
   return '';
 };
 
-export const generateSnapshotOwnerString = async (ownerType: string, ownerId: string): Promise<string> => {
+export const generateSnapshotOwnerString = async (ownerType: string, ownerId: string): Promise<string | undefined> => {
   try {
     switch (ownerType) {
       case 'CoreUnitDraft': {
@@ -126,11 +126,6 @@ export const generateSnapshotOwnerString = async (ownerType: string, ownerId: st
         const shortCode = await getTeamsShortCode(ownerId);
         return `${shortCode} Ecosystem Actor`;
       }
-      default:
-        // TODO: add the correct phrase
-        return `<<PENDING: ${ownerType}, ${ownerId}>>`;
     }
-  } catch (error) {
-    return ownerType;
-  }
+  } catch (error) {}
 };

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.stories.tsx
@@ -21,7 +21,7 @@ const variantsArgs = [
       .withInflow(305000)
       .withOutflow(-538320)
       .build(),
-    accounts: [
+    onChainData: [
       new SnapshotAccountBuilder()
         .withId('1')
         .withAccountLabel('DSS Vest')

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -7,17 +7,17 @@ import FundChangeCard from '../Cards/FundChangeCard';
 import ReserveCard from '../Cards/ReserveCard';
 import SimpleStatCard from '../Cards/SimpleStatCard';
 import SectionHeader from '../SectionHeader/SectionHeader';
-import type { SnapshotAccount, SnapshotAccountBalance } from '@ses/core/models/dto/snapshotAccountDTO';
+import type { SnapshotAccountBalance, UIReservesData } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface CUReservesProps {
-  snapshotOwner: string;
+  snapshotOwner?: string;
   includeOffChain: boolean;
   toggleIncludeOffChain: () => void;
   startDate?: string;
   endDate?: string;
   balance?: SnapshotAccountBalance;
-  accounts?: SnapshotAccount[];
+  onChainData?: UIReservesData[];
 }
 
 const CUReserves: React.FC<CUReservesProps> = ({
@@ -27,7 +27,7 @@ const CUReserves: React.FC<CUReservesProps> = ({
   startDate,
   endDate,
   balance,
-  accounts,
+  onChainData,
 }) => {
   const { isLight } = useThemeContext();
 
@@ -36,7 +36,7 @@ const CUReserves: React.FC<CUReservesProps> = ({
       <HeaderContainer>
         <SectionHeader
           title="Total Core Unit Reserves"
-          subtitle={`On-chain and off-chain reserves accessible to the ${snapshotOwner}.`}
+          subtitle={`On-chain and off-chain reserves accessible${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
           tooltip={'pending...'}
         />
         <CheckContainer isLight={isLight}>
@@ -66,27 +66,14 @@ const CUReserves: React.FC<CUReservesProps> = ({
       <OnChainSubsection>
         <SectionHeader
           title="On Chain Reserves"
-          subtitle={`Unspent on-chain reserves to the ${snapshotOwner}.`}
+          subtitle={`Unspent on-chain reserves${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
           tooltip={'pending...'}
           isSubsection
         />
 
         <ReservesCardsContainer>
-          {accounts?.map((account) => (
-            <ReserveCard
-              key={account.id}
-              name={account.accountLabel}
-              isGroup={account.accountType !== 'singular'}
-              address={account.accountAddress}
-              initialBalance={account.snapshotAccountBalance?.[0]?.initialBalance}
-              inflow={account.snapshotAccountBalance?.[0]?.inflow}
-              outflow={
-                account.snapshotAccountBalance?.[0]?.outflow
-                  ? account.snapshotAccountBalance?.[0]?.outflow * -1
-                  : account.snapshotAccountBalance?.[0]?.outflow
-              }
-              newBalance={account.snapshotAccountBalance?.[0]?.newBalance}
-            />
+          {onChainData?.map((account) => (
+            <ReserveCard key={account.id} account={account} />
           ))}
         </ReservesCardsContainer>
       </OnChainSubsection>
@@ -94,29 +81,47 @@ const CUReserves: React.FC<CUReservesProps> = ({
       <OffChainSubsection isDisabled={!includeOffChain}>
         <SectionHeader
           title="Off Chain Reserves"
-          subtitle={`Unspent off-chain reserves to the ${snapshotOwner}.`}
+          subtitle={`Unspent off-chain reserves${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
           tooltip={'pending...'}
           isSubsection
         />
 
         <ReservesCardsContainer>
           <ReserveCard
-            name="Payment Processor"
-            isGroup
-            initialBalance={100000}
-            inflow={300000}
-            outflow={300000}
-            newBalance={0}
+            account={
+              {
+                accountLabel: 'Payment Processor',
+                accountType: 'group',
+                snapshotAccountBalance: [
+                  {
+                    initialBalance: 100000,
+                    inflow: 300000,
+                    outflow: -300000,
+                    newBalance: 0,
+                  },
+                ],
+                groups: [],
+              } as unknown as UIReservesData
+            }
           />
           <ReserveCard
-            // temporary disable as this is a WIP
-            // eslint-disable-next-line spellcheck/spell-checker
-            name="Coinbase Account"
-            isGroup
-            initialBalance={500000}
-            inflow={300000}
-            outflow={250000}
-            newBalance={550680}
+            account={
+              {
+                // temporary disable as this is a WIP
+                // eslint-disable-next-line spellcheck/spell-checker
+                accountLabel: 'Coinbase Account',
+                accountType: 'group',
+                snapshotAccountBalance: [
+                  {
+                    initialBalance: 500000,
+                    inflow: 300000,
+                    outflow: -250000,
+                    newBalance: 550680,
+                  },
+                ],
+                groups: [],
+              } as unknown as UIReservesData
+            }
           />
         </ReservesCardsContainer>
       </OffChainSubsection>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -11,32 +11,27 @@ import TransactionList from '../TransactionList/TransactionList';
 import WalletInfo from '../WalletInfo/WalletInfo';
 import type { AccordionProps } from '@mui/material/Accordion';
 import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
+import type { Token, UIReservesData } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface ReserveCardProps {
-  name: string;
-  address?: string;
-  isGroup?: boolean;
-  initialBalance: number;
-  inflow: number;
-  outflow: number;
-  newBalance: number;
-  currency?: 'DAI' | 'ETH' | 'MKR';
+  account: UIReservesData;
+  currency?: Token;
 }
 
-const ReserveCard: React.FC<ReserveCardProps> = ({
-  name,
-  address,
-  isGroup = false,
-  initialBalance,
-  inflow,
-  outflow,
-  newBalance,
-  currency = 'DAI',
-}) => {
+const ReserveCard: React.FC<ReserveCardProps> = ({ account, currency = 'DAI' }) => {
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
   const [expanded, setExpanded] = React.useState<boolean>(false);
+
+  const isGroup = account.accountType === 'group';
+  const initialBalance = account.snapshotAccountBalance?.[0]?.initialBalance ?? 0;
+  const inflow = account.snapshotAccountBalance?.[0]?.inflow ?? 0;
+  const outflow =
+    (account.snapshotAccountBalance?.[0]?.outflow
+      ? account.snapshotAccountBalance?.[0]?.outflow * -1
+      : account.snapshotAccountBalance?.[0]?.outflow) ?? 0;
+  const newBalance = account.snapshotAccountBalance?.[0]?.newBalance ?? 0;
 
   const SVG = (
     <Arrow
@@ -50,7 +45,7 @@ const ReserveCard: React.FC<ReserveCardProps> = ({
     >
       <path
         d="M4.69339 5.86308C4.85404 6.04564 5.14598 6.04564 5.30664 5.86308L9.90358 0.639524C10.1255 0.38735 9.93978 0 9.59696 0H0.403059C0.0602253 0 -0.125491 0.38735 0.0964331 0.639525L4.69339 5.86308Z"
-        fill={isLight ? '#546978' : '#546978'}
+        fill={'#546978'}
       />
     </Arrow>
   );
@@ -60,10 +55,10 @@ const ReserveCard: React.FC<ReserveCardProps> = ({
       <Card isLight={isLight}>
         <NameContainer>
           {isGroup ? (
-            <Name isLight={isLight}>{name}</Name>
+            <Name isLight={isLight}>{account?.accountLabel}</Name>
           ) : (
             <WalletInfoWrapper>
-              <WalletInfo name={name} address={address ?? ''} />
+              <WalletInfo name={account.accountLabel} address={account.accountAddress ?? ''} />
             </WalletInfoWrapper>
           )}
           {isMobile && SVG}
@@ -95,7 +90,7 @@ const ReserveCard: React.FC<ReserveCardProps> = ({
         {!isMobile && <ArrowContainer>{SVG}</ArrowContainer>}
       </Card>
       <TransactionContainer>
-        <TransactionList showGroup={true} />
+        <TransactionList items={isGroup ? account.groups : account.snapshotAccountTransaction} />
       </TransactionContainer>
     </Accordion>
   );

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -10,7 +10,7 @@ import TransactionHistory from '../TransactionHistory/TransactionHistory';
 import type { SnapshotAccountBalance, SnapshotAccountTransaction } from '@ses/core/models/dto/snapshotAccountDTO';
 
 interface FundingOverviewProps {
-  snapshotOwner: string;
+  snapshotOwner?: string;
   startDate?: string;
   endDate?: string;
   balance?: SnapshotAccountBalance;
@@ -32,9 +32,9 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({
     <HeaderContainer>
       <SectionHeader
         title="MakerDAO Funding Overview"
-        subtitle={`Totals funds made available to the ${snapshotOwner} over its entire lifetime${
-          startDate ? `, since ${DateTime.fromISO(startDate).toFormat('LLLL yyyy')}` : ''
-        }.`}
+        subtitle={`Totals funds made available ${
+          snapshotOwner ? `to the ${snapshotOwner}` : ''
+        } over its entire lifetime${startDate ? `, since ${DateTime.fromISO(startDate).toFormat('LLLL yyyy')}` : ''}.`}
         tooltip={'pending...'}
       />
       <CurrencyPicker />

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
@@ -6,20 +6,39 @@ import React from 'react';
 import GreenArrowDown from '../SVG/GreenArrowDown';
 import RedArrowUp from '../SVG/RedArrowUp';
 import WalletInfo from '../WalletInfo/WalletInfo';
+import type { Token } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
-const GroupItem: React.FC = () => {
+interface GroupItemProps {
+  name: string;
+  address: string;
+  initialBalance: number;
+  inflow: number;
+  outflow: number;
+  newBalance: number;
+  currency: Token;
+}
+
+const GroupItem: React.FC<GroupItemProps> = ({
+  name,
+  address,
+  initialBalance,
+  inflow,
+  outflow,
+  newBalance,
+  currency,
+}) => {
   const { isLight } = useThemeContext();
 
   return (
     <GroupItemContainer isLight={isLight}>
       <WalletContainer>
-        <WalletInfo name={'Stream #13'} address={'0x232b54886a238482'} />
+        <WalletInfo name={name} address={address} />
       </WalletContainer>
       <InitialBalance>
         <Label isLight={isLight}>Initial Balance</Label>
         <Value isLight={isLight}>
-          {usLocalizedNumber(153480)} <Currency isLight={isLight}>DAI</Currency>
+          {usLocalizedNumber(initialBalance)} <Currency isLight={isLight}>{currency}</Currency>
         </Value>
       </InitialBalance>
       <Inflow>
@@ -30,7 +49,7 @@ const GroupItem: React.FC = () => {
           <GreenArrowDown width={16} height={16} />
           <Value isLight={isLight}>
             <Sign>{'+'}</Sign>
-            {usLocalizedNumber(150000)} <Currency isLight={isLight}>DAI</Currency>
+            {usLocalizedNumber(inflow)} <Currency isLight={isLight}>{currency}</Currency>
           </Value>
         </ValueContainer>
       </Inflow>
@@ -43,14 +62,14 @@ const GroupItem: React.FC = () => {
           <RedArrowUp width={16} height={16} />
           <Value isLight={isLight}>
             <Sign>{'-'}</Sign>
-            {usLocalizedNumber(300000)} <Currency isLight={isLight}>DAI</Currency>
+            {usLocalizedNumber(Math.abs(outflow))} <Currency isLight={isLight}>{currency}</Currency>
           </Value>
         </ValueContainer>
       </Outflow>
       <NewBalance>
         <Label isLight={isLight}>New Balance</Label>
         <Value isLight={isLight}>
-          <span>{usLocalizedNumber(100000)}</span> <Currency isLight={isLight}>DAI</Currency>
+          <span>{usLocalizedNumber(Math.abs(newBalance))}</span> <Currency isLight={isLight}>{currency}</Currency>
         </Value>
       </NewBalance>
     </GroupItemContainer>
@@ -79,6 +98,10 @@ const GroupItemContainer = styled.div<WithIsLight>(({ isLight }) => ({
 
     '&:hover': {
       background: isLight ? '#F6F8F9' : '#1F2931',
+    },
+
+    '&:not(:first-of-type)': {
+      borderTop: `1px solid ${isLight ? '#D4D9E1' : '#405361'}`,
     },
   },
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/InitialBalanceRow.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/InitialBalanceRow.tsx
@@ -1,0 +1,98 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface InitialBalanceRow {
+  initialBalance: number;
+}
+
+const InitialBalanceRow: React.FC<InitialBalanceRow> = ({ initialBalance }) => {
+  const { isLight } = useThemeContext();
+  return (
+    <Wrapper isLight={isLight}>
+      <Title isLight={isLight}>Initial Balance</Title>
+      <Amount isLight={isLight}>
+        {usLocalizedNumber(initialBalance)}
+        <Currency isLight={isLight}>DAI</Currency>
+      </Amount>
+    </Wrapper>
+  );
+};
+
+export default InitialBalanceRow;
+
+const Wrapper = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'none',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  justifyContent: 'center',
+  gap: 8,
+  padding: '16px 32px 13px 20px',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    display: 'flex',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '16px 56px 14px 20px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    padding: '16px 64px 14px 20px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    padding: '16px 80px 14px 20px',
+  },
+
+  '&:hover': {
+    background: isLight ? '#F6F8F9' : '#1F2931',
+  },
+}));
+
+const Title = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 11,
+  lineHeight: '13px',
+  color: isLight ? '#546978' : '#708390',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    fontSize: 12,
+    lineHeight: '15px',
+  },
+}));
+
+const Amount = styled.div<WithIsLight>(({ isLight }) => ({
+  fontWeight: 700,
+  display: 'flex',
+  alignItems: 'baseline',
+  justifyContent: 'flex-end',
+  gap: 4,
+  fontSize: 14,
+  lineHeight: '22px',
+  color: isLight ? '#231536' : '#D2D4EF',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    fontSize: 16,
+  },
+}));
+
+const Currency = styled.span<WithIsLight>(({ isLight }) => ({
+  fontWeight: 600,
+  fontSize: 12,
+  lineHeight: '15px',
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  color: isLight ? '#9FAFB9' : '#546978',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    color: '#9FAFB9',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    fontSize: 14,
+    lineHeight: '17px',
+  },
+}));

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
@@ -27,7 +27,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ transactionHist
       <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)}>
         <AccordionSummary isLight={isLight}>View Transaction History</AccordionSummary>
         <AccordionDetails>
-          <TransactionList transactions={transactionHistory} />
+          <TransactionList items={transactionHistory} />
         </AccordionDetails>
       </Accordion>
     </TransactionHistoryContainer>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/typesHelpers.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/typesHelpers.ts
@@ -1,0 +1,9 @@
+import type { SnapshotAccount } from '@ses/core/models/dto/snapshotAccountDTO';
+
+export const isSnapshotAccount = (snapshotAccount: SnapshotAccount | unknown): snapshotAccount is SnapshotAccount => {
+  const account = snapshotAccount as SnapshotAccount;
+  if (account?.accountLabel || account?.accountType || account?.snapshotAccountBalance) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Integrated the wallets on the On Chain reserves  with the API

# What solved
- Should show the data coming from the API in the expanded data of the "Total Core Unit Reserves" section 