### PR TITLE
[SES-268] Created Expenses Comparison Skeleton

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCardSkeleton.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCardSkeleton.tsx
@@ -1,0 +1,184 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import React from 'react';
+import { BaseSkeleton } from '../../BaseSkeleton/BaseSkeleton';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+const ExpensesComparisonRowCardSkeleton: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <CardsContainer>
+      <Card isLight={isLight}>
+        <DateSkeleton isLight={isLight} />
+        <PairContainer>
+          <ReportedLabelSkeleton isLight={isLight} />
+          <ReportedValueSkeleton isLight={isLight} />
+        </PairContainer>
+        <NetExpenseLabelSkeleton isLight={isLight} />
+
+        <PairContainer>
+          <LabelContainer>
+            <OnchainLabelSkeleton isLight={isLight} />
+            <IconSkeleton isLight={isLight} variant="circular" />
+          </LabelContainer>
+          <OnchainValueSkeleton isLight={isLight} />
+        </PairContainer>
+        <PairContainer style={{ marginTop: 22 }}>
+          <OnchainDifferenceLabelSkeleton isLight={isLight} />
+          <OnchainDifferenceValueSkeleton isLight={isLight} />
+        </PairContainer>
+
+        <Divider isLight={isLight} />
+
+        <PairContainer>
+          <LabelContainer>
+            <OffChainLabelSkeleton isLight={isLight} />
+            <IconSkeleton isLight={isLight} variant="circular" />
+          </LabelContainer>
+          <OffChainValueSkeleton isLight={isLight} />
+        </PairContainer>
+        <PairContainer style={{ marginTop: 22 }}>
+          <OffChainDifferenceLabelSkeleton isLight={isLight} />
+          <OffChainDifferenceValueSkeleton isLight={isLight} />
+        </PairContainer>
+      </Card>
+
+      <CollapsedCard isLight={isLight}>
+        <CollapsedCardTextSkeleton isLight={isLight} width={68} />
+      </CollapsedCard>
+      <CollapsedCard isLight={isLight}>
+        <CollapsedCardTextSkeleton isLight={isLight} width={71} />
+      </CollapsedCard>
+      <TotalsCard isLight={isLight}>
+        <CollapsedCardTextSkeleton isLight={isLight} width={103} height={12.25} />
+      </TotalsCard>
+    </CardsContainer>
+  );
+};
+
+export default ExpensesComparisonRowCardSkeleton;
+
+const CardsContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  marginTop: 20.75,
+});
+
+const BaseCard = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  borderRadius: 6,
+  background: isLight ? '#FFFFFF' : 'red',
+  boxShadow: isLight
+    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
+    : '0px 1px 3px 0px red, 0px 20px 40px 0px red',
+}));
+
+const Card = styled(BaseCard)({
+  padding: '16px 16px 28.75px 16px',
+});
+
+const CollapsedCard = styled(BaseCard)({
+  padding: '8.5px 8px 13px 16px',
+});
+
+const TotalsCard = styled(BaseCard)({
+  padding: '8px 8px 12.75px 16px',
+});
+
+const CollapsedCardTextSkeleton = styled(BaseSkeleton)({
+  height: 10.5,
+});
+
+const DateSkeleton = styled(BaseSkeleton)({
+  width: 70,
+  height: 10.5,
+  marginBottom: 28.5,
+});
+
+const PairContainer = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+const ReportedLabelSkeleton = styled(BaseSkeleton)({
+  width: 139,
+  height: 10.5,
+});
+
+const ReportedValueSkeleton = styled(BaseSkeleton)({
+  width: 116,
+  height: 12.25,
+});
+
+const NetExpenseLabelSkeleton = styled(BaseSkeleton)({
+  width: 177,
+  height: 12.25,
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  marginTop: 20.75,
+  marginBottom: 33.75,
+});
+
+const OnchainLabelSkeleton = styled(BaseSkeleton)({
+  width: 111,
+  height: 10.5,
+});
+
+const OnchainValueSkeleton = styled(BaseSkeleton)({
+  width: 116,
+  height: 12.25,
+});
+
+const OnchainDifferenceLabelSkeleton = styled(BaseSkeleton)({
+  width: 83,
+  height: 10.5,
+});
+
+const OnchainDifferenceValueSkeleton = styled(BaseSkeleton)({
+  width: 47,
+  height: 12.25,
+});
+
+const LabelContainer = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8.78,
+});
+
+const IconSkeleton = styled(BaseSkeleton)({
+  width: 15,
+  height: 15,
+});
+
+const Divider = styled.div<WithIsLight>(({ isLight }) => ({
+  width: 'calc(100% + 16)',
+  marginLeft: -8,
+  marginRight: -8,
+  marginTop: 20.75,
+  marginBottom: 21,
+  borderTop: `1px solid ${isLight ? '#ECF1F3' : 'red'}`,
+}));
+
+const OffChainLabelSkeleton = styled(BaseSkeleton)({
+  width: 156,
+  height: 10.5,
+});
+
+const OffChainValueSkeleton = styled(BaseSkeleton)({
+  width: 116,
+  height: 12.25,
+});
+
+const OffChainDifferenceLabelSkeleton = styled(BaseSkeleton)({
+  width: 83,
+  height: 10.5,
+});
+
+const OffChainDifferenceValueSkeleton = styled(BaseSkeleton)({
+  width: 53,
+  height: 12.25,
+});

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ComparisonTableSkeleton.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ComparisonTableSkeleton.tsx
@@ -1,0 +1,382 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import { BaseSkeleton } from '../BaseSkeleton/BaseSkeleton';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+const ComparisonTableSkeleton: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Table isLight={isLight}>
+      <thead>
+        <tr>
+          <ReportedHeaderTH rowSpan={2} colSpan={2}>
+            <ReportedHeaderSkeleton isLight={isLight} />
+          </ReportedHeaderTH>
+          <NetHeaderTH colSpan={4}>
+            <NetHeaderSkeleton isLight={isLight} />
+          </NetHeaderTH>
+        </tr>
+        <tr>
+          <IconHeaderTH>
+            <ItemWithIconContainer>
+              <OnChainHeaderSkeleton isLight={isLight} />
+              <IconSkeleton isLight={isLight} variant="circular" />
+            </ItemWithIconContainer>
+          </IconHeaderTH>
+          <DifferenceHeaderTH>
+            <DifferenceHeaderSkeleton isLight={isLight} />
+          </DifferenceHeaderTH>
+          <IconHeaderTH>
+            <ItemWithIconContainer>
+              <OffChainHeaderSkeleton isLight={isLight} />
+              <IconSkeleton isLight={isLight} variant="circular" />
+            </ItemWithIconContainer>
+          </IconHeaderTH>
+          <DifferenceHeaderTH>
+            <DifferenceHeaderSkeleton isLight={isLight} />
+          </DifferenceHeaderTH>
+        </tr>
+      </thead>
+      <tbody>
+        <CurrentMonthRow isLight={isLight}>
+          <Col1>
+            <MonthLabelSkeleton isLight={isLight} />
+          </Col1>
+          <Col2>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col2>
+          <Col3>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col3>
+          <Col4>
+            <DifferenceValueSmallSkeleton isLight={isLight} />
+          </Col4>
+          <Col5>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col5>
+          <Col6>
+            <DifferenceValueSmallSkeleton isLight={isLight} />
+          </Col6>
+        </CurrentMonthRow>
+        <tr>
+          <Col1>
+            <MonthLabelSkeleton isLight={isLight} />
+          </Col1>
+          <Col2>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col2>
+          <Col3>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col3>
+          <Col4>
+            <DifferenceValueLargeSkeleton isLight={isLight} />
+          </Col4>
+          <Col5>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col5>
+          <Col6>
+            <DifferenceValueSmallSkeleton isLight={isLight} />
+          </Col6>
+        </tr>
+        <tr>
+          <Col1>
+            <MonthLabelSkeleton isLight={isLight} />
+          </Col1>
+          <Col2>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col2>
+          <Col3>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col3>
+          <Col4>
+            <DifferenceValueLargeSkeleton isLight={isLight} />
+          </Col4>
+          <Col5>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col5>
+          <Col6>
+            <DifferenceValueLargeSkeleton isLight={isLight} />
+          </Col6>
+        </tr>
+        <tr>
+          <Col1>
+            <MonthLabelSkeleton isLight={isLight} />
+          </Col1>
+          <Col2>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col2>
+          <Col3>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col3>
+          <Col4>
+            <DifferenceValueSmallSkeleton isLight={isLight} />
+          </Col4>
+          <Col5>
+            <BigNumberValueSkeleton isLight={isLight} />
+          </Col5>
+          <Col6>
+            <DifferenceValueLargeSkeleton isLight={isLight} />
+          </Col6>
+        </tr>
+      </tbody>
+    </Table>
+  );
+};
+
+export default ComparisonTableSkeleton;
+
+const Table = styled.table<WithIsLight>(({ isLight }) => ({
+  marginTop: 32,
+  borderRadius: 6,
+  backgroundColor: isLight ? '#ffffff' : 'red',
+  boxShadow: isLight
+    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px -40px rgba(219, 227, 237, 0.40)'
+    : '0px 1px 3px 0px red, 0px 20px 40px -40px red',
+  width: '100%',
+  borderCollapse: 'collapse',
+  borderSpacing: 0,
+  border: 'none',
+  padding: 0,
+}));
+
+const ReportedHeaderTH = styled.th({
+  paddingRight: 16,
+});
+
+const ReportedHeaderSkeleton = styled(BaseSkeleton)({
+  width: 139,
+  height: 10.5,
+  marginLeft: 'auto',
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: 227,
+    height: 16,
+  },
+});
+
+const NetHeaderTH = styled.th({
+  paddingTop: 16,
+  paddingBottom: 22.75,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    paddingBottom: 21,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    paddingTop: 11,
+    paddingBottom: 16,
+  },
+});
+
+const NetHeaderSkeleton = styled(BaseSkeleton)({
+  width: 179,
+  height: 12.25,
+  marginLeft: 'auto',
+  marginRight: 'auto',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: 205,
+    height: 14,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: 405,
+    height: 24,
+  },
+});
+
+const IconHeaderTH = styled.th({
+  padding: '24px 12.5px 24px 6px',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '24px 15.5px 24px 6px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    padding: '22px 15.5px 26px 6px',
+  },
+});
+
+const ItemWithIconContainer = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  gap: 6.5,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    gap: 12.5,
+  },
+});
+
+const OnChainHeaderSkeleton = styled(BaseSkeleton)({
+  width: 111,
+  height: 10.5,
+});
+
+const OffChainHeaderSkeleton = styled(BaseSkeleton)({
+  width: 156,
+  height: 10.5,
+});
+
+const IconSkeleton = styled(BaseSkeleton)({
+  width: 15,
+  height: 15,
+});
+
+const DifferenceHeaderTH = styled.th({
+  padding: '26px 8px 26.5px 0',
+  display: 'flex',
+  justifyContent: 'flex-end',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '26px 16px 26.5px 0',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    padding: '24px 16px 28.5px 0',
+  },
+});
+
+const DifferenceHeaderSkeleton = styled(BaseSkeleton)({
+  width: 83,
+  height: 10.5,
+});
+
+const CurrentMonthRow = styled.tr<WithIsLight>(({ isLight }) => ({
+  background: isLight ? 'rgba(236, 239, 249, 0.30)' : 'red',
+}));
+
+const MonthLabelSkeleton = styled(BaseSkeleton)({
+  width: 75,
+  height: 12.25,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: 150,
+    height: 14,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: 120,
+  },
+});
+
+const BigNumberValueSkeleton = styled(BaseSkeleton)({
+  width: 111,
+  height: 12.25,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: 127,
+    height: 14,
+  },
+});
+
+const DifferenceValueSmallSkeleton = styled(BaseSkeleton)({
+  width: 44,
+  height: 12.25,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: 50,
+    height: 14,
+  },
+});
+
+const DifferenceValueLargeSkeleton = styled(BaseSkeleton)({
+  width: 51,
+  height: 12.25,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: 58,
+    height: 14,
+  },
+});
+
+const RowCell = styled.td({
+  padding: '18.5px 8px 23.25px 0px',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '17.5px 16px 22.5px 0px',
+  },
+
+  '& > *': {
+    marginLeft: 'auto',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    '&:first-child > *': {
+      marginLeft: 16,
+    },
+  },
+});
+
+const Col1 = styled(RowCell)({
+  minWidth: 91,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    minWidth: 186,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    minWidth: 195,
+  },
+});
+
+const Col2 = styled(RowCell)({
+  minWidth: 142,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    minWidth: 186,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    minWidth: 195,
+  },
+});
+
+const Col3 = styled(RowCell)({
+  minWidth: 151,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    minWidth: 249,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    minWidth: 261,
+  },
+});
+
+const Col4 = styled(RowCell)({
+  minWidth: 92,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    minWidth: 126,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    minWidth: 132,
+  },
+});
+
+const Col5 = styled(RowCell)({
+  minWidth: 200,
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    minWidth: 249,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    minWidth: 261,
+  },
+});
+
+const Col6 = styled(RowCell)({
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    minWidth: 134,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    minWidth: 140,
+  },
+});

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparisonSkeleton.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparisonSkeleton.stories.tsx
@@ -1,0 +1,85 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import ExpensesComparisonSkeleton from './ExpensesComparisonSkeleton';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/CUTransparencyReport/Accounts Snapshot/Expenses Comparison Skeleton',
+  component: ExpensesComparisonSkeleton,
+  parameters: {
+    chromatic: {
+      viewports: [375, 834, 1194, 1280, 1440],
+    },
+  },
+} as ComponentMeta<typeof ExpensesComparisonSkeleton>;
+
+const variantsArgs = [{}];
+
+export const [[LightMode, DarkMode]] = createThemeModeVariants(ExpensesComparisonSkeleton, variantsArgs);
+
+LightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=21718:260728',
+        options: {
+          componentStyle: {
+            width: 343,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      834: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=21718:257320',
+        options: {
+          componentStyle: {
+            width: 770,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1194: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=21718:253800',
+        options: {
+          componentStyle: {
+            width: 1130,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1280: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=21716:254817',
+        options: {
+          componentStyle: {
+            width: 1184,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=21688:249867',
+        options: {
+          componentStyle: {
+            width: 1312,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparisonSkeleton.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparisonSkeleton.tsx
@@ -1,5 +1,91 @@
+import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
+import { BaseSkeleton } from '../BaseSkeleton/BaseSkeleton';
+import ExpensesComparisonRowCardSkeleton from '../Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCardSkeleton';
+import ComparisonTableSkeleton from './ComparisonTableSkeleton';
 
-const ExpensesComparisonSkeleton: React.FC = () => <div>skeleton...</div>;
+const ExpensesComparisonSkeleton: React.FC = () => {
+  const { isLight } = useThemeContext();
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+
+  return (
+    <div>
+      <TitleContainer>
+        <TitleLine1Skeleton isLight={isLight} />
+        <TitleLine2Skeleton isLight={isLight} />
+      </TitleContainer>
+      <SubtitleContainer>
+        <SubtitleLine1Skeleton isLight={isLight} />
+        <SubtitleLine2Skeleton isLight={isLight} />
+        <SubtitleLine3Skeleton isLight={isLight} />
+      </SubtitleContainer>
+
+      {isMobile ? <ExpensesComparisonRowCardSkeleton /> : <ComparisonTableSkeleton />}
+    </div>
+  );
+};
 
 export default ExpensesComparisonSkeleton;
+
+const TitleContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    gap: 11,
+  },
+});
+
+const TitleLine1Skeleton = styled(BaseSkeleton)({
+  maxWidth: 314,
+  height: 18,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    maxWidth: 190,
+    height: 21,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    maxWidth: 248,
+  },
+});
+
+const TitleLine2Skeleton = styled(BaseSkeleton)({
+  maxWidth: 122,
+  height: 17.5,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    maxWidth: 408,
+    height: 14,
+  },
+});
+
+const SubtitleContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 5.25,
+  marginTop: 14.5,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    display: 'none',
+  },
+});
+
+const SubtitleLine1Skeleton = styled(BaseSkeleton)({
+  maxWidth: 236,
+  height: 12.25,
+});
+
+const SubtitleLine2Skeleton = styled(BaseSkeleton)({
+  maxWidth: 210,
+  height: 12.25,
+});
+
+const SubtitleLine3Skeleton = styled(BaseSkeleton)({
+  maxWidth: 200,
+  height: 12.25,
+});


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Added the Reported expenses comparison skeleton to the general Account Snapshot skeleton

# What solved
- [X] Show add a loading state for the account snapshot tab when the content is being loaded