### PR TITLE
[SES-208] Feature/add space to reserve cards

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.stories.tsx
@@ -79,15 +79,15 @@ const variantsArgs = [
         .build(),
       new SnapshotAccountBuilder()
         .withId('2')
-        .withAccountLabel('Auditor 2')
-        .withAccountType('singular')
-        .withAccountAddress('0x23b554585a4ef8483')
+        // eslint-disable-next-line spellcheck/spell-checker
+        .withAccountLabel('Coinbase Account')
+        .withAccountType('group')
         .addSnapshotAccountBalance(
           new SnapshotAccountBalanceBuilder()
-            .withInitialBalance(500000)
-            .withNewBalance(550000)
-            .withInflow(300000)
-            .withOutflow(-250000)
+            .withInitialBalance(900000)
+            .withNewBalance(1100000)
+            .withInflow(250000)
+            .withOutflow(-50000)
             .build()
         )
         .build(),
@@ -149,7 +149,7 @@ LightMode.parameters = {
         },
       },
       1440: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?node-id=18149%3A200168',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19847%3A227648',
         options: {
           componentStyle: {
             width: 1312,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -156,22 +156,22 @@ const NameContainer = styled.div({
   width: '100%',
 
   [lightTheme.breakpoints.up('table_834')]: {
-    width: '22.7%',
+    width: '300px',
     padding: '0 16px',
   },
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    width: '18.7%',
+    width: '300px',
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: '18.4%',
+    width: '300px',
   },
 });
 
 const WalletInfoWrapper = styled.div({
   paddingTop: 3,
-  marginBottom: -6,
+  marginBottom: 1,
 
   [lightTheme.breakpoints.up('table_834')]: {
     paddingTop: 0,
@@ -208,11 +208,11 @@ const InitialBalance = styled.div({
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
     padding: 16,
-    width: '18.8%',
+    width: '17.2%',
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: '18.4%',
+    width: '17.2%',
   },
 });
 
@@ -288,7 +288,7 @@ const Inflow = styled.div<WithIsLight>(({ isLight }) => ({
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: '16%',
+    width: '15%',
   },
 }));
 
@@ -333,6 +333,7 @@ const ArrowContainer = styled.div({
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
     width: 106,
+    marginLeft: 32,
   },
 });
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -156,7 +156,7 @@ const NameContainer = styled.div({
   width: '100%',
 
   [lightTheme.breakpoints.up('table_834')]: {
-    width: '300px',
+    width: '220px',
     padding: '0 16px',
   },
 
@@ -186,7 +186,7 @@ const Name = styled.div<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#231536' : '#D2D4EF',
 
   [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    fontSize: 14,
+    fontSize: 12,
     lineHeight: '17px',
   },
 }));
