### PR TITLE
Add hover and fix color arrow in header table for dark mode

### DIFF
--- a/src/stories/components/CustomTableHeader/CustomTableHeader.tsx
+++ b/src/stories/components/CustomTableHeader/CustomTableHeader.tsx
@@ -26,8 +26,29 @@ export const CustomTableHeader = (props: CustomTableHeaderProps) => {
       <Label isLight={isLight}>{props.title}</Label>
       {props.state !== SortEnum.Disabled && (
         <Arrows>
-          <ArrowUp fill={props.state === SortEnum.Asc ? '#231536' : '#708390'} style={{ margin: '4px 0' }} />
-          <ArrowDown fill={props.state === SortEnum.Desc ? '#231536' : '#708390'} />
+          <ArrowUp
+            fill={
+              isLight
+                ? props.state === SortEnum.Asc
+                  ? '#231536'
+                  : '#708390'
+                : props.state === SortEnum.Asc
+                ? '#434358'
+                : '#708390'
+            }
+            style={{ margin: '4px 0' }}
+          />
+          <ArrowDown
+            fill={
+              isLight
+                ? props.state === SortEnum.Desc
+                  ? '#231536'
+                  : '#708390'
+                : props.state === SortEnum.Desc
+                ? '#434358'
+                : '#708390'
+            }
+          />
         </Arrows>
       )}
     </Container>

--- a/src/stories/containers/Actors/ActorsContainer.tsx
+++ b/src/stories/containers/Actors/ActorsContainer.tsx
@@ -196,6 +196,9 @@ const ReadMore = styled.div<WithIsLight>(({ isLight }) => ({
   [lightTheme.breakpoints.up('table_834')]: {
     marginBottom: 30,
   },
+  ':hover': {
+    color: isLight ? 'rgba(35, 21, 54, 0.8)' : 'rgba(210, 212, 239, 0.8)',
+  },
 }));
 
 const ContainerReadMore = styled.div({

--- a/src/stories/containers/Actors/components/ActorHeader/ActorsHeaderTable.tsx
+++ b/src/stories/containers/Actors/components/ActorHeader/ActorsHeaderTable.tsx
@@ -38,8 +38,29 @@ const ActorsHeaderTable: React.FC<Props> = ({ columns, sortClick }) => {
               {column.header}
               {column.sort !== SortEnum.Disabled && (
                 <Arrows>
-                  <ArrowUp fill={column.sort === SortEnum.Asc ? '#231536' : '#708390'} style={{ margin: '4px 0' }} />
-                  <ArrowDown fill={column.sort === SortEnum.Desc ? '#231536' : '#708390'} />
+                  <ArrowUp
+                    fill={
+                      isLight
+                        ? column.sort === SortEnum.Asc
+                          ? '#231536'
+                          : '#708390'
+                        : column.sort === SortEnum.Asc
+                        ? '#434358'
+                        : '#708390'
+                    }
+                    style={{ margin: '4px 0' }}
+                  />
+                  <ArrowDown
+                    fill={
+                      isLight
+                        ? column.sort === SortEnum.Desc
+                          ? '#231536'
+                          : '#708390'
+                        : column.sort === SortEnum.Desc
+                        ? '#434358'
+                        : '#708390'
+                    }
+                  />
                 </Arrows>
               )}
             </TableHeaderTitle>


### PR DESCRIPTION

# Ticket

https://trello.com/c/8LcgvKYi/286-user-story-basic-list-with-ecosystem-actors

# What solved
- [X] Read More option (Light and dark mode). It should have a hover.  
- [X]  The inactive arrows should have color: #434358.  

# Description
This add hover to read more, and also fix color in the arrow