### PR TITLE
Fix error popover remainder open

### DIFF
--- a/src/stories/components/CustomPopover/CustomPopover.tsx
+++ b/src/stories/components/CustomPopover/CustomPopover.tsx
@@ -3,7 +3,7 @@ import { Popover } from '@mui/material';
 import { getPageWrapper } from '@ses/core/utils/dom';
 
 import isEqual from 'lodash/isEqual';
-import React, { useCallback, useReducer, useRef } from 'react';
+import React, { useCallback, useEffect, useReducer, useRef } from 'react';
 import { useThemeContext } from '../../../core/context/ThemeContext';
 import type { PopoverOrigin } from '@mui/material';
 import type { SxProps } from '@mui/material/styles';
@@ -171,6 +171,21 @@ export const CustomPopover = ({
     onClose?.();
   }, [onClose]);
 
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        dispatch({
+          type: 'none',
+          payload: null,
+        });
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
   const handlePopoverOpen = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       clearTimeout(leaveTimeout);


### PR DESCRIPTION
# Ticket

https://trello.com/c/8LcgvKYi/286-user-story-basic-list-with-ecosystem-actors

# What solved
- [X] Clicking on the social icons. A new tab should be opened and the tooltip should disappear. 

# Description
Fix the tooltip should close when opening a new tab