### PR TITLE
[SES-268] Improve the UI when there is no data for the off-chain section

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -41,10 +41,12 @@ const CUReserves: React.FC<CUReservesProps> = ({
           subtitle={`On-chain and off-chain reserves accessible${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
           tooltip={'pending...'}
         />
-        <CheckContainer isLight={isLight}>
-          Include Off-Chain Reserves{' '}
-          <Checkbox checked={includeOffChain} onChange={toggleIncludeOffChain} isLight={isLight} size="small" />
-        </CheckContainer>
+        {!!offChainData?.length && (
+          <CheckContainer isLight={isLight}>
+            Include Off-Chain Reserves{' '}
+            <Checkbox checked={includeOffChain} onChange={toggleIncludeOffChain} isLight={isLight} size="small" />
+          </CheckContainer>
+        )}
       </HeaderContainer>
 
       <CardsContainer>
@@ -91,20 +93,22 @@ const CUReserves: React.FC<CUReservesProps> = ({
         </ReservesCardsContainer>
       </OnChainSubsection>
 
-      <OffChainSubsection isDisabled={!includeOffChain}>
-        <SectionHeader
-          title="Off Chain Reserves"
-          subtitle={`Unspent off-chain reserves${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
-          tooltip={'pending...'}
-          isSubsection
-        />
+      {!!offChainData?.length && (
+        <OffChainSubsection isDisabled={!includeOffChain}>
+          <SectionHeader
+            title="Off Chain Reserves"
+            subtitle={`Unspent off-chain reserves${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
+            tooltip={'pending...'}
+            isSubsection
+          />
 
-        <ReservesCardsContainer>
-          {offChainData?.map((account) => (
-            <ReserveCard key={account.id} account={account} />
-          ))}
-        </ReservesCardsContainer>
-      </OffChainSubsection>
+          <ReservesCardsContainer>
+            {offChainData?.map((account) => (
+              <ReserveCard key={account.id} account={account} />
+            ))}
+          </ReservesCardsContainer>
+        </OffChainSubsection>
+      )}
     </div>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
@@ -32,6 +32,7 @@ const TransactionList: React.FC<TransactionListProps> = ({ items, highlightPosit
   return (
     <TransactionListContainer isLight={isLight}>
       <TransactionCard isLight={isLight}>
+        {!items?.length && <EmptyList isLight={isLight}>N/A</EmptyList>}
         {items?.map((item: SnapshotAccountTransaction | SnapshotAccount) =>
           isSnapshotAccount(item) ? (
             <GroupContainer key={item.id}>
@@ -121,3 +122,10 @@ const GroupContainer = styled.div({
     gap: 0,
   },
 });
+
+const EmptyList = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  justifyContent: 'center',
+  color: isLight ? '#231536' : '#D2D4EF',
+  padding: '48px 0',
+}));

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -86,27 +86,27 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
   const startDate = snapshot.start ?? undefined;
   const endDate = snapshot.end ?? undefined;
 
+  // root account
   const rootAccount = snapshot.snapshotAccount.find(
     (account) => account.groupAccountId === null && account.upstreamAccountId === null
   );
   if (!rootAccount) throw new Error('Maker Protocol Wallet not found');
 
+  // main account (MakerDAO Funding Overview section)
   const mainAccount = snapshot.snapshotAccount.find(
     (account) => account.groupAccountId === rootAccount.id && account.upstreamAccountId === null
   );
   if (!mainAccount) throw new Error('Maker Protocol Wallet not found');
   const rootBalance = rootAccount.snapshotAccountBalance.find((balance) => balance.token === selectedToken);
 
+  // transaction history (MakerDAO Funding Overview section)
   const transactionHistory = mainAccount.snapshotAccountTransaction
     .filter((transaction) => transaction.token === selectedToken)
     .sort(transactionSort);
 
-  // cu reserves balance
+  // Total Core Unit Reserves section
   const cuReservesAccount = snapshot.snapshotAccount.find(
-    // eslint-disable-next-line arrow-body-style
-    (account) => {
-      return account.groupAccountId === rootAccount.id && account.upstreamAccountId !== null;
-    }
+    (account) => account.groupAccountId === rootAccount.id && account.upstreamAccountId !== null
   );
   const cuReservesBalances = cuReservesAccount?.snapshotAccountBalance?.filter(
     (balance) => balance.token === selectedToken


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Hide the arrow of the CU reserve cards when they have no transactions, also was made it unclickable the cards when there are no transactions. The Off-Chain section and all its data are now hidden when there is no Off-chain data

# What solved
- [X] Should hide the expand/collapse arrow when there are no transactions from the Off-Chain Reserves/On-Chain Reserves
- [X] Should hide the section and the Include Off-Chain Reserves checkbox when there is no data