@@ -202,8 +202,8 @@ const InitialBalance = styled.div({
     marginTop: 0,
     justifyContent: 'normal',
     alignItems: 'normal',
-    padding: '16px 8px',
-    width: '17.1%',
+    padding: '16px 2px',
+    width: '17.08%',
   },
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
@@ -271,11 +271,11 @@ const Inflow = styled.div<WithIsLight>(({ isLight }) => ({
 
   [lightTheme.breakpoints.up('table_834')]: {
     flexDirection: 'column',
-    margin: 8,
+    margin: '8px 2px',
     padding: 8,
     justifyContent: 'normal',
     alignItems: 'normal',
-    width: '16%',
+    minWidth: 'calc(16.1% - 4px)',
   },
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
@@ -298,8 +298,9 @@ const NewBalance = styled(InitialBalance)({
   marginTop: 8,
 
   [lightTheme.breakpoints.up('table_834')]: {
-    padding: '16px 8px',
+    padding: 2,
     marginLeft: 'auto',
+    width: 'unset',
 
     '& > div': {
       textAlign: 'right',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -208,11 +208,15 @@ const InitialBalance = styled.div({
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
     padding: 16,
-    width: '17.2%',
+    width: '16.4%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    width: '17.1%',
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: '17.2%',
+    width: '17.3%',
   },
 });
 
@@ -280,15 +284,11 @@ const Inflow = styled.div<WithIsLight>(({ isLight }) => ({
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
     margin: '8px 16px',
-    width: '15.9%',
+    minWidth: 'calc(16.8% - 32px)',
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: '16.2%',
-  },
-
-  [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: '15%',
+    minWidth: 'calc(17.2% - 32px)',
   },
 }));
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
@@ -130,8 +130,8 @@ const WalletContainer = styled.div({
     },
   },
 
-  [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: '39.5%',
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: 'calc(295px + 16%)',
   },
 });
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
@@ -123,7 +123,7 @@ const WalletContainer = styled.div({
 
   [lightTheme.breakpoints.up('table_834')]: {
     marginBottom: 0,
-    width: '40.5%',
+    width: 'calc(204px + 17%)',
 
     '& > div': {
       marginTop: 0,
@@ -170,6 +170,7 @@ const Label = styled.div<WithIsLight>(({ isLight }) => ({
 const ValueContainer = styled.div({
   display: 'flex',
   alignItems: 'center',
+  flexWrap: 'wrap',
   gap: 4,
 
   '& > svg': {
@@ -186,6 +187,7 @@ const ValueContainer = styled.div({
 const Value = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'flex',
   alignItems: 'baseline',
+  flexWrap: 'wrap',
   gap: 4,
   fontWeight: 700,
   fontSize: 14,
@@ -227,7 +229,7 @@ const Inflow = styled.div({
     flexDirection: 'column',
     justifyContent: 'normal',
     gap: 8,
-    width: '20.5%',
+    minWidth: '18%',
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
@@ -68,7 +68,7 @@ export default Transaction;
 
 const TransactionContainer = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'grid',
-  gridTemplateColumns: '1.35fr 1fr 1fr',
+  gridTemplateColumns: '204px 17% max-content 1fr',
   padding: '16px 32px 13px 20px',
 
   [lightTheme.breakpoints.up('desktop_1194')]: {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
@@ -72,18 +72,8 @@ const TransactionContainer = styled.div<WithIsLight>(({ isLight }) => ({
   padding: '16px 32px 13px 20px',
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    gridTemplateColumns: '1.365fr 1fr 1fr',
+    gridTemplateColumns: '295px 16% max-content 1fr',
     padding: '16px 56px 14px 20px',
-  },
-
-  [lightTheme.breakpoints.up('desktop_1280')]: {
-    gridTemplateColumns: '1.296fr 1fr 1fr',
-    padding: '16px 64px 14px 20px',
-  },
-
-  [lightTheme.breakpoints.up('desktop_1440')]: {
-    gridTemplateColumns: '1.311fr 1fr 1fr',
-    padding: '16px 80px 14px 20px',
   },
 
   '&:hover': {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionHeader.tsx
@@ -40,6 +40,8 @@ export default TransactionHeader;
 const Wrapper = styled.div({
   display: 'flex',
   gap: 16,
+  gridColumn: '1 / 3',
+  padding: '0 16px',
 });
 
 const commonArrowStyles = {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.tsx
@@ -47,7 +47,7 @@ const Container = styled.div({
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    marginTop: 8,
+    marginTop: 3,
   },
 });
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/WalletInfo/WalletInfo.tsx
@@ -43,7 +43,7 @@ const Container = styled.div({
   display: 'flex',
 
   [lightTheme.breakpoints.up('table_834')]: {
-    marginTop: 10,
+    marginTop: 4,
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
@@ -86,9 +86,10 @@ const Name = styled.div<WithIsLight>(({ isLight }) => ({
   marginRight: 8.5,
 
   [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    fontSize: 14,
+    fontSize: 12,
     lineHeight: '17px',
     marginBottom: 6,
+    marginRight: 4,
   },
 }));
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

## Description
Redistributing the space on Reserve Card so it supports longer account names

## What solved
 - [X] Should animate the numbers on the "Total Core Unit Reserves" section when the "Include Off-Chain Reserves" check is checked/unchecked and the number changes