### PR TITLE
[SES-no-ticket-278]Fix/delete icon budget cap

### DIFF
--- a/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
@@ -148,7 +148,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({
           notHeadCountCategory={actualsData.notHeadCountCategory}
           handleCloseModal={actualsData.handleCloseModal}
           handleCheckedExpandedAll={actualsData.handleCheckedExpandedAll}
-          handleChangeItemAccordion={actualsData.handleCheckedExpandedAll}
+          handleChangeItemAccordion={actualsData.handleChangeItemAccordion}
           isLight={isLight}
           openModal={actualsData.openModal}
         />

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
@@ -406,13 +406,7 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
   const [breakdownColumnsForActiveTab, allBreakdownColumns] = useMemo(() => {
     const allBreakdownColumns: { [key: string]: InnerTableColumn[] } = {};
     for (const wallet of wallets) {
-      allBreakdownColumns[wallet.name] = getForecastBreakdownColumns(
-        wallet,
-        firstMonth,
-        secondMonth,
-        thirdMonth
-        // handleOpenModal
-      );
+      allBreakdownColumns[wallet.name] = getForecastBreakdownColumns(wallet, firstMonth, secondMonth, thirdMonth);
     }
 
     return [allBreakdownColumns[wallets[thirdIndex]?.name], allBreakdownColumns];


### PR DESCRIPTION
# Ticket
https://trello.com/c/udGDe7fW/278-qc-round-r

# What solved
✅Should remove the icon displayed in the Forecast tab, next to the Budget Category

# Description
This is to remove the icon for the forecast view