### PR TITLE
[SES-268] Add On chain only version to the expense comparison table

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -23,6 +23,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
     cuReservesBalance,
     onChainData,
     offChainData,
+    hasOffChainData,
   } = useAccountsSnapshot(snapshot);
 
   return (
@@ -44,7 +45,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
         onChainData={onChainData}
         offChainData={offChainData}
       />
-      <ExpensesComparison rows={expensesComparisonRows} />
+      <ExpensesComparison rows={expensesComparisonRows} hasOffChainData={hasOffChainData} />
     </Wrapper>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -209,7 +209,7 @@ const OnChainSubsection = styled.div({
 });
 
 const OffChainSubsection = styled.div<{ isDisabled?: boolean }>(({ isDisabled = false }) => ({
-  marginTop: 16,
+  marginTop: 24,
   opacity: isDisabled ? 0.3 : 1,
 }));
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCard.tsx
@@ -12,10 +12,15 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface ExpensesComparisonRowCardProps {
   row: RowProps;
+  hasOffChainData: boolean;
   expandable?: boolean;
 }
 
-const ExpensesComparisonRowCard: React.FC<ExpensesComparisonRowCardProps> = ({ row, expandable = true }) => {
+const ExpensesComparisonRowCard: React.FC<ExpensesComparisonRowCardProps> = ({
+  row,
+  hasOffChainData,
+  expandable = true,
+}) => {
   const { isLight } = useThemeContext();
   const [expanded, setExpanded] = React.useState<boolean>(!expandable);
   const isTotalCard = row.cells[0].value === 'Totals';
@@ -61,7 +66,9 @@ const ExpensesComparisonRowCard: React.FC<ExpensesComparisonRowCardProps> = ({ r
                 {row.cells[1].value as React.ReactNode}
               </Value>
             </Item>
-            <NetExpenseTransactions isLight={isLight}>Net Expense Transactions</NetExpenseTransactions>
+            {hasOffChainData && (
+              <NetExpenseTransactions isLight={isLight}>Net Expense Transactions</NetExpenseTransactions>
+            )}
           </Reported>
           <BorderedContainer isLight={isLight}>
             {/* on chain only */}
@@ -91,33 +98,37 @@ const ExpensesComparisonRowCard: React.FC<ExpensesComparisonRowCardProps> = ({ r
                 {row.cells[3].value as React.ReactNode}
               </Value>
             </Item>
-            <HorizontalDivider isLight={isLight} />
-            {/* including off-chain */}
-            <Item>
-              <BasicTHCell
-                as="div"
-                cell={{
-                  ...(row.cells[4].inherit ?? ({} as GenericCell)),
-                  cellPadding: 0,
-                }}
-              />
-              <Value isLight={isLight} isTotal={isTotalCard}>
-                {row.cells[4].value as React.ReactNode}
-              </Value>
-            </Item>
-            {/* difference */}
-            <Item marginTop={20}>
-              <BasicTHCell
-                as="div"
-                cell={{
-                  ...(row.cells[5].inherit ?? ({} as GenericCell)),
-                  cellPadding: 0,
-                }}
-              />
-              <Value isLight={isLight} isTotal={isTotalCard}>
-                {row.cells[5].value as React.ReactNode}
-              </Value>
-            </Item>
+            {hasOffChainData && (
+              <>
+                <HorizontalDivider isLight={isLight} />
+                {/* including off-chain */}
+                <Item>
+                  <BasicTHCell
+                    as="div"
+                    cell={{
+                      ...(row.cells[4].inherit ?? ({} as GenericCell)),
+                      cellPadding: 0,
+                    }}
+                  />
+                  <Value isLight={isLight} isTotal={isTotalCard}>
+                    {row.cells[4].value as React.ReactNode}
+                  </Value>
+                </Item>
+                {/* difference */}
+                <Item marginTop={20}>
+                  <BasicTHCell
+                    as="div"
+                    cell={{
+                      ...(row.cells[5].inherit ?? ({} as GenericCell)),
+                      cellPadding: 0,
+                    }}
+                  />
+                  <Value isLight={isLight} isTotal={isTotalCard}>
+                    {row.cells[5].value as React.ReactNode}
+                  </Value>
+                </Item>
+              </>
+            )}
           </BorderedContainer>
         </AccordionDetails>
       </Accordion>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 import TransactionList from '../TransactionList/TransactionList';
 import WalletInfo from '../WalletInfo/WalletInfo';
 import type { AccordionProps } from '@mui/material/Accordion';
-import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
 import type { Token, UIReservesData } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
@@ -105,48 +104,51 @@ export default ReserveCard;
 
 const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters elevation={0} square {...props} />)({
   backgroundColor: 'transparent',
-  marginBottom: 8,
   borderRadius: '6px',
+
+  '&:not(:last-of-type)': {
+    marginBottom: 8,
+  },
 
   '&:before': {
     display: 'none',
   },
 });
 
-const Card = styled((props: AccordionSummaryProps) => <MuiAccordionSummary {...props} />)<
-  WithIsLight & { hasTransactions: boolean }
->(({ isLight, hasTransactions }) => ({
-  padding: '16px 24px 24px',
-  background: isLight ? '#ffffff' : '#1E2C37',
-  boxShadow: isLight
-    ? '0px 4px 6px rgba(196, 196, 196, 0.25)'
-    : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
-  borderRadius: 6,
-  zIndex: 1,
-  // !important is required to override default cursor style
-  cursor: hasTransactions ? 'pointer' : 'auto!important',
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    padding: 0,
-  },
-
-  '&.Mui-expanded': {
-    [lightTheme.breakpoints.down('table_834')]: {
-      borderRadius: '6px 6px 0 0',
-    },
-  },
-
-  '& .MuiAccordionSummary-content': {
-    margin: 0,
-    width: '100%',
-    flexDirection: 'column',
+const Card = styled(MuiAccordionSummary)<WithIsLight & { hasTransactions: boolean }>(
+  ({ isLight, hasTransactions }) => ({
+    padding: '16px 24px 24px',
+    background: isLight ? '#ffffff' : '#1E2C37',
+    boxShadow: isLight
+      ? '0px 4px 6px rgba(196, 196, 196, 0.25)'
+      : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
+    borderRadius: 6,
+    zIndex: 1,
+    // !important is required to override default cursor style
+    cursor: hasTransactions ? 'pointer' : 'auto!important',
 
     [lightTheme.breakpoints.up('table_834')]: {
-      flexDirection: 'row',
-      alignItems: 'center',
+      padding: 0,
     },
-  },
-}));
+
+    '&.Mui-expanded': {
+      [lightTheme.breakpoints.down('table_834')]: {
+        borderRadius: '6px 6px 0 0',
+      },
+    },
+
+    '& .MuiAccordionSummary-content': {
+      margin: 0,
+      width: '100%',
+      flexDirection: 'column',
+
+      [lightTheme.breakpoints.up('table_834')]: {
+        flexDirection: 'row',
+        alignItems: 'center',
+      },
+    },
+  })
+);
 
 const TransactionContainer = styled(MuiAccordionDetails)(() => ({
   padding: 0,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
@@ -1,5 +1,5 @@
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
-import { buildRow } from '../../useAccountsSnapshot';
+import { buildRow, buildRowWithoutOffChain } from '../../useAccountsSnapshot';
 import ExpensesComparison from './ExpensesComparison';
 import type { RowProps } from '@ses/components/AdvanceTable/types';
 import type { ComponentMeta } from '@storybook/react';
@@ -23,9 +23,23 @@ const rows = [
   buildRow(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%', '681,304.25 DAI', '-0.03%'], false, true),
 ] as RowProps[];
 
-const variantsArgs = [{}];
+const rowsWithoutOffChain = [
+  buildRowWithoutOffChain(['MAY-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%'], true, false),
+  buildRowWithoutOffChain(['APR-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%'], false, false),
+  buildRowWithoutOffChain(['MAR-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%'], false, false),
+  buildRowWithoutOffChain(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%'], false, true),
+] as RowProps[];
 
-export const [[LightMode, DarkMode]] = createThemeModeVariants(() => <ExpensesComparison rows={rows} />, variantsArgs);
+export const [[LightMode, DarkMode]] = createThemeModeVariants(
+  // it is required to initialized this way due the rows has react components and they can not be serialized
+  () => <ExpensesComparison hasOffChainData={true} rows={rows} />,
+  [{}]
+);
+
+export const [[WithoutOffChainLightMode, WithoutOffChainDarkMode]] = createThemeModeVariants(
+  () => <ExpensesComparison hasOffChainData={false} rows={rowsWithoutOffChain} />,
+  [{}]
+);
 
 LightMode.parameters = {
   figma: {
@@ -86,6 +100,61 @@ LightMode.parameters = {
           },
           style: {
             top: 0,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};
+
+WithoutOffChainLightMode.parameters = {
+  figma: {
+    component: {
+      834: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20802:265303',
+        options: {
+          componentStyle: {
+            width: 770,
+          },
+          style: {
+            top: 58,
+            left: -40,
+          },
+        },
+      },
+      1194: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20802:265228',
+        options: {
+          componentStyle: {
+            width: 1130,
+          },
+          style: {
+            top: 58,
+            left: -40,
+          },
+        },
+      },
+      1280: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20802:265153',
+        options: {
+          componentStyle: {
+            width: 1184,
+          },
+          style: {
+            top: 58,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20802:265078',
+        options: {
+          componentStyle: {
+            width: 1312,
+          },
+          style: {
+            top: 58,
             left: -40,
           },
         },

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
@@ -93,7 +93,7 @@ LightMode.parameters = {
         },
       },
       1440: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18569%3A222613',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19847:227753',
         options: {
           componentStyle: {
             width: 1312,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
@@ -1,137 +1,18 @@
 import styled from '@emotion/styled';
 import AdvanceTable from '@ses/components/AdvanceTable/AdvanceTable';
-import Information from '@ses/components/svg/information';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import SectionHeader from '../SectionHeader/SectionHeader';
+import { EXPENSES_COMPARISON_TABLE_HEADER, EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN } from './headers';
 import type { RowProps } from '@ses/components/AdvanceTable/types';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface ExpensesComparisonProps {
   rows: RowProps[];
+  hasOffChainData: boolean;
 }
 
-const HeaderWithIcon = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'flex-end',
-  gap: 6.5,
-
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    gap: 10,
-  },
-});
-
-export const EXPENSES_COMPARISON_TABLE_HEADER = [
-  {
-    cells: [
-      {
-        value: 'Reported actuals',
-        rowSpan: 2,
-        colSpan: 2,
-        border: {
-          right: true,
-        },
-        alignment: 'right',
-      },
-      {
-        value: 'Net Expense Transactions',
-        defaultRenderer: 'boldText',
-        colSpan: 4,
-        border: {
-          bottom: true,
-        },
-        cellPadding: {
-          table_834: '16px 16px 18px',
-          desktop_1194: '16px',
-        },
-        alignment: 'center',
-      },
-    ],
-  },
-  {
-    cellPadding: {
-      table_834: '23px 8px 23px 0',
-      desktop_1194: '23px 16px',
-    },
-    cells: [
-      {
-        isHidden: true,
-        border: {
-          right: true,
-        },
-        width: {
-          desktop_1194: '16.463%',
-          table_834: '12%',
-        },
-      },
-      {
-        isHidden: true,
-        border: {
-          right: true,
-        },
-        alignment: 'right',
-        width: {
-          desktop_1194: '16.463%',
-          table_834: '18.463%',
-        },
-      },
-      {
-        value: (
-          <HeaderWithIcon>
-            On-Chain Only <Information />
-          </HeaderWithIcon>
-        ),
-        alignment: 'right',
-        width: {
-          desktop_1194: '22.027%',
-          table_834: '19.5%',
-        },
-        cellPadding: {
-          table_834: '23px 13px 23px 0',
-          desktop_1194: '23px 16px',
-        },
-      },
-      {
-        value: 'difference',
-        alignment: 'right',
-        width: {
-          desktop_1194: '11.28%',
-          table_834: '11.28%',
-        },
-        border: {
-          right: true,
-        },
-      },
-      {
-        value: (
-          <HeaderWithIcon>
-            Including off-chain <Information />
-          </HeaderWithIcon>
-        ),
-        alignment: 'right',
-        width: {
-          desktop_1194: '22.027%',
-          table_834: '26%',
-        },
-        cellPadding: {
-          table_834: '23px 13px 23px 0',
-          desktop_1194: '23px 16px',
-        },
-      },
-      {
-        value: 'difference',
-        alignment: 'right',
-      },
-    ],
-    border: {
-      bottom: true,
-    },
-  },
-] as RowProps[];
-
-const ExpensesComparison: React.FC<ExpensesComparisonProps> = ({ rows }) => {
+const ExpensesComparison: React.FC<ExpensesComparisonProps> = ({ rows, hasOffChainData }) => {
   const { isLight } = useThemeContext();
 
   return (
@@ -143,7 +24,13 @@ const ExpensesComparison: React.FC<ExpensesComparisonProps> = ({ rows }) => {
       />
 
       <TableWrapper>
-        <StyledTable isLight={isLight} header={EXPENSES_COMPARISON_TABLE_HEADER} body={rows} />
+        <StyledTable
+          isLight={isLight}
+          header={
+            hasOffChainData ? EXPENSES_COMPARISON_TABLE_HEADER : EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN
+          }
+          body={rows}
+        />
       </TableWrapper>
     </div>
   );

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/headers.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/headers.tsx
@@ -1,0 +1,199 @@
+import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
+import Information from '@ses/components/svg/information';
+import lightTheme from '@ses/styles/theme/light';
+import type { RowProps } from '@ses/components/AdvanceTable/types';
+
+const HeaderWithIcon = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  gap: 6.5,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    gap: 10,
+  },
+});
+
+const NetExpenseTransactions = () => {
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+
+  return (
+    <HeaderWithIcon>
+      Net {isMobile ? 'Exp' : 'Expense'} transactions <Information />
+    </HeaderWithIcon>
+  );
+};
+
+export const EXPENSES_COMPARISON_TABLE_HEADER = [
+  {
+    cells: [
+      {
+        value: 'Reported actuals',
+        rowSpan: 2,
+        colSpan: 2,
+        border: {
+          right: true,
+        },
+        alignment: 'right',
+      },
+      {
+        value: 'Net Expense Transactions',
+        defaultRenderer: 'boldText',
+        colSpan: 4,
+        border: {
+          bottom: true,
+        },
+        cellPadding: {
+          table_834: '16px 16px 18px',
+          desktop_1194: '16px',
+        },
+        alignment: 'center',
+      },
+    ],
+  },
+  {
+    cellPadding: {
+      table_834: '23px 8px 23px 0',
+      desktop_1194: '23px 16px',
+    },
+    cells: [
+      {
+        isHidden: true,
+        border: {
+          right: true,
+        },
+        width: {
+          desktop_1194: '16.463%',
+          table_834: '12%',
+        },
+      },
+      {
+        isHidden: true,
+        border: {
+          right: true,
+        },
+        alignment: 'right',
+        width: {
+          desktop_1194: '16.463%',
+          table_834: '18.463%',
+        },
+      },
+      {
+        value: (
+          <HeaderWithIcon>
+            On-Chain Only <Information />
+          </HeaderWithIcon>
+        ),
+        alignment: 'right',
+        width: {
+          desktop_1194: '22.027%',
+          table_834: '19.5%',
+        },
+        cellPadding: {
+          table_834: '23px 13px 23px 0',
+          desktop_1194: '23px 16px',
+        },
+      },
+      {
+        value: 'difference',
+        alignment: 'right',
+        width: {
+          desktop_1194: '11.28%',
+          table_834: '11.28%',
+        },
+        border: {
+          right: true,
+        },
+      },
+      {
+        value: (
+          <HeaderWithIcon>
+            Including off-chain <Information />
+          </HeaderWithIcon>
+        ),
+        alignment: 'right',
+        width: {
+          desktop_1194: '22.027%',
+          table_834: '26%',
+        },
+        cellPadding: {
+          table_834: '23px 13px 23px 0',
+          desktop_1194: '23px 16px',
+        },
+      },
+      {
+        value: 'difference',
+        alignment: 'right',
+      },
+    ],
+    border: {
+      bottom: true,
+    },
+  },
+] as RowProps[];
+
+export const EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN = [
+  {
+    cellPadding: {
+      table_834: '23px 8px 23px 0',
+      desktop_1194: '23px 16px',
+    },
+    cells: [
+      {
+        isHidden: true,
+        border: {
+          right: true,
+        },
+        width: {
+          desktop_1440: '16.5%',
+          desktop_1280: '18.25%',
+          desktop_1194: '19.1%',
+          table_834: '25.5%',
+        },
+      },
+      {
+        isHidden: true,
+        border: {
+          right: true,
+        },
+        alignment: 'right',
+        width: {
+          desktop_1440: '16.5%',
+          desktop_1280: '18.25%',
+          desktop_1194: '19.2%',
+          table_834: '25.4%',
+        },
+      },
+      {
+        value: 'Reported actuals',
+        colSpan: 2,
+        border: {
+          right: true,
+        },
+        alignment: 'right',
+      },
+      {
+        value: <NetExpenseTransactions />,
+        alignment: 'right',
+        width: {
+          desktop_1440: '33.5%',
+          desktop_1280: '31.8%',
+          desktop_1194: '30.8%',
+          table_834: '33.5%',
+        },
+        cellPadding: {
+          table_834: '23px 13px 23px 0',
+          desktop_1194: '23px 16px',
+        },
+      },
+      {
+        value: 'difference',
+        alignment: 'right',
+      },
+    ],
+    border: {
+      bottom: true,
+    },
+  },
+] as RowProps[];

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
@@ -13,7 +13,7 @@ export interface TransactionProps {
   name: string;
   date: string;
   toDate?: string | null;
-  txHash: string;
+  txHash: string | null;
   counterPartyName: string;
   counterPartyAddress: string;
   amount: number;

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionHeader.tsx
@@ -12,7 +12,7 @@ interface TransactionHeaderProps {
   name: string;
   date: string;
   toDate?: string | null;
-  txHash: string;
+  txHash: string | null;
 }
 
 const TransactionHeader: React.FC<TransactionHeaderProps> = ({ isIncomingTransaction, name, date, toDate, txHash }) => {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
@@ -8,7 +8,6 @@ import React, { useState } from 'react';
 import AccordionArrow from '../AccordionArrow/AccordionArrow';
 import TransactionList from '../TransactionList/TransactionList';
 import type { AccordionProps } from '@mui/material/Accordion';
-import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
 import type { SnapshotAccountTransaction } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
@@ -25,7 +24,9 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ transactionHist
   return (
     <TransactionHistoryContainer>
       <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)}>
-        <AccordionSummary isLight={isLight}>View Transaction History</AccordionSummary>
+        <AccordionSummary isLight={isLight} expandIcon={<AccordionArrow />}>
+          View Transaction History
+        </AccordionSummary>
         <AccordionDetails>
           <TransactionList items={transactionHistory} highlightPositiveAmounts={true} />
         </AccordionDetails>
@@ -44,9 +45,7 @@ const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters
   backgroundColor: 'transparent',
 });
 
-const AccordionSummary = styled((props: AccordionSummaryProps) => (
-  <MuiAccordionSummary expandIcon={<AccordionArrow />} {...props} />
-))<WithIsLight>(({ isLight }) => ({
+const AccordionSummary = styled(MuiAccordionSummary)<WithIsLight>(({ isLight }) => ({
   backgroundColor: isLight ? '#FFFFFF' : '#1E2C37',
   boxShadow: isLight
     ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TxHash/TxHash.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TxHash/TxHash.tsx
@@ -4,19 +4,19 @@ import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 
 interface TxHashProps {
-  txHash: string;
+  txHash: string | null;
   className?: string;
 }
 
 const TxHash: React.FC<TxHashProps> = ({ txHash, ...props }) => {
-  const formattedHash = txHash.length <= 16 ? txHash : `${txHash.slice(0, 16)}...`;
+  const formattedHash = !txHash ? '' : txHash?.length <= 16 ? txHash : `${txHash.slice(0, 16)}...`;
 
   return (
     <TxHashContainer {...props}>
       <Hash href={`https://etherscan.io/tx/${txHash}`} target="_blank">
         {formattedHash}
       </Hash>
-      <CopyIcon text={txHash} defaultTooltip="Copy Transaction Hash" />
+      <CopyIcon text={txHash ?? ''} defaultTooltip="Copy Transaction Hash" />
     </TxHashContainer>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -1,7 +1,10 @@
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import ExpensesComparisonRowCard from './components/Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCard';
-import { EXPENSES_COMPARISON_TABLE_HEADER } from './components/ExpensesComparison/ExpensesComparison';
+import {
+  EXPENSES_COMPARISON_TABLE_HEADER,
+  EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN,
+} from './components/ExpensesComparison/headers';
 import { getReserveAccounts, transactionSort } from './utils/reserveUtils';
 import type { CardRenderProps, RowProps } from '@ses/components/AdvanceTable/types';
 import type { Snapshots, Token } from '@ses/core/models/dto/snapshotAccountDTO';
@@ -24,7 +27,11 @@ export const buildRow = (
     },
     rowToCardConfig: {
       render: (props: CardRenderProps) => (
-        <ExpensesComparisonRowCard row={{ cells: props.cells ?? [] }} expandable={!!props.cells?.[0].rowIndex} />
+        <ExpensesComparisonRowCard
+          row={{ cells: props.cells ?? [] }}
+          hasOffChainData={true}
+          expandable={!!props.cells?.[0].rowIndex}
+        />
       ),
       ...(isTotal ? { type: 'total' } : {}),
     },
@@ -73,6 +80,62 @@ export const buildRow = (
     ],
   } as RowProps);
 
+export const buildRowWithoutOffChain = (
+  values: [string, string, string, string],
+  isCurrentMonth = false,
+  isTotal = false
+): RowProps =>
+  ({
+    ...(isCurrentMonth ? { render: RenderCurrentMonthRow } : {}),
+    cellPadding: {
+      table_834: isTotal ? '17px 8px 18.5px' : '18.5px 8px',
+      desktop_1194: '17.4px 16px',
+    },
+    rowToCardConfig: {
+      render: (props: CardRenderProps) => (
+        <ExpensesComparisonRowCard
+          row={{ cells: props.cells ?? [] }}
+          hasOffChainData={false}
+          expandable={!!props.cells?.[0].rowIndex}
+        />
+      ),
+      ...(isTotal ? { type: 'total' } : {}),
+    },
+    ...(isTotal
+      ? {
+          extraProps: {
+            isBold: true,
+          },
+          border: {
+            top: true,
+          },
+        }
+      : {}),
+    cells: [
+      {
+        value: values[0],
+        defaultRenderer: 'boldText',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[0],
+        isCardHeader: true,
+      },
+      {
+        value: values[1],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[1],
+      },
+      {
+        value: values[2],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[3],
+      },
+      {
+        value: values[3],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[4],
+      },
+    ],
+  } as RowProps);
+
 const useAccountsSnapshot = (snapshot: Snapshots) => {
   const { isLight } = useThemeContext();
 
@@ -87,47 +150,88 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
   const endDate = snapshot.end ?? undefined;
 
   // root account
-  const rootAccount = snapshot.snapshotAccount.find(
-    (account) => account.groupAccountId === null && account.upstreamAccountId === null
+  const rootAccount = useMemo(
+    () =>
+      snapshot.snapshotAccount.find((account) => account.groupAccountId === null && account.upstreamAccountId === null),
+    [snapshot.snapshotAccount]
   );
   if (!rootAccount) throw new Error('Maker Protocol Wallet not found');
 
   // main account (MakerDAO Funding Overview section)
-  const mainAccount = snapshot.snapshotAccount.find(
-    (account) => account.groupAccountId === rootAccount.id && account.upstreamAccountId === null
+  const mainAccount = useMemo(
+    () =>
+      snapshot.snapshotAccount.find(
+        (account) => account.groupAccountId === rootAccount.id && account.upstreamAccountId === null
+      ),
+    [rootAccount?.id, snapshot.snapshotAccount]
   );
   if (!mainAccount) throw new Error('Maker Protocol Wallet not found');
-  const rootBalance = rootAccount.snapshotAccountBalance.find((balance) => balance.token === selectedToken);
+  const rootBalance = useMemo(
+    () => rootAccount.snapshotAccountBalance.find((balance) => balance.token === selectedToken),
+    [rootAccount?.snapshotAccountBalance, selectedToken]
+  );
 
   // transaction history (MakerDAO Funding Overview section)
-  const transactionHistory = mainAccount.snapshotAccountTransaction
-    .filter((transaction) => transaction.token === selectedToken)
-    .sort(transactionSort);
+  const transactionHistory = useMemo(
+    () =>
+      mainAccount.snapshotAccountTransaction
+        .filter((transaction) => transaction.token === selectedToken)
+        .sort(transactionSort),
+    [mainAccount?.snapshotAccountTransaction, selectedToken]
+  );
 
   // Total Core Unit Reserves section
-  const cuReservesAccount = snapshot.snapshotAccount.find(
-    (account) => account.groupAccountId === rootAccount.id && account.upstreamAccountId !== null
+  const cuReservesAccount = useMemo(
+    () =>
+      snapshot.snapshotAccount.find(
+        (account) => account.groupAccountId === rootAccount.id && account.upstreamAccountId !== null
+      ),
+    [rootAccount?.id, snapshot?.snapshotAccount]
   );
-  const cuReservesBalances = cuReservesAccount?.snapshotAccountBalance?.filter(
-    (balance) => balance.token === selectedToken
+  const cuReservesBalances = useMemo(
+    () => cuReservesAccount?.snapshotAccountBalance?.filter((balance) => balance.token === selectedToken),
+    [cuReservesAccount?.snapshotAccountBalance, selectedToken]
   );
+
   // balance with or without the off-chain data
-  const cuReservesBalance =
-    (cuReservesBalances?.length ?? 0) > 1
-      ? cuReservesBalances?.find((account) => account.includesOffChain === includeOffChain)
-      : cuReservesBalances?.[0];
+  const cuReservesBalance = useMemo(
+    () =>
+      (cuReservesBalances?.length ?? 0) > 1
+        ? cuReservesBalances?.find((account) => account.includesOffChain === includeOffChain)
+        : cuReservesBalances?.[0],
+    [cuReservesBalances, includeOffChain]
+  );
 
-  const onChainData = getReserveAccounts(snapshot, false, cuReservesAccount?.id, mainAccount.id, selectedToken);
+  const onChainData = useMemo(
+    () => getReserveAccounts(snapshot, false, cuReservesAccount?.id, mainAccount.id, selectedToken),
+    [cuReservesAccount?.id, mainAccount.id, selectedToken, snapshot]
+  );
 
-  const offChainData = getReserveAccounts(snapshot, true, cuReservesAccount?.id, mainAccount.id, selectedToken);
+  const offChainData = useMemo(
+    () => getReserveAccounts(snapshot, true, cuReservesAccount?.id, mainAccount.id, selectedToken),
+    [cuReservesAccount?.id, mainAccount?.id, selectedToken, snapshot]
+  );
+
+  const hasOffChainData = offChainData.length > 0;
 
   // mocked data for the "Reported Expenses Comparison" table
-  const expensesComparisonRows = [
-    buildRow(['MAY-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%', '221,504.00 DAI', '0.00%'], true, false),
-    buildRow(['APR-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%', '171,500,00 DAI', '0.00%'], false, false),
-    buildRow(['MAR-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%', '288,300.00 DAI', '-0.07%'], false, false),
-    buildRow(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%', '681,304.25 DAI', '-0.03%'], false, true),
-  ] as RowProps[];
+  const expensesComparisonRows = useMemo(() => {
+    if (hasOffChainData) {
+      return [
+        buildRow(['MAY-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%', '221,504.00 DAI', '0.00%'], true, false),
+        buildRow(['APR-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%', '171,500,00 DAI', '0.00%'], false, false),
+        buildRow(['MAR-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%', '288,300.00 DAI', '-0.07%'], false, false),
+        buildRow(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%', '681,304.25 DAI', '-0.03%'], false, true),
+      ] as RowProps[];
+    } else {
+      return [
+        buildRowWithoutOffChain(['MAY-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%'], true, false),
+        buildRowWithoutOffChain(['APR-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%'], false, false),
+        buildRowWithoutOffChain(['MAR-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%'], false, false),
+        buildRowWithoutOffChain(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%'], false, true),
+      ] as RowProps[];
+    }
+  }, [hasOffChainData]);
 
   return {
     isLight,
@@ -141,6 +245,7 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
     cuReservesBalance,
     onChainData,
     offChainData,
+    hasOffChainData,
   };
 };
 


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
A new version of the table is sown in the Expense comparison section when there are no off-chain data, this change includes the mobile version of the table in cards too. The performance of the Snapshot account page was improved by memorizing the high CPU-demanding operations. 

# What solved
- [X] Should show a compacted version of the expense comparison section when there are no off-chain data