### PR TITLE
[SES-268] Add account snapshot empty state

### DIFF
--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -163,6 +163,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
                   snapshotOwner={`${code} Core Unit`}
                   currentMonth={currentMonth}
                   ownerId={coreUnit.id}
+                  longCode={coreUnit.code}
                 />
               )}
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import React from 'react';
+import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import AccountsSnapshot from './AccountsSnapshot';
 import AccountsSnapshotSkeleton from './AccountsSnapshotSkeleton';
 import useAccountsSnapshotTab from './components/useAccountsSnapshotTab';
@@ -9,12 +10,14 @@ interface AccountsSnapshotTabContainerProps {
   snapshotOwner: string;
   currentMonth: DateTime;
   ownerId: string;
+  longCode: string;
 }
 
 const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> = ({
   snapshotOwner,
   currentMonth,
   ownerId,
+  longCode,
 }) => {
   const { isLoading, snapshot } = useAccountsSnapshotTab(ownerId, currentMonth);
 
@@ -23,14 +26,8 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
   ) : snapshot ? (
     <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} />
   ) : (
-    <Box
-      sx={{
-        textAlign: 'center',
-        mt: 2,
-        mb: 5,
-      }}
-    >
-      There is no snapshot data for this month
+    <Box sx={{ mb: '64px' }}>
+      <TransparencyEmptyTable longCode={longCode} />
     </Box>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/Placeholders/TransparencyEmptyTable.tsx
+++ b/src/stories/containers/TransparencyReport/components/Placeholders/TransparencyEmptyTable.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
 import { LinkButton } from '@ses/components/LinkButton/LinkButton';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { ButtonType } from '@ses/core/enums/buttonTypeEnum';
+import { MAKER_BURN_LINK } from '@ses/core/utils/const';
+import { getShortCode } from '@ses/core/utils/string';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
-import lightTheme from '../../../../../../styles/theme/light';
-import { useThemeContext } from '../../../../../core/context/ThemeContext';
-import { ButtonType } from '../../../../../core/enums/buttonTypeEnum';
-import { MAKER_BURN_LINK } from '../../../../../core/utils/const';
-import { getShortCode } from '../../../../../core/utils/string';
 
 interface Props {
   breakdown?: boolean;


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Add an empty state in the Account Snapshots tab of the Core Unit reporting page when there is no data for the Account snapshots

# What solved
- [X] Should add a "No data" state for the Account Snapshot tab