### PR TITLE
[SES-268] Make the positive numbers green in the transaction history section

### DIFF
--- a/src/core/models/dto/snapshotAccountDTO.ts
+++ b/src/core/models/dto/snapshotAccountDTO.ts
@@ -53,5 +53,5 @@ export interface Snapshots {
 }
 
 export interface UIReservesData extends SnapshotAccount {
-  groups?: SnapshotAccount[];
+  children?: SnapshotAccount[];
 }

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -90,7 +90,7 @@ const ReserveCard: React.FC<ReserveCardProps> = ({ account, currency = 'DAI' }) 
         {!isMobile && <ArrowContainer>{SVG}</ArrowContainer>}
       </Card>
       <TransactionContainer>
-        <TransactionList items={isGroup ? account.groups : account.snapshotAccountTransaction} />
+        <TransactionList items={isGroup ? account.children : account.snapshotAccountTransaction} />
       </TransactionContainer>
     </Accordion>
   );

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/MobileTransaction.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/MobileTransaction.tsx
@@ -28,11 +28,12 @@ const MobileTransaction: React.FC<MobileTransactionProps> = ({
   counterPartyName,
   counterPartyAddress,
   amount,
-  isIncomingTransaction = true,
   defaultExpanded = false,
+  highlightPositiveAmounts,
 }) => {
   const { isLight } = useThemeContext();
   const [expanded, setExpanded] = useState<boolean>(defaultExpanded);
+  const isIncomingTransaction = amount > 0;
   const formattedDate = toDate ? (
     <>
       from {DateTime.fromISO(date).toUTC().toFormat('dd-MMM-yyyy')}
@@ -52,7 +53,7 @@ const MobileTransaction: React.FC<MobileTransactionProps> = ({
             <Name isLight={isLight}>{name}</Name>
             <Date isLight={isLight}>{formattedDate}</Date>
           </Data>
-          <Value isLight={isLight}>
+          <Value isLight={isLight} isGreen={amount > 0 && !!highlightPositiveAmounts}>
             <Sign>{amount < 0 ? '-' : '+'}</Sign>
             {usLocalizedNumber(Math.abs(amount))}
             <Currency isLight={isLight}>DAI</Currency>
@@ -158,7 +159,7 @@ const Date = styled.div<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#9FAFB9' : '#405361',
 }));
 
-const Value = styled.div<WithIsLight>(({ isLight }) => ({
+const Value = styled.div<WithIsLight & { isGreen: boolean }>(({ isLight, isGreen }) => ({
   display: 'flex',
   alignItems: 'baseline',
   justifyContent: 'flex-end',
@@ -168,7 +169,7 @@ const Value = styled.div<WithIsLight>(({ isLight }) => ({
   marginTop: 5,
 
   '&, & > span:first-of-type': {
-    color: isLight ? '#231536' : '#D2D4EF',
+    color: isGreen ? '#1AAB9B' : isLight ? '#231536' : '#D2D4EF',
   },
 }));
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
@@ -17,7 +17,7 @@ export interface TransactionProps {
   counterPartyName: string;
   counterPartyAddress: string;
   amount: number;
-  isIncomingTransaction?: boolean;
+  highlightPositiveAmounts?: boolean;
 }
 
 const Transaction: React.FC<TransactionProps> = ({
@@ -28,16 +28,14 @@ const Transaction: React.FC<TransactionProps> = ({
   counterPartyName,
   counterPartyAddress,
   amount,
-  isIncomingTransaction = true,
+  highlightPositiveAmounts = false,
 }) => {
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
-
-  isIncomingTransaction = amount > 0;
+  const isIncomingTransaction = amount > 0;
 
   return isMobile ? (
     <MobileTransaction
-      isIncomingTransaction={isIncomingTransaction}
       name={name}
       date={date}
       toDate={toDate}
@@ -45,6 +43,7 @@ const Transaction: React.FC<TransactionProps> = ({
       counterPartyName={counterPartyName}
       counterPartyAddress={counterPartyAddress}
       amount={amount}
+      highlightPositiveAmounts={highlightPositiveAmounts}
     />
   ) : (
     <TransactionContainer isLight={isLight}>
@@ -60,7 +59,7 @@ const Transaction: React.FC<TransactionProps> = ({
         name={counterPartyName}
         address={counterPartyAddress}
       />
-      <TransactionAmount amount={amount} />
+      <TransactionAmount amount={amount} highlightPositiveAmounts={highlightPositiveAmounts} />
     </TransactionContainer>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionAmount.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionAmount.tsx
@@ -7,15 +7,16 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface TransactionAmountProps {
   amount: number;
+  highlightPositiveAmounts?: boolean;
 }
 
-const TransactionAmount: React.FC<TransactionAmountProps> = ({ amount }) => {
+const TransactionAmount: React.FC<TransactionAmountProps> = ({ amount, highlightPositiveAmounts }) => {
   const { isLight } = useThemeContext();
 
   return (
     <Wrapper>
       <Title isLight={isLight}>Amount</Title>
-      <Amount isLight={isLight}>
+      <Amount isLight={isLight} isGreen={amount > 0 && !!highlightPositiveAmounts}>
         <Sign>{amount < 0 ? '-' : '+'}</Sign>
         {usLocalizedNumber(Math.abs(amount))}
         <Currency isLight={isLight}>DAI</Currency>
@@ -49,7 +50,7 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const Amount = styled.div<WithIsLight>(({ isLight }) => ({
+const Amount = styled.div<WithIsLight & { isGreen: boolean }>(({ isLight, isGreen }) => ({
   display: 'flex',
   alignItems: 'baseline',
   justifyContent: 'flex-end',
@@ -62,7 +63,7 @@ const Amount = styled.div<WithIsLight>(({ isLight }) => ({
   },
 
   '&, & > span:first-of-type': {
-    color: isLight ? '#231536' : '#D2D4EF',
+    color: isGreen ? '#1AAB9B' : isLight ? '#231536' : '#D2D4EF',
   },
 }));
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
@@ -27,7 +27,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ transactionHist
       <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)}>
         <AccordionSummary isLight={isLight}>View Transaction History</AccordionSummary>
         <AccordionDetails>
-          <TransactionList items={transactionHistory} />
+          <TransactionList items={transactionHistory} highlightPositiveAmounts={true} />
         </AccordionDetails>
       </Accordion>
     </TransactionHistoryContainer>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
@@ -10,9 +10,10 @@ import type { SnapshotAccount, SnapshotAccountTransaction } from '@ses/core/mode
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 interface TransactionListProps {
   items?: (SnapshotAccountTransaction | SnapshotAccount)[];
+  highlightPositiveAmounts?: boolean;
 }
 
-const TransactionList: React.FC<TransactionListProps> = ({ items }) => {
+const TransactionList: React.FC<TransactionListProps> = ({ items, highlightPositiveAmounts = false }) => {
   const { isLight } = useThemeContext();
   const renderTransaction = (transaction: SnapshotAccountTransaction) => (
     <Transaction
@@ -24,6 +25,7 @@ const TransactionList: React.FC<TransactionListProps> = ({ items }) => {
       counterPartyName={transaction.counterPartyName ?? 'N/A'}
       counterPartyAddress={transaction.counterParty}
       amount={transaction.amount}
+      highlightPositiveAmounts={highlightPositiveAmounts}
     />
   );
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -118,7 +118,7 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
           snapshotAccountTransaction: account.snapshotAccountTransaction
             .filter((transaction) => transaction.token === selectedToken)
             .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()),
-          groups: snapshot.snapshotAccount
+          children: snapshot.snapshotAccount
             .filter((childrenAccount) => childrenAccount.groupAccountId === account.id)
             .map((childrenAccount) => ({
               ...childrenAccount,
@@ -130,7 +130,8 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
                 .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()),
             })),
         } as UIReservesData)
-    );
+    )
+    .sort((a, b) => parseInt(a.id) - parseInt(b.id));
 
   // mocked data for the "Reported Expenses Comparison" table
   const expensesComparisonRows = [


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Make the positive numbers in the "View Transaction History" section green

# What solved
- [X] Should display the positive numbers on green in the "View Transaction History" section