### PR TITLE
[SES-208] Animate number transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.4",
     "@reduxjs/toolkit": "^1.8.2",
+    "countup.js": "2.5.0",
     "deepmerge": "^4.3.1",
     "echarts": "^5.4.1",
     "echarts-for-react": "^3.0.2",
@@ -36,6 +37,7 @@
     "react": "18.1.0",
     "react-cookie": "^4.1.1",
     "react-copy-to-clipboard": "^5.1.0",
+    "react-countup": "^6.4.2",
     "react-dom": "18.1.0",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
@@ -108,5 +110,8 @@
     "*.{ts,tsx,css,json}": "prettier --write"
   },
   "readme": "ERROR: No README data found!",
-  "_id": "makerdao-ses-typescript@0.1.0"
+  "_id": "makerdao-ses-typescript@0.1.0",
+  "resolutions": {
+    "react-countup/countup.js": "2.5.0"
+  }
 }

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -48,13 +48,19 @@ const CUReserves: React.FC<CUReservesProps> = ({
       </HeaderContainer>
 
       <CardsContainer>
-        <SimpleStatCard date={startDate} value={balance?.initialBalance} caption="Initial Core Unit Reserves" />
+        <SimpleStatCard
+          date={startDate}
+          value={balance?.initialBalance}
+          caption="Initial Core Unit Reserves"
+          dynamicChanges
+        />
         <FundChangeCard
           netChange={balance?.inflow && balance?.outflow ? balance.outflow - balance.inflow * -1 : undefined}
           leftValue={balance?.inflow}
           leftText="Inflow"
           rightValue={balance?.outflow ? balance?.outflow * -1 : undefined}
           rightText="Outflow"
+          dynamicChanges
         />
         <SimpleStatCard
           date={endDate}
@@ -62,6 +68,7 @@ const CUReserves: React.FC<CUReservesProps> = ({
           caption="New Core Unit Reserves"
           hasEqualSign
           isReserves
+          dynamicChanges
         />
       </CardsContainer>
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCard.tsx
@@ -4,6 +4,7 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
+import DefaultCountUp from '../DefaultCountUp/DefaultCountUp';
 import NumberWithSignCard from '../NumberWithSignCard/NumberWithSignCard';
 import OutlinedCard from './OutlinedCard';
 import type { ValueColor } from '../NumberWithSignCard/NumberWithSignCard';
@@ -17,6 +18,7 @@ interface FundChangeCardProps {
   rightValue?: number;
   rightValueColor?: ValueColor;
   rightText: string;
+  dynamicChanges?: boolean;
 }
 
 const FundChangeCard: React.FC<FundChangeCardProps> = ({
@@ -27,6 +29,7 @@ const FundChangeCard: React.FC<FundChangeCardProps> = ({
   rightValue,
   rightValueColor = 'normal',
   rightText,
+  dynamicChanges = false,
 }) => {
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
@@ -43,7 +46,12 @@ const FundChangeCard: React.FC<FundChangeCardProps> = ({
             {netChange !== undefined ? (
               <>
                 {netChange > 0 && '+'}
-                {usLocalizedNumber(Math.round(netChange))} <span>DAI</span>
+                {dynamicChanges ? (
+                  <DefaultCountUp end={Math.round(netChange)} formattingFn={usLocalizedNumber} />
+                ) : (
+                  usLocalizedNumber(Math.round(netChange))
+                )}
+                <div>DAI</div>
               </>
             ) : (
               'N/A'
@@ -61,8 +69,20 @@ const FundChangeCard: React.FC<FundChangeCardProps> = ({
         </RightArrowContainer>
       </ChangeContainer>
       <ValuesContainer>
-        <NumberWithSignCard value={leftValue} valueColor={leftValueColor} sign="positive" text={leftText} />
-        <NumberWithSignCard value={rightValue} valueColor={rightValueColor} sign="negative" text={rightText} />
+        <NumberWithSignCard
+          dynamicChanges={dynamicChanges}
+          value={leftValue}
+          valueColor={leftValueColor}
+          sign="positive"
+          text={leftText}
+        />
+        <NumberWithSignCard
+          dynamicChanges={dynamicChanges}
+          value={rightValue}
+          valueColor={rightValueColor}
+          sign="negative"
+          text={rightText}
+        />
       </ValuesContainer>
     </Card>
   );
@@ -255,7 +275,7 @@ const Value = styled.div<WithIsLight>(({ isLight }) => ({
     lineHeight: '19px',
   },
 
-  '& > span': {
+  '& > div': {
     fontWeight: 700,
     fontSize: 14,
     lineHeight: '17px',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/SimpleStatCard.tsx
@@ -5,6 +5,7 @@ import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
 import { DateTime } from 'luxon';
 import React from 'react';
+import DefaultCountUp from '../DefaultCountUp/DefaultCountUp';
 import EqualSign from '../SVG/Equals';
 import OutlinedCard from './OutlinedCard';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -15,6 +16,7 @@ interface SimpleStatCardProps {
   caption: string;
   hasEqualSign?: boolean;
   isReserves?: boolean;
+  dynamicChanges?: boolean;
 }
 
 const SimpleStatCard: React.FC<SimpleStatCardProps> = ({
@@ -23,6 +25,7 @@ const SimpleStatCard: React.FC<SimpleStatCardProps> = ({
   caption,
   hasEqualSign = false,
   isReserves = false,
+  dynamicChanges = false,
 }) => {
   const { isLight } = useThemeContext();
   const isTablet = useMediaQuery(lightTheme.breakpoints.down('desktop_1194'));
@@ -43,7 +46,12 @@ const SimpleStatCard: React.FC<SimpleStatCardProps> = ({
           <Value isLight={isLight}>
             {value !== undefined ? (
               <>
-                {usLocalizedNumber(Math.round(value))} <span>DAI</span>
+                {dynamicChanges ? (
+                  <DefaultCountUp end={Math.round(value)} formattingFn={usLocalizedNumber} />
+                ) : (
+                  usLocalizedNumber(Math.round(value))
+                )}
+                <div>DAI</div>
               </>
             ) : (
               'N/A'
@@ -154,7 +162,7 @@ const Value = styled.div<WithIsLight>(({ isLight }) => ({
     lineHeight: '36px',
   },
 
-  '& > span': {
+  '& > div': {
     marginLeft: 4,
     fontWeight: 700,
     fontSize: 12,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/DefaultCountUp/DefaultCountUp.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/DefaultCountUp/DefaultCountUp.tsx
@@ -1,0 +1,6 @@
+import CountUp from 'react-countup';
+import type { CountUpProps } from 'react-countup/build/CountUp';
+
+export default function DefaultCountUp({ duration = 1, preserveValue = true, ...props }: CountUpProps) {
+  return <CountUp duration={duration} preserveValue={preserveValue} {...props} />;
+}

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCard.tsx
@@ -3,6 +3,7 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
+import DefaultCountUp from '../DefaultCountUp/DefaultCountUp';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 export type ValueColor = 'normal' | 'green';
@@ -13,9 +14,16 @@ interface NumberWithSignCardProps {
   sign: 'positive' | 'negative';
   valueColor?: ValueColor;
   cardWidth?: string | number;
+  dynamicChanges?: boolean;
 }
 
-const NumberWithSignCard: React.FC<NumberWithSignCardProps> = ({ value, sign, text, valueColor = 'normal' }) => {
+const NumberWithSignCard: React.FC<NumberWithSignCardProps> = ({
+  value,
+  sign,
+  text,
+  valueColor = 'normal',
+  dynamicChanges = false,
+}) => {
   const { isLight } = useThemeContext();
 
   return (
@@ -50,7 +58,12 @@ const NumberWithSignCard: React.FC<NumberWithSignCardProps> = ({ value, sign, te
         <Value isLight={isLight} valueColor={valueColor}>
           {value !== undefined ? (
             <>
-              {usLocalizedNumber(Math.round(value))} <span>DAI</span>
+              {dynamicChanges ? (
+                <DefaultCountUp end={Math.round(value)} formattingFn={usLocalizedNumber} />
+              ) : (
+                usLocalizedNumber(Math.round(value))
+              )}
+              <div>DAI</div>
             </>
           ) : (
             'N/A'
@@ -149,7 +162,7 @@ const Value = styled.div<WithIsLight & { valueColor: ValueColor }>(({ isLight, v
       lineHeight: '36px',
     },
 
-    '& span': {
+    '& div': {
       marginLeft: 4,
       fontWeight: 700,
       fontSize: 12,

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,6 +261,13 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
+"@babel/helper-module-imports@^7.18.6":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz#1a8f4c9f4027d23f520bd76b364d44434a72660c"
+  integrity sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.16.7", "@babel/helper-module-transforms@^7.17.7":
   version "7.17.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz#3943c7f777139e7954a5355c815263741a9c1cbd"
@@ -357,6 +364,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
+"@babel/helper-string-parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
+  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
@@ -366,6 +378,11 @@
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
+"@babel/helper-validator-identifier@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
+  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
 
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
@@ -1309,6 +1326,15 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.5.tgz#cd93eeaab025880a3a47ec881f4b096a5b786fbe"
+  integrity sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
+    to-fast-properties "^2.0.0"
+
 "@base2/pretty-print-object@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz#371ba8be66d556812dc7fb169ebc3c08378f69d4"
@@ -2121,6 +2147,23 @@
     redux "^4.1.2"
     redux-thunk "^2.4.1"
     reselect "^4.1.5"
+
+"@rollup/plugin-babel@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-6.0.3.tgz#07ccde15de278c581673034ad6accdb4a153dfeb"
+  integrity sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.18.6"
+    "@rollup/pluginutils" "^5.0.1"
+
+"@rollup/pluginutils@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
+  integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^2.3.1"
 
 "@rushstack/eslint-patch@^1.1.3":
   version "1.1.3"
@@ -3592,6 +3635,11 @@
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
+"@types/estree@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
 
 "@types/express-serve-static-core@^4.17.31":
   version "4.17.32"
@@ -6128,6 +6176,11 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+countup.js@2.5.0, countup.js@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/countup.js/-/countup.js-2.5.0.tgz#156d300044b6dd8239f6e8315addfc3f8143b5a3"
+  integrity sha512-/59H8Q6wzu6VfHeqGUgXoyh6kgboGr5mALmRKi8YA11DlcaXSnT1PZG6mTyBRLco4ZjExKlmfNHeMbQgZvis9Q==
+
 cp-file@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/cp-file/-/cp-file-7.0.0.tgz#b9454cfd07fe3b974ab9ea0e5f29655791a9b8cd"
@@ -7240,6 +7293,11 @@ estree-to-babel@^3.1.0:
     "@babel/traverse" "^7.1.6"
     "@babel/types" "^7.2.0"
     c8 "^7.6.0"
+
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -11856,6 +11914,14 @@ react-copy-to-clipboard@^5.1.0:
   dependencies:
     copy-to-clipboard "^3.3.1"
     prop-types "^15.8.1"
+
+react-countup@^6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/react-countup/-/react-countup-6.4.2.tgz#cf8564c9381958a36c7c25f7c0769f7a472e4c99"
+  integrity sha512-wdDrNb2lPFGbLb+i0FTgswPbWziubS6KZRII8NRpXmUCoZsi15PFbIHgBz60Dyxd4KPuRvwsK5aawIU4OPP3jA==
+  dependencies:
+    "@rollup/plugin-babel" "^6.0.3"
+    countup.js "^2.5.0"
 
 react-docgen-typescript@^2.1.1:
   version "2.2.2"


### PR DESCRIPTION
## Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

## Description
Should animate the numbers on the "Total Core Unit Reserves" section when the "Include Off-Chain Reserves" check is checked/unchecked and the number changes

## What solved
- [X] Should animate the numbers on the "Total Core Unit Reserves" section when the "Include Off-Chain Reserves" check is checked/unchecked and the number changes