### PR TITLE
Add header for table and dark mode

### DIFF
--- a/src/stories/components/CUActivityTable/ActivityTable.tsx
+++ b/src/stories/components/CUActivityTable/ActivityTable.tsx
@@ -244,7 +244,7 @@ const TableHeaderTitle = styled.div<{
     ...(width && { width }),
   },
 
-  ...(styles || {}),
+  ...styles,
 }));
 
 const ChangesButtonContainer = styled.div({

--- a/src/stories/containers/Actors/ActorsContainer.stories.tsx
+++ b/src/stories/containers/Actors/ActorsContainer.stories.tsx
@@ -1,10 +1,40 @@
+import { EcosystemActorBuilder } from '@ses/core/businessLogic/builders/actors/actorsBuilder';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import AppLayout from '../AppLayout/AppLayout';
 import ActorsContainer from './ActorsContainer';
 import type { EcosystemActor } from '@ses/core/models/dto/teamsDTO';
 import type { ComponentMeta } from '@storybook/react';
 import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
-
+const itemForList = new EcosystemActorBuilder()
+  .withId('23')
+  .withCode('PH-001')
+  .withName('Powerhouse Inc.')
+  .withType('EcosystemActor')
+  .withImage('https://live.staticflickr.com/65535/52808669587_127cc79684_m.jpg')
+  .addCategory('Active Ecosystem Actor')
+  .addScope({
+    id: '1',
+    code: 'SUP',
+    name: 'Support Scope',
+  })
+  .addScope({
+    id: '3',
+    code: 'STA',
+    name: 'Stability Scope',
+  })
+  .withSocials({
+    twitter: '#',
+    forumProfile: '#',
+    forumPlatform: '#',
+    youtube: '#',
+    votingPortal: '#',
+    forumTag: '#',
+    github: '#',
+    discord: '#',
+    website: '#',
+    linkedIn: '#',
+  })
+  .build();
 export default {
   title: 'Pages/Actors',
   component: ActorsContainer,
@@ -22,7 +52,65 @@ export default {
 
 const variantsArgs = [
   {
-    actors: [] as EcosystemActor[],
+    actors: [
+      new EcosystemActorBuilder()
+        .withId('23')
+        .withCode('PH-001')
+        .withName('Powerhouse Inc.')
+        .withType('EcosystemActor')
+        .withImage('https://live.staticflickr.com/65535/52808669587_127cc79684_m.jpg')
+        .addCategory('Active Ecosystem Actor')
+        .addScope({
+          id: '1',
+          code: 'SUP',
+          name: 'Support Scope',
+        })
+        .addScope({
+          id: '3',
+          code: 'STA',
+          name: 'Stability Scope',
+        })
+        .withSocials({
+          twitter: '#',
+          forumProfile: '#',
+          forumPlatform: '#',
+          youtube: '#',
+          votingPortal: '#',
+          forumTag: '#',
+          github: '#',
+          discord: '#',
+          website: '#',
+          linkedIn: '#',
+        })
+        .build(),
+      itemForList,
+      itemForList,
+      itemForList,
+      itemForList,
+      new EcosystemActorBuilder()
+        .withId('23')
+        .withCode('PH-001')
+        .withName('Pull Up')
+        .withType('EcosystemActor')
+        .withImage('https://live.staticflickr.com/65535/52808669587_127cc79684_m.jpg')
+        .addCategory('Scope Facilitators')
+        .withSocials({
+          twitter: '#',
+          forumProfile: '#',
+          forumPlatform: '#',
+          youtube: '#',
+          votingPortal: '#',
+          forumTag: '#',
+          github: '#',
+          discord: '#',
+          website: '#',
+          linkedIn: '#',
+        })
+        .build(),
+      itemForList,
+      itemForList,
+      itemForList,
+    ] as EcosystemActor[],
     stories: true,
   },
   {
@@ -51,7 +139,7 @@ LightMode.parameters = {
     component: {
       0: {
         component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20207:261115&mode=design&t=ALuMnY1kY1FDcgbg-4',
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20187:244239&mode=design&t=m3bXwDUEoYywfyIX-4',
         options: {
           ...optionStyles,
           componentStyle: {

--- a/src/stories/containers/Actors/ActorsContainer.tsx
+++ b/src/stories/containers/Actors/ActorsContainer.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const ActorsContainer: React.FC<Props> = ({ actors, stories = false }) => {
-  const { readMore, handleRead, showTextDesk, isLessPhone, filtersActive } = useActors(actors, stories);
+  const { readMore, handleRead, showTextDesk, isLessPhone, filtersActive, columns } = useActors(actors, stories);
 
   const { isLight } = useThemeContext();
 
@@ -55,7 +55,7 @@ const ActorsContainer: React.FC<Props> = ({ actors, stories = false }) => {
           </ReadMore>
         </ContainerReadMore>
         <ContainerList>
-          <ActorTable actors={filtersActive} />
+          <ActorTable actors={filtersActive} columns={columns} />
         </ContainerList>
       </Container>
     </ExtendedPageContainer>
@@ -126,7 +126,13 @@ const ContainerText = styled.div({
 const ContainerList = styled.div({
   marginBottom: 64,
   // TODO:Remove this margin when add filter
-  marginTop: 32,
+  marginTop: 56,
+  [lightTheme.breakpoints.up('table_834')]: {
+    marginTop: 80,
+  },
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    marginTop: 46,
+  },
 });
 
 const StyledParagraphOne = styled.p<{ readMore: boolean }>(({ readMore }) => ({

--- a/src/stories/containers/Actors/components/ActorHeader/ActorsHeaderTable.tsx
+++ b/src/stories/containers/Actors/components/ActorHeader/ActorsHeaderTable.tsx
@@ -1,0 +1,102 @@
+import styled from '@emotion/styled';
+import ArrowDown from '@ses/components/svg/arrow-down';
+import ArrowUp from '@ses/components/svg/arrow-up';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { SortEnum } from '@ses/core/enums/sortEnum';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import type { EcosystemActor } from '@ses/core/models/dto/teamsDTO';
+
+export interface ActorTableHeader {
+  header: string;
+  width?: string;
+  align?: 'left' | 'center' | 'right';
+  styles?: React.CSSProperties;
+  sort?: SortEnum;
+  hidden?: boolean;
+}
+
+export interface Props {
+  columns: ActorTableHeader[];
+  actors?: EcosystemActor[];
+  sortClick?: (index: number) => void;
+}
+
+const ActorsHeaderTable: React.FC<Props> = ({ columns, sortClick }) => {
+  const { isLight } = useThemeContext();
+  return (
+    <TableHeader isLight={isLight}>
+      <TableHeaderRow className="no-select">
+        {columns
+          .filter((column) => !column.hidden)
+          .map((column, i) => (
+            <TableHeaderTitle
+              key={column.header}
+              width={column.width}
+              styles={column.styles}
+              align={column.align ?? 'left'}
+              onClick={() => column.sort !== SortEnum.Disabled && sortClick?.(i)}
+            >
+              {column.header}
+              {column.sort !== SortEnum.Disabled && (
+                <Arrows>
+                  <ArrowUp fill={column.sort === SortEnum.Asc ? '#231536' : '#708390'} style={{ margin: '4px 0' }} />
+                  <ArrowDown fill={column.sort === SortEnum.Desc ? '#231536' : '#708390'} />
+                </Arrows>
+              )}
+            </TableHeaderTitle>
+          ))}
+      </TableHeaderRow>
+    </TableHeader>
+  );
+};
+
+export default ActorsHeaderTable;
+const TableHeader = styled.div<{ isLight: boolean; isGlobal?: boolean }>(({ isLight }) => ({
+  display: 'none',
+  position: 'relative',
+  zIndex: 1,
+  background: isLight ? '#F7F8F9' : '#25273D',
+  color: isLight ? '#231536' : '#FFFFFF',
+  padding: '16px 0 14px',
+  borderRadius: '6px',
+  lineHeight: '22px',
+  boxShadow: isLight
+    ? 'inset .25px -.25px .25px .25px rgba(190, 190, 190, 0.25), 0px 20px 40px rgba(190, 190, 190, .25), 0px 1px 3px rgba(190, 190, 190, 0.25)'
+    : '0px 20px 40px rgba(7, 22, 40, 0.4)',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    display: 'block',
+  },
+}));
+
+const TableHeaderRow = styled.div({
+  display: 'flex',
+});
+
+const TableHeaderTitle = styled.div<{
+  width?: string;
+  styles?: React.CSSProperties;
+  align: 'left' | 'center' | 'right';
+}>(({ width, styles, align }) => ({
+  display: 'flex',
+  cursor: 'pointer',
+  fontFamily: 'Inter, sans-serif',
+  fontSize: '16px',
+  fontWeight: 400,
+  lineHeight: '22px',
+  ...{
+    textAlign: align,
+    ...(width && { width }),
+  },
+
+  ...(styles || {}),
+}));
+
+const Arrows = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  margin: '0 8px',
+  cursor: 'pointer',
+  boxSizing: 'unset',
+});

--- a/src/stories/containers/Actors/components/ActorHeader/ActorsHeaderTable.tsx
+++ b/src/stories/containers/Actors/components/ActorHeader/ActorsHeaderTable.tsx
@@ -85,10 +85,9 @@ const TableHeaderTitle = styled.div<{
   fontSize: '16px',
   fontWeight: 400,
   lineHeight: '22px',
-  ...{
-    textAlign: align,
-    ...(width && { width }),
-  },
+
+  textAlign: align,
+  ...(width && { width }),
 
   ...(styles || {}),
 }));

--- a/src/stories/containers/Actors/components/ActorItem/ActorItem.tsx
+++ b/src/stories/containers/Actors/components/ActorItem/ActorItem.tsx
@@ -21,7 +21,7 @@ const ActorItem: React.FC<Props> = ({ actor }) => {
   const { isLight } = useThemeContext();
 
   return (
-    <ExtendedGenericDelegate isLight={isLight}>
+    <ExtendedGenericDelegate isLight={isLight} hasScope={actor?.scopes.length > 0}>
       <ContainerActorType>
         <WrapperEcosystemActor>
           <EcosystemActorText isLight={isLight}>Ecosystem Actor</EcosystemActorText>
@@ -43,13 +43,14 @@ const ActorItem: React.FC<Props> = ({ actor }) => {
         </TypeSection>
       </ContainerActorType>
       <Line isLight={isLight} />
-      <WrapperScopeLinks>
-        <ScopeSection>
-          {actor?.scopes?.map((item) => (
-            <ScopeChip status={item.name as ActorScopeEnum} code={item.code} />
-          ))}
-        </ScopeSection>
-
+      <WrapperScopeLinks alignEnd={actor?.scopes.length === 0}>
+        {actor?.scopes.length > 0 && (
+          <ScopeSection>
+            {actor?.scopes?.map((item) => (
+              <ScopeChip status={item.name as ActorScopeEnum} code={item.code} />
+            ))}
+          </ScopeSection>
+        )}
         <SocialIconsSection>
           {actor?.socialMediaChannels && (
             <LinkContainer>
@@ -68,38 +69,43 @@ const ActorItem: React.FC<Props> = ({ actor }) => {
 };
 
 export default ActorItem;
-const ExtendedGenericDelegate = styled(GenericDelegateCard)<WithIsLight>(({ isLight }) => ({
-  background: isLight ? '#FFFFFF' : '#10191F',
-  boxShadow: isLight
-    ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
-    : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
+const ExtendedGenericDelegate = styled(GenericDelegateCard)<WithIsLight & { hasScope: boolean }>(
+  ({ isLight, hasScope }) => ({
+    background: isLight ? '#FFFFFF' : '#10191F',
+    boxShadow: isLight
+      ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
+      : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
 
-  padding: '16px',
-  display: 'flex',
-  flexDirection: 'column',
-  fontFamily: 'Inter, sans-serif',
-  fontStyle: 'normal',
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    padding: '8px 16px',
-    flexDirection: 'column',
-    height: 129,
-  },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    height: 82,
-    flexDirection: 'row',
     padding: '16px',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  [lightTheme.breakpoints.up('desktop_1440')]: {
-    flexDirection: 'row',
-    gap: 59,
-    height: 82,
-    maxWidth: 1312,
-    alignItems: 'center',
-  },
-}));
+    display: 'flex',
+    flexDirection: 'column',
+    fontFamily: 'Inter, sans-serif',
+    fontStyle: 'normal',
+    minHeight: hasScope ? '214px' : '183px',
+
+    [lightTheme.breakpoints.up('table_834')]: {
+      padding: '8px 16px',
+      flexDirection: 'column',
+      maxHeight: 'revert',
+      height: 129,
+      minHeight: 'revert',
+    },
+    [lightTheme.breakpoints.up('desktop_1194')]: {
+      height: 82,
+      flexDirection: 'row',
+      padding: '16px',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    [lightTheme.breakpoints.up('desktop_1440')]: {
+      flexDirection: 'row',
+      gap: 59,
+      height: 82,
+      maxWidth: 1312,
+      alignItems: 'center',
+    },
+  })
+);
 
 const ContainerActorType = styled.div({
   display: 'flex',
@@ -240,15 +246,15 @@ const CircleAvatarExtended = styled(CircleAvatar)<WithIsLight>(({ isLight }) => 
   boxShadow: isLight ? '2px 4px 7px rgba(26, 171, 155, 0.25)' : '2px 4px 7px rgba(26, 171, 155, 0.25)',
 }));
 
-const WrapperScopeLinks = styled.div({
+const WrapperScopeLinks = styled.div<{ alignEnd: boolean }>(({ alignEnd }) => ({
   display: 'flex',
   flexDirection: 'column',
-  justifyContent: 'space-between',
+  justifyContent: alignEnd ? 'flex-end' : 'space-between',
   [lightTheme.breakpoints.up('table_834')]: {
     flexDirection: 'row',
     alignItems: 'center',
   },
-});
+}));
 
 const ScopeSection = styled.div({
   display: 'flex',

--- a/src/stories/containers/Actors/components/ActorTable/ActorTable.tsx
+++ b/src/stories/containers/Actors/components/ActorTable/ActorTable.tsx
@@ -1,17 +1,21 @@
 import styled from '@emotion/styled';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
+import ActorsHeaderTable from '../ActorHeader/ActorsHeaderTable';
 import ActorItem from '../ActorItem/ActorItem';
+import type { ActorTableHeader } from '../ActorHeader/ActorsHeaderTable';
 import type { EcosystemActor } from '@ses/core/models/dto/teamsDTO';
 
 interface Props {
   actors: EcosystemActor[];
   sortClick?: (index: number) => void;
+  columns: ActorTableHeader[];
 }
 
-const ActorTable: React.FC<Props> = ({ actors }) => (
+const ActorTable: React.FC<Props> = ({ actors, columns, sortClick }) => (
   <TableWrapper>
     <ContainerList>
+      <ActorsHeaderTable actors={actors} columns={columns} sortClick={sortClick} />
       {actors?.map((actor) => (
         <ActorItem actor={actor} key={actor.name} />
       ))}

--- a/src/stories/containers/Actors/useActors.ts
+++ b/src/stories/containers/Actors/useActors.ts
@@ -1,8 +1,10 @@
 import useMediaQuery from '@mui/material/useMediaQuery';
 
+import { SortEnum } from '@ses/core/enums/sortEnum';
 import lightTheme from '@ses/styles/theme/light';
 import { useState } from 'react';
 
+import type { ActorTableHeader } from './components/ActorHeader/ActorsHeaderTable';
 import type { EcosystemActor } from '@ses/core/models/dto/teamsDTO';
 
 export const useActors = (actors: EcosystemActor[], stories = false) => {
@@ -12,6 +14,51 @@ export const useActors = (actors: EcosystemActor[], stories = false) => {
   const handleRead = () => {
     setReadMore(!readMore);
   };
+  const columns: ActorTableHeader[] = [
+    {
+      header: 'Ecosystem Actor',
+      styles: {
+        boxSizing: 'border-box',
+        [lightTheme.breakpoints.up('desktop_1194')]: {
+          minWidth: 359,
+          paddingLeft: 16,
+        },
+      },
+      sort: SortEnum.Neutral,
+    },
+    {
+      header: 'Role',
+      styles: {
+        width: 232,
+        [lightTheme.breakpoints.up('desktop_1280')]: {
+          paddingLeft: 18,
+        },
+        [lightTheme.breakpoints.up('desktop_1440')]: {
+          paddingLeft: 60,
+        },
+      },
+      sort: SortEnum.Neutral,
+    },
+    {
+      header: 'Scope',
+      sort: SortEnum.Neutral,
+      styles: {
+        width: 232,
+        [lightTheme.breakpoints.up('desktop_1280')]: {
+          paddingLeft: 36,
+        },
+        [lightTheme.breakpoints.up('desktop_1440')]: {
+          paddingLeft: 52,
+          justifyContent: 'center',
+        },
+      },
+    },
+    {
+      header: 'Last Modified',
+      sort: SortEnum.Neutral,
+      hidden: true,
+    },
+  ];
 
   // TODO: Remove this add new search when filter is add
   const filtersActive = actors;
@@ -22,5 +69,6 @@ export const useActors = (actors: EcosystemActor[], stories = false) => {
     showTextDesk,
     isLessPhone,
     filtersActive,
+    columns,
   };
 };


### PR DESCRIPTION
# Ticket

https://trello.com/c/8LcgvKYi/286-user-story-basic-list-with-ecosystem-actors

# What solved
- [X] Move all the ItemsHeader Dictionary
- [X] Add the header of the table  and all responsive
- [X] Should  add a dark mode for the page
- [X] Should Clicking relevant links to the actor's GitHub, Discord, website, and Twitter get you each profile of the actors

# Description
This adds a header for the table, add dark mode, and different sizes for the cards
