### PR TITLE
[SES-268] Integrate the expense comparison section with the API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "actuals",
         "Blockie",
         "Blockies",
+        "deepmerge",
         "Formik",
         "gtag",
         "jhon",

--- a/src/core/models/dto/snapshotAccountDTO.ts
+++ b/src/core/models/dto/snapshotAccountDTO.ts
@@ -4,10 +4,9 @@ export type AccountType = 'singular' | 'group';
 
 export interface SnapshotFilter {
   id?: string;
-  start?: string;
-  end?: string;
   ownerType?: string;
   ownerId?: string;
+  period?: string;
 }
 
 export interface SnapshotAccountTransaction {
@@ -43,13 +42,32 @@ export interface SnapshotAccount {
   snapshotAccountBalance: SnapshotAccountBalance[];
 }
 
+export interface ActualsComparisonNetExpensesItem {
+  amount: number;
+  difference: number;
+}
+
+export interface ActualsComparisonNetExpenses {
+  onChainOnly: ActualsComparisonNetExpensesItem;
+  offChainIncluded: ActualsComparisonNetExpensesItem;
+}
+
+export interface ActualsComparison {
+  month: string;
+  currency: Token;
+  reportedActuals: number;
+  netExpenses: ActualsComparisonNetExpenses;
+}
+
 export interface Snapshots {
   id: string;
+  period: string;
   start: string | null;
   end: string | null;
   ownerType: string;
   ownerId: string;
   snapshotAccount: SnapshotAccount[];
+  actualsComparison: ActualsComparison[];
 }
 
 export interface UIReservesData extends SnapshotAccount {

--- a/src/stories/components/SESTooltip/SESTooltip.stories.tsx
+++ b/src/stories/components/SESTooltip/SESTooltip.stories.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { tooltipClasses } from '@mui/material/Tooltip';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import React from 'react';
-import CustomTooltip from './CustomTooltip';
+import SESTooltip from './SESTooltip';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 const ALIGNMENTS = [
@@ -21,8 +21,8 @@ const ALIGNMENTS = [
 ];
 
 export default {
-  title: 'Components/CustomTooltip',
-  component: CustomTooltip,
+  title: 'Components/General/SESTooltip',
+  component: SESTooltip,
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -35,22 +35,22 @@ export default {
       defaultValue: 'bottom-start',
     },
   },
-} as ComponentMeta<typeof CustomTooltip>;
+} as ComponentMeta<typeof SESTooltip>;
 
-const getCustomBtnTemplate: (btnText?: string) => ComponentStory<typeof CustomTooltip> =
+const getCustomBtnTemplate: (btnText?: string) => ComponentStory<typeof SESTooltip> =
   (btnText = 'Hover me') =>
   ({ ...args }) =>
     (
       <WideContainer>
-        <CustomTooltip {...args} content={<>Custom content here.</>}>
+        <SESTooltip {...args} content={<>Custom content here.</>}>
           <button>{btnText}</button>
-        </CustomTooltip>
+        </SESTooltip>
       </WideContainer>
     );
 
-const VariablePlacementTemplate: ComponentStory<typeof CustomTooltip> = ({ placement, ...args }) => (
+const VariablePlacementTemplate: ComponentStory<typeof SESTooltip> = ({ placement, ...args }) => (
   <CenteredContent>
-    <CustomTooltip
+    <SESTooltip
       placement={placement}
       {...args}
       disableInteractive
@@ -63,11 +63,11 @@ const VariablePlacementTemplate: ComponentStory<typeof CustomTooltip> = ({ place
       }
     >
       <FixedWidthButton>{placement as string}</FixedWidthButton>
-    </CustomTooltip>
+    </SESTooltip>
   </CenteredContent>
 );
 
-const BoundariesTemplate: ComponentStory<typeof CustomTooltip> = ({ placement, ...args }) => (
+const BoundariesTemplate: ComponentStory<typeof SESTooltip> = ({ placement, ...args }) => (
   <OverflownContainer
     ref={(node: HTMLElement | null) => {
       if (node) {
@@ -79,7 +79,7 @@ const BoundariesTemplate: ComponentStory<typeof CustomTooltip> = ({ placement, .
       }
     }}
   >
-    <CustomTooltip
+    <SESTooltip
       open
       placement={placement}
       {...args}
@@ -92,11 +92,11 @@ const BoundariesTemplate: ComponentStory<typeof CustomTooltip> = ({ placement, .
       }
     >
       <button>{placement}</button>
-    </CustomTooltip>
+    </SESTooltip>
   </OverflownContainer>
 );
 
-const CustomStyledTemplate: ComponentStory<typeof CustomTooltip> = ({ placement, ...args }) => (
+const CustomStyledTemplate: ComponentStory<typeof SESTooltip> = ({ placement, ...args }) => (
   <CenteredContent>
     <StyledTooltip
       placement={placement}
@@ -178,7 +178,7 @@ WithFallbackPlacements.args = {
   fallbackPlacements: ['bottom', 'bottom-end', 'top'],
 };
 
-const StyledTooltip = styled(CustomTooltip)(() => ({
+const StyledTooltip = styled(SESTooltip)(() => ({
   backgroundColor: 'red',
   color: 'white',
 

--- a/src/stories/components/SESTooltip/SESTooltip.tsx
+++ b/src/stories/components/SESTooltip/SESTooltip.tsx
@@ -5,14 +5,14 @@ import merge from 'deepmerge';
 import React, { useMemo } from 'react';
 import type { TooltipProps } from '@mui/material';
 
-export interface CustomTooltipProps extends Omit<TooltipProps, 'title'> {
+export interface SESTooltipProps extends Omit<TooltipProps, 'title'> {
   content: NonNullable<React.ReactNode>;
   enableClickListener?: boolean;
   borderColor?: React.CSSProperties['color'];
   fallbackPlacements?: TooltipProps['placement'][];
 }
 
-export default function CustomTooltip({
+const SESTooltip: React.FC<SESTooltipProps> = ({
   content,
   children,
   enableClickListener,
@@ -20,13 +20,13 @@ export default function CustomTooltip({
   className,
   fallbackPlacements,
   ...props
-}: CustomTooltipProps) {
+}) => {
   const { isLight } = useThemeContext();
   const borderColor = borderColorProp || (isLight === false ? '#231536' : '#D4D9E1');
 
   const [controlledOpen, setControlledOpen] = React.useState(props.open ?? enableClickListener ? false : undefined);
 
-  const defaultProps = useMemo<Partial<CustomTooltipProps>>(
+  const defaultProps = useMemo<Partial<SESTooltipProps>>(
     () => ({
       placement: 'bottom-end',
       open: controlledOpen,
@@ -76,7 +76,9 @@ export default function CustomTooltip({
         : children}
     </Tooltip>
   );
-}
+};
+
+export default SESTooltip;
 
 const arrowProps = (borderColor: React.CSSProperties['color'], isLight = true) => ({
   // using sx to access pseudo-elements

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -24,6 +24,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
     onChainData,
     offChainData,
     hasOffChainData,
+    hasActualsComparison,
   } = useAccountsSnapshot(snapshot);
 
   return (
@@ -45,7 +46,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
         onChainData={onChainData}
         offChainData={offChainData}
       />
-      <ExpensesComparison rows={expensesComparisonRows} hasOffChainData={hasOffChainData} />
+      {hasActualsComparison && <ExpensesComparison rows={expensesComparisonRows} hasOffChainData={hasOffChainData} />}
     </Wrapper>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
@@ -17,7 +17,7 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
   currentMonth,
   ownerId,
 }) => {
-  const { isLoading, snapshot } = useAccountsSnapshotTab(ownerId);
+  const { isLoading, snapshot } = useAccountsSnapshotTab(ownerId, currentMonth);
 
   return isLoading ? (
     // TODO: implement a fancy loading state
@@ -30,20 +30,18 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
     >
       loading...
     </Box>
+  ) : snapshot ? (
+    <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} />
   ) : (
-    <AccountsSnapshot
-      snapshot={
-        snapshot ?? {
-          id: '1',
-          start: null,
-          end: null,
-          ownerType: 'CoreUnit',
-          ownerId: '1',
-          snapshotAccount: [],
-        }
-      }
-      snapshotOwner={snapshotOwner}
-    />
+    <Box
+      sx={{
+        textAlign: 'center',
+        mt: 2,
+        mb: 5,
+      }}
+    >
+      There is no snapshot data for this month
+    </Box>
   );
 };
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
@@ -1,5 +1,5 @@
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
-import { buildRow, buildRowWithoutOffChain } from '../../useAccountsSnapshot';
+import { buildRow, buildRowWithoutOffChain } from '../../utils/expenseComparisonUtils';
 import ExpensesComparison from './ExpensesComparison';
 import type { RowProps } from '@ses/components/AdvanceTable/types';
 import type { ComponentMeta } from '@storybook/react';

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/useAccountsSnapshotTab.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/useAccountsSnapshotTab.ts
@@ -1,20 +1,21 @@
 import { useEffect, useState } from 'react';
 import { fetchAccountsSnapshot } from '../api/queries';
 import type { Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
+import type { DateTime } from 'luxon';
 
-const useAccountsSnapshotTab = (ownerId: string) => {
+const useAccountsSnapshotTab = (ownerId: string, currentMonth: DateTime) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [snapshot, setSnapshot] = useState<Snapshots>();
 
   useEffect(() => {
     const fetchFn = async () => {
       setIsLoading(true);
-      const _snapshot = (await fetchAccountsSnapshot('CoreUnitDraft', ownerId))[0];
+      const _snapshot = (await fetchAccountsSnapshot('CoreUnit', ownerId, currentMonth))[0];
       setSnapshot(_snapshot);
       setIsLoading(false);
     };
     fetchFn();
-  }, [ownerId]);
+  }, [currentMonth, ownerId]);
 
   return {
     isLoading,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
@@ -1,0 +1,255 @@
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import { DateTime } from 'luxon';
+import ExpensesComparisonRowCard from '../components/Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCard';
+import {
+  EXPENSES_COMPARISON_TABLE_HEADER,
+  EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN,
+} from '../components/ExpensesComparison/headers';
+import type { CardRenderProps, RowProps } from '@ses/components/AdvanceTable/types';
+import type { ActualsComparison, Token } from '@ses/core/models/dto/snapshotAccountDTO';
+
+const RenderCurrentMonthRow: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { isLight } = useThemeContext();
+  return <tr style={{ background: isLight ? 'rgba(236, 239, 249, 0.5)' : '#283341' }}>{children}</tr>;
+};
+
+export const buildRow = (
+  values: [string, string, string, string, string, string],
+  isCurrentMonth = false,
+  isTotal = false
+): RowProps =>
+  ({
+    ...(isCurrentMonth ? { render: RenderCurrentMonthRow } : {}),
+    cellPadding: {
+      table_834: isTotal ? '17px 8px 18.5px' : '18.5px 8px',
+      desktop_1194: '17.4px 16px',
+    },
+    rowToCardConfig: {
+      render: (props: CardRenderProps) => (
+        <ExpensesComparisonRowCard
+          row={{ cells: props.cells ?? [] }}
+          hasOffChainData={true}
+          expandable={!!props.cells?.[0].rowIndex}
+        />
+      ),
+      ...(isTotal ? { type: 'total' } : {}),
+    },
+    ...(isTotal
+      ? {
+          extraProps: {
+            isBold: true,
+          },
+          border: {
+            top: true,
+          },
+        }
+      : {}),
+    cells: [
+      {
+        value: values[0],
+        defaultRenderer: 'boldText',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[0],
+        isCardHeader: true,
+      },
+      {
+        value: values[1],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
+      },
+      {
+        value: values[2],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
+      },
+      {
+        value: values[3],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
+      },
+      {
+        value: values[4],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
+      },
+      {
+        value: values[5],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
+      },
+    ],
+  } as RowProps);
+
+export const buildRowWithoutOffChain = (
+  values: [string, string, string, string],
+  isCurrentMonth = false,
+  isTotal = false
+): RowProps =>
+  ({
+    ...(isCurrentMonth ? { render: RenderCurrentMonthRow } : {}),
+    cellPadding: {
+      table_834: isTotal ? '17px 8px 18.5px' : '18.5px 8px',
+      desktop_1194: '17.4px 16px',
+    },
+    rowToCardConfig: {
+      render: (props: CardRenderProps) => (
+        <ExpensesComparisonRowCard
+          row={{ cells: props.cells ?? [] }}
+          hasOffChainData={false}
+          expandable={!!props.cells?.[0].rowIndex}
+        />
+      ),
+      ...(isTotal ? { type: 'total' } : {}),
+    },
+    ...(isTotal
+      ? {
+          extraProps: {
+            isBold: true,
+          },
+          border: {
+            top: true,
+          },
+        }
+      : {}),
+    cells: [
+      {
+        value: values[0],
+        defaultRenderer: 'boldText',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[0],
+        isCardHeader: true,
+      },
+      {
+        value: values[1],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[1],
+      },
+      {
+        value: values[2],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[3],
+      },
+      {
+        value: values[3],
+        defaultRenderer: 'number',
+        inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[4],
+      },
+    ],
+  } as RowProps);
+
+export const formatExpenseMonth = (month: string): string =>
+  DateTime.fromFormat(month, 'yyyy/MM').toFormat('MMM-yyyy').toLocaleUpperCase();
+
+export const formatExpenseWithCurrency = (value: number, currency: Token): string => {
+  const formatted = `${usLocalizedNumber(value, 2)} ${currency}`;
+  return formatted;
+};
+
+export const formatExpenseDifference = (value: number): string => {
+  const formatted = `${usLocalizedNumber(value, 2)}%`;
+  return formatted;
+};
+
+export const getTotals = (values: ActualsComparison[]): ActualsComparison =>
+  values.reduce(
+    (acc, curr) => {
+      acc.reportedActuals += curr.reportedActuals;
+      acc.netExpenses.onChainOnly.amount += curr.netExpenses.onChainOnly.amount;
+      acc.netExpenses.onChainOnly.difference += curr.netExpenses.onChainOnly.difference;
+      acc.netExpenses.offChainIncluded.amount += curr.netExpenses.offChainIncluded.amount;
+      acc.netExpenses.offChainIncluded.difference += curr.netExpenses.offChainIncluded.difference;
+
+      return acc;
+    },
+    {
+      reportedActuals: 0,
+      netExpenses: {
+        onChainOnly: {
+          amount: 0,
+          difference: 0,
+        },
+        offChainIncluded: {
+          amount: 0,
+          difference: 0,
+        },
+      },
+    } as ActualsComparison
+  );
+
+export const buildExpensesComparisonRows = (
+  values: ActualsComparison[],
+  currency: Token,
+  currentPeriod: string
+): RowProps[] => {
+  const hasOffChainData = values.some(
+    (value) => value.netExpenses.offChainIncluded.amount || value.netExpenses.offChainIncluded.difference
+  );
+
+  const rows: RowProps[] = [];
+  if (hasOffChainData) {
+    values.forEach((comparison) => {
+      const row = buildRow(
+        [
+          formatExpenseMonth(comparison.month),
+          formatExpenseWithCurrency(comparison.reportedActuals, currency),
+          formatExpenseWithCurrency(comparison.netExpenses.onChainOnly.amount, currency),
+          formatExpenseDifference(comparison.netExpenses.onChainOnly.difference),
+          formatExpenseWithCurrency(comparison.netExpenses.offChainIncluded.amount, currency),
+          formatExpenseDifference(comparison.netExpenses.offChainIncluded.difference),
+        ],
+        comparison.month === currentPeriod,
+        false
+      );
+      rows.push(row);
+    });
+
+    if (values.length > 1) {
+      const totals = getTotals(values);
+      rows.push(
+        buildRow(
+          [
+            'Totals',
+            formatExpenseWithCurrency(totals.reportedActuals, currency),
+            formatExpenseWithCurrency(totals.netExpenses.onChainOnly.amount, currency),
+            formatExpenseDifference(totals.netExpenses.onChainOnly.difference),
+            formatExpenseWithCurrency(totals.netExpenses.offChainIncluded.amount, currency),
+            formatExpenseDifference(totals.netExpenses.offChainIncluded.difference),
+          ],
+          false,
+          true
+        )
+      );
+    }
+  } else {
+    values.forEach((comparison) => {
+      const row = buildRowWithoutOffChain(
+        [
+          formatExpenseMonth(comparison.month),
+          formatExpenseWithCurrency(comparison.reportedActuals, currency),
+          formatExpenseWithCurrency(comparison.netExpenses.onChainOnly.amount, currency),
+          formatExpenseDifference(comparison.netExpenses.onChainOnly.difference),
+        ],
+        comparison.month === currentPeriod,
+        false
+      );
+      rows.push(row);
+    });
+
+    if (values.length > 1) {
+      const totals = getTotals(values);
+      rows.push(
+        buildRowWithoutOffChain(
+          [
+            'Totals',
+            formatExpenseWithCurrency(totals.reportedActuals, currency),
+            formatExpenseWithCurrency(totals.netExpenses.onChainOnly.amount, currency),
+            formatExpenseDifference(totals.netExpenses.onChainOnly.difference),
+          ],
+          false,
+          true
+        )
+      );
+    }
+  }
+
+  return rows;
+};


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Integrate the Expense comparison section with the API
Renamed the new Tooltip component

# What solved
- [X] Should display the correct data coming from the API in the Reported Expenses Comparison table/cards
- [X] Should hide the totals row if there is only one month in reported comparison table