### PR TITLE
[SES-QA-277] Fix sitemap

### DIFF
--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -10,7 +10,7 @@ export const siteRoutes = {
   financesOverview: '/',
   coreUnitAbout: (shortCode: string) => `/core-unit/${shortCode}`,
   coreUnitReports: (shortCode: string) => `/core-unit/${shortCode}/finances/reports`,
-  coreUnitActivityFeed: (shortCode: string) => `core-unit/${shortCode}/activity-feed`,
+  coreUnitActivityFeed: (shortCode: string) => `/core-unit/${shortCode}/activity-feed`,
   globalActivityFeed: '/activity-feed',
   cookiesPolicy: '/cookies-policy',
   recognizedDelegateReport: '/recognized-delegates/finances/reports',


### PR DESCRIPTION
# Ticket
https://trello.com/c/FEo923dc/277-qa-bug-finding-r

# Description
Fixed the sitemap by adding a missing `/`

# What solved
- [X] SEO-related: the sitemap seems to have malformed URLs with slashes missing after the domain. [image.png](https://trello.com/1/cards/6470706b05557d3aa8875967/attachments/6494418378eee1f9b518a500/download/image.png)