### PR TITLE
[SES-288] Stabilize primary tabs

### DIFF
--- a/pages/ecosystem-actors/[code]/finances/reports/index.tsx
+++ b/pages/ecosystem-actors/[code]/finances/reports/index.tsx
@@ -2,6 +2,7 @@ import { CURRENT_ENVIRONMENT } from '@ses/config/endpoints';
 import { fetchActors } from '@ses/containers/Actors/api/queries';
 import ActorsTransparencyReportContainer from '@ses/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer';
 import { fetchEcosystemActor } from '@ses/containers/ActorsTransparencyReport/api/queries';
+import { fetchExpenseCategories } from '@ses/containers/FinancesOverview/api/queries';
 import { ActorContext } from '@ses/core/context/ActorContext';
 import { featureFlags } from 'feature-flags/feature-flags';
 import React, { useEffect, useState } from 'react';
@@ -10,6 +11,7 @@ import type { GetServerSideProps, GetServerSidePropsContext, InferGetServerSideP
 const EcosystemActorsTransparencyReportingPage: NextPage = ({
   actor,
   actors,
+  expenseCategories,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const [currentActor, setCurrentActor] = useState(actor);
   useEffect(() => {
@@ -24,7 +26,7 @@ const EcosystemActorsTransparencyReportingPage: NextPage = ({
         setCurrentActor,
       }}
     >
-      <ActorsTransparencyReportContainer actor={currentActor} actors={actors} />
+      <ActorsTransparencyReportContainer actor={currentActor} actors={actors} expenseCategories={expenseCategories} />
     </ActorContext.Provider>
   );
 };
@@ -40,7 +42,11 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
 
   const { query } = context;
   const code = query.code as string;
-  const [actors, actor] = await Promise.all([fetchActors('EcosystemActor'), fetchEcosystemActor(code)]);
+  const [actors, actor, expenseCategories] = await Promise.all([
+    fetchActors('EcosystemActor'),
+    fetchEcosystemActor(code),
+    fetchExpenseCategories(),
+  ]);
 
   if (!actor) {
     return {
@@ -52,6 +58,7 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
     props: {
       actor,
       actors,
+      expenseCategories,
     },
   };
 };

--- a/pages/ecosystem-actors/[code]/finances/reports/index.tsx
+++ b/pages/ecosystem-actors/[code]/finances/reports/index.tsx
@@ -26,7 +26,7 @@ const EcosystemActorsTransparencyReportingPage: NextPage = ({
         setCurrentActor,
       }}
     >
-      <ActorsTransparencyReportContainer actor={currentActor} actors={actors} expenseCategories={expenseCategories} />
+      <ActorsTransparencyReportContainer actor={actor} actors={actors} expenseCategories={expenseCategories} />
     </ActorContext.Provider>
   );
 };

--- a/src/core/businessLogic/coreUnits.ts
+++ b/src/core/businessLogic/coreUnits.ts
@@ -303,7 +303,7 @@ export const getLastMonthWithData = (cu: CoreUnit) => {
 };
 
 export const getLastUpdateForBudgetStatement = (element: WithActivityFeed, budgetStatementId: string) => {
-  const activityFeed = element.activityFeed?.filter(
+  const activityFeed = element?.activityFeed?.filter(
     (af) => Number(af.params.budgetStatementId) === Number(budgetStatementId)
   );
 

--- a/src/core/businessLogic/coreUnits.ts
+++ b/src/core/businessLogic/coreUnits.ts
@@ -6,11 +6,11 @@ import { CuMipStatus } from '../models/interfaces/types';
 import { API_MONTH_FROM_FORMAT, API_MONTH_TO_FORMAT } from '../utils/date';
 import type { LinkModel } from '../../stories/components/CuTableColumnLinks/CuTableColumnLinks';
 import type { CustomChartItemModel } from '../models/customChartItemModel';
-import type { ChangeTrackingEvent } from '../models/interfaces/activity';
 import type { BudgetStatement, BudgetStatementFTEs } from '../models/interfaces/budgetStatement';
 import type { BudgetStatementComment } from '../models/interfaces/budgetStatementComment';
 import type { CoreUnit } from '../models/interfaces/coreUnit';
 import type { CuMip, Mip40, Mip40BudgetPeriod, Mip40Wallet } from '../models/interfaces/cuMip';
+import type { WithActivityFeed } from '../models/interfaces/generics';
 
 export const setCuMipStatusModifiedDate = (mip: CuMip, status: CuMipStatus, date: string) => {
   let index = status.toLowerCase();
@@ -302,10 +302,7 @@ export const getLastMonthWithData = (cu: CoreUnit) => {
   return undefined;
 };
 
-export const getLastUpdateForBudgetStatement = (
-  element: { activityFeed: ChangeTrackingEvent[] },
-  budgetStatementId: string
-) => {
+export const getLastUpdateForBudgetStatement = (element: WithActivityFeed, budgetStatementId: string) => {
   const activityFeed = element.activityFeed?.filter(
     (af) => Number(af.params.budgetStatementId) === Number(budgetStatementId)
   );

--- a/src/core/hooks/useBudgetStatementPager.ts
+++ b/src/core/hooks/useBudgetStatementPager.ts
@@ -5,17 +5,14 @@ import { getCurrentOrLastMonthWithData, getLastMonthWithActualOrForecast } from 
 import { API_MONTH_TO_FORMAT } from '../utils/date';
 import { useUrlAnchor } from './useUrlAnchor';
 import type { BudgetStatement } from '../models/interfaces/budgetStatement';
-
-export interface WithBudget {
-  budgetStatements: BudgetStatement[];
-}
+import type { WithBudgetStatement } from '../models/interfaces/generics';
 
 export interface BudgetStatementPagerOptions {
   onPrevious?: () => void;
   onNext?: () => void;
 }
 
-const useBudgetStatementPager = (element: WithBudget, options?: BudgetStatementPagerOptions) => {
+const useBudgetStatementPager = (element: WithBudgetStatement, options?: BudgetStatementPagerOptions) => {
   const router = useRouter();
   const viewMonthStr = router.query.viewMonth;
   const anchor = useUrlAnchor();

--- a/src/core/hooks/useTransparencyReporting.ts
+++ b/src/core/hooks/useTransparencyReporting.ts
@@ -7,9 +7,9 @@ import { budgetStatementCommentsCollectionId } from '../utils/collectionsIds';
 import { LastVisitHandler } from '../utils/lastVisitHandler';
 import useBudgetStatementComments from './useBudgetStatementComments';
 import useBudgetStatementPager from './useBudgetStatementPager';
-import type { CoreUnitDto } from '../models/dto/coreUnitDTO';
+import type { CoreUnit } from '../models/interfaces/coreUnit';
+import type { WithActivityFeed, WithBudgetStatement } from '../models/interfaces/generics';
 import type { Team } from '../models/interfaces/team';
-import type { WithBudget } from './useBudgetStatementPager';
 
 interface TransparencyReportingOptions<TabIds extends string> {
   commentTabId?: TabIds;
@@ -17,7 +17,7 @@ interface TransparencyReportingOptions<TabIds extends string> {
 }
 
 const useTransparencyReporting = <TabIds extends string>(
-  transparencyElement: Team | CoreUnitDto,
+  transparencyElement: Team | CoreUnit,
   options: TransparencyReportingOptions<TabIds> = {}
 ) => {
   const router = useRouter();
@@ -41,8 +41,7 @@ const useTransparencyReporting = <TabIds extends string>(
 
   // data and functions to navigate between budget statements
   const { currentMonth, currentBudgetStatement, handleNextMonth, handlePreviousMonth, hasNextMonth, hasPreviousMonth } =
-    // TODO: improve the typing here
-    useBudgetStatementPager(transparencyElement as unknown as WithBudget, {
+    useBudgetStatementPager(transparencyElement as WithBudgetStatement, {
       onNext: onPagerChanges,
       onPrevious: onPagerChanges,
     });
@@ -58,11 +57,9 @@ const useTransparencyReporting = <TabIds extends string>(
 
   // get the budget statement last update date
   const lastUpdateForBudgetStatement = useMemo(
-    // TODO: the teams doesn't have the activity feed item
-    // so we need to research what to do in these cases
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    () => getLastUpdateForBudgetStatement(transparencyElement as any, currentBudgetStatement?.id ?? '0'),
-    [currentBudgetStatement, transparencyElement]
+    () =>
+      getLastUpdateForBudgetStatement(currentBudgetStatement as WithActivityFeed, currentBudgetStatement?.id ?? '0'),
+    [currentBudgetStatement]
   );
 
   // should we show the budget status CTA?

--- a/src/core/models/interfaces/generics.ts
+++ b/src/core/models/interfaces/generics.ts
@@ -1,0 +1,10 @@
+import type { ChangeTrackingEvent } from './activity';
+import type { BudgetStatement } from './budgetStatement';
+
+export interface WithBudgetStatement {
+  budgetStatements: BudgetStatement[];
+}
+
+export interface WithActivityFeed {
+  activityFeed: ChangeTrackingEvent[];
+}

--- a/src/stories/containers/ActorsAbout/ActorSummary/ActorTitleAbout.tsx
+++ b/src/stories/containers/ActorsAbout/ActorSummary/ActorTitleAbout.tsx
@@ -1,18 +1,14 @@
 import styled from '@emotion/styled';
 import { Typography, useMediaQuery } from '@mui/material';
-
 import { CircleAvatar } from '@ses/components/CircleAvatar/CircleAvatar';
 import { SocialMediaComponentStyled } from '@ses/containers/Actors/components/ActorItem/ActorItem';
 import ScopeChip from '@ses/containers/Actors/components/ScopeChip/ScopeChip';
 import { ActorsLinkType, getLinksFromRecognizedActors } from '@ses/containers/Actors/utils/utils';
-
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { pascalCaseToNormalString } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
-
 import React from 'react';
 import type { ActorScopeEnum } from '@ses/core/enums/actorScopeEnum';
-
 import type { EcosystemActor } from '@ses/core/models/dto/teamsDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
@@ -44,7 +40,7 @@ export const ActorTitleAbout = ({ actorAbout, showTextDescription, cutTextTooLon
               <ResponsiveTitle>
                 {actorAbout?.name && <TypographyTitle isLight={isLight}>{actorAbout?.name}</TypographyTitle>}
                 <TypographyCategory isLight={isLight}>
-                  {pascalCaseToNormalString(actorAbout?.category[0] || '')}
+                  {pascalCaseToNormalString(actorAbout?.category?.[0] || '')}
                 </TypographyCategory>
               </ResponsiveTitle>
             </ContainerSeparateData>
@@ -62,7 +58,7 @@ export const ActorTitleAbout = ({ actorAbout, showTextDescription, cutTextTooLon
                   </TypographyTitle>
                 )}
                 <TypographyCategory isLight={isLight}>
-                  {pascalCaseToNormalString(actorAbout?.category[0])}
+                  {pascalCaseToNormalString(actorAbout?.category?.[0] || '')}
                 </TypographyCategory>
               </ResponsiveTitle>
             </ContainerSeparateData>

--- a/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
@@ -5,8 +5,10 @@ import { SEOHead } from '@ses/components/SEOHead/SEOHead';
 import Tabs from '@ses/components/Tabs/Tabs';
 import BudgetStatementPager from '@ses/components/TransparencyReporting/BudgetStatementPager/BudgetStatementPager';
 import { siteRoutes } from '@ses/config/routes';
+import { ModalCategoriesProvider } from '@ses/core/context/CategoryModalContext';
 import { CommentActivityContext } from '@ses/core/context/CommentActivityContext';
 import { BudgetStatus } from '@ses/core/models/dto/coreUnitDTO';
+import { ResourceType } from '@ses/core/models/interfaces/types';
 import { toAbsoluteURL } from '@ses/core/utils/urls';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
@@ -20,15 +22,22 @@ import { TransparencyForecast } from '../TransparencyReport/components/Transpare
 import { TransparencyMkrVesting } from '../TransparencyReport/components/TransparencyMkrVesting/TransparencyMkrVesting';
 import { TransparencyTransferRequest } from '../TransparencyReport/components/TransparencyTransferRequest/TransparencyTransferRequest';
 import { TRANSPARENCY_IDS_ENUM } from '../TransparencyReport/useTransparencyReport';
+import TeamHeadLine from './components/TeamHeadlineText/TeamHeadlineText';
 import useActorsTransparencyReport from './useActorsTransparencyReport';
+import type { ExpenseCategory } from '@ses/core/models/dto/expenseCategoriesDTO';
 import type { Team } from '@ses/core/models/interfaces/team';
 
 interface ActorsTransparencyReportContainerProps {
   actors: Partial<Team>[];
   actor: Team;
+  expenseCategories: ExpenseCategory[];
 }
 
-const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContainerProps> = ({ actor, actors }) => {
+const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContainerProps> = ({
+  actor,
+  actors,
+  expenseCategories,
+}) => {
   const {
     isEnabled,
     pagerRef,
@@ -50,6 +59,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
     comments,
   } = useActorsTransparencyReport(actor);
 
+  const headline = <TeamHeadLine teamLongCode={actor.code} />;
   return (
     <Wrapper>
       <SEOHead
@@ -102,75 +112,72 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
               />
             </TabsContainer>
           </Container>
-          <Container>
-            {tabsIndex === TRANSPARENCY_IDS_ENUM.ACTUALS && (
-              <TransparencyActuals
-                code={actor.shortCode}
-                currentMonth={currentMonth}
-                // TODO: modify the type of actors to be BudgetStatement[]
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                budgetStatements={actor?.budgetStatements as any}
-                longCode={actor.code}
-              />
-            )}
-            {tabsIndex === TRANSPARENCY_IDS_ENUM.FORECAST && (
-              <TransparencyForecast
-                currentMonth={currentMonth}
-                // TODO: modify the type of actors to be BudgetStatement[]
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                budgetStatements={actor?.budgetStatements as any}
-                code={actor.shortCode}
-                longCode={actor.code}
-              />
-            )}
-            {tabsIndex === TRANSPARENCY_IDS_ENUM.MKR_VESTING && (
-              <TransparencyMkrVesting
-                currentMonth={currentMonth}
-                // TODO: modify the type of actors to be BudgetStatement[]
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                budgetStatements={actor?.budgetStatements as any}
-                code={actor.shortCode}
-                longCode={actor.code}
-              />
-            )}
-            {tabsIndex === TRANSPARENCY_IDS_ENUM.TRANSFER_REQUESTS && (
-              <TransparencyTransferRequest
-                currentMonth={currentMonth}
-                // TODO: modify the type of actors to be BudgetStatement[]
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                budgetStatements={actor?.budgetStatements as any}
-                code={actor.shortCode}
-                longCode={actor.code}
-              />
-            )}
-            {tabsIndex === TRANSPARENCY_IDS_ENUM.AUDIT_REPORTS && isEnabled('FEATURE_AUDIT_REPORTS') && (
-              <TransparencyAudit budgetStatement={currentBudgetStatement} />
-            )}
-            {tabsIndex === TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS && isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') && (
-              <AccountsSnapshotTabContainer
-                snapshotOwner={`${actor.shortCode} Ecosystem Actor`}
-                currentMonth={currentMonth}
-                ownerId={actor.id}
-                longCode={actor.code}
-              />
-            )}
-            {tabsIndex === TRANSPARENCY_IDS_ENUM.COMMENTS && (
-              <CommentActivityContext.Provider value={{ lastVisitHandler }}>
-                <AuditorCommentsContainer budgetStatement={currentBudgetStatement} comments={comments} />
-              </CommentActivityContext.Provider>
-            )}
-          </Container>
+          <ModalCategoriesProvider expenseCategories={expenseCategories}>
+            <Container>
+              {tabsIndex === TRANSPARENCY_IDS_ENUM.ACTUALS && (
+                <TransparencyActuals
+                  currentMonth={currentMonth}
+                  budgetStatements={actor?.budgetStatements}
+                  longCode={actor.code}
+                  headline={headline}
+                  resource={ResourceType.EcosystemActor}
+                />
+              )}
+              {tabsIndex === TRANSPARENCY_IDS_ENUM.FORECAST && (
+                <TransparencyForecast
+                  currentMonth={currentMonth}
+                  budgetStatements={actor?.budgetStatements}
+                  longCode={actor.code}
+                  headline={headline}
+                  resource={ResourceType.EcosystemActor}
+                />
+              )}
+              {tabsIndex === TRANSPARENCY_IDS_ENUM.MKR_VESTING && (
+                <TransparencyMkrVesting
+                  currentMonth={currentMonth}
+                  budgetStatements={actor?.budgetStatements}
+                  longCode={actor.code}
+                  headline={headline}
+                  resource={ResourceType.EcosystemActor}
+                />
+              )}
+              {tabsIndex === TRANSPARENCY_IDS_ENUM.TRANSFER_REQUESTS && (
+                <TransparencyTransferRequest
+                  currentMonth={currentMonth}
+                  budgetStatements={actor?.budgetStatements}
+                  longCode={actor.code}
+                  headline={headline}
+                  resource={ResourceType.EcosystemActor}
+                />
+              )}
+              {tabsIndex === TRANSPARENCY_IDS_ENUM.AUDIT_REPORTS && isEnabled('FEATURE_AUDIT_REPORTS') && (
+                <TransparencyAudit budgetStatement={currentBudgetStatement} />
+              )}
+              {tabsIndex === TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS && isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') && (
+                <AccountsSnapshotTabContainer
+                  snapshotOwner={`${actor.shortCode} Ecosystem Actor`}
+                  currentMonth={currentMonth}
+                  ownerId={actor.id}
+                  longCode={actor.code}
+                  resource={ResourceType.EcosystemActor}
+                />
+              )}
+              {tabsIndex === TRANSPARENCY_IDS_ENUM.COMMENTS && (
+                <CommentActivityContext.Provider value={{ lastVisitHandler }}>
+                  <AuditorCommentsContainer budgetStatement={currentBudgetStatement} comments={comments} />
+                </CommentActivityContext.Provider>
+              )}
+            </Container>
 
-          {tabsIndex === TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT && (
-            <ExpenseReport
-              code={actor.shortCode}
-              currentMonth={currentMonth}
-              // TODO: modify the type of actors to be BudgetStatement[]
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              budgetStatements={actor?.budgetStatements as any}
-              longCode={actor.code}
-            />
-          )}
+            {tabsIndex === TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT && (
+              <ExpenseReport
+                code={actor.shortCode}
+                currentMonth={currentMonth}
+                budgetStatements={actor?.budgetStatements}
+                longCode={actor.code}
+              />
+            )}
+          </ModalCategoriesProvider>
         </PageSeparator>
       </PageContainer>
     </Wrapper>

--- a/src/stories/containers/ActorsTransparencyReport/api/queries.ts
+++ b/src/stories/containers/ActorsTransparencyReport/api/queries.ts
@@ -2,7 +2,7 @@ import { GRAPHQL_ENDPOINT } from '@ses/config/endpoints';
 import request, { gql } from 'graphql-request';
 import type { Team } from '@ses/core/models/interfaces/team';
 
-export const getEcosystemActor = (code: string) => ({
+export const getEcosystemActor = (shortCode: string) => ({
   query: gql`
     query teams($filter: TeamFilter) {
       teams(filter: $filter) {
@@ -110,13 +110,13 @@ export const getEcosystemActor = (code: string) => ({
   filter: {
     filter: {
       type: 'EcosystemActor',
-      code,
+      shortCode,
     },
   },
 });
 
-export const fetchEcosystemActor = async (code: string): Promise<Team> => {
-  const { query, filter } = getEcosystemActor(code);
+export const fetchEcosystemActor = async (shortCode: string): Promise<Team> => {
+  const { query, filter } = getEcosystemActor(shortCode);
   const res = await request<{ teams: Team[] }>(GRAPHQL_ENDPOINT, query, filter);
   return res?.teams?.[0];
 };

--- a/src/stories/containers/ActorsTransparencyReport/components/TeamHeadlineText/TeamHeadlineText.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/components/TeamHeadlineText/TeamHeadlineText.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
+import { CustomLink } from '@ses/components/CustomLink/CustomLink';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { MAKER_BURN_LINK } from '@ses/core/utils/const';
+import { getShortCode } from '@ses/core/utils/string';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface TeamHeadlineTextProps {
+  teamLongCode: string;
+}
+
+const TeamHeadLine: React.FC<TeamHeadlineTextProps> = ({ teamLongCode }) => {
+  const { isLight } = useThemeContext();
+  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
+
+  return (
+    <LinkDescription isLight={isLight}>
+      <span> Visit makerburn.com to</span>
+      <CustomLink
+        href={`${MAKER_BURN_LINK}/${teamLongCode}`}
+        style={{
+          color: '#447AFB',
+          letterSpacing: '0.3px',
+          lineHeight: '18px',
+          marginBottom: isMobile ? '0px' : '32px',
+          marginLeft: 0,
+          whiteSpace: 'break-spaces',
+          display: 'inline-block',
+        }}
+        fontSize={16}
+        fontWeight={500}
+        iconWidth={10}
+        iconHeight={10}
+        marginLeft="7px"
+      >
+        {`view the ${getShortCode(teamLongCode)} Ecosystem Actor on-chain transaction history`}
+      </CustomLink>
+    </LinkDescription>
+  );
+};
+
+export default TeamHeadLine;
+
+export const LinkDescription = styled.div<WithIsLight>(({ isLight }) => ({
+  fontFamily: 'Inter, sans-serif',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  fontSize: 14,
+  lineHeight: '22px',
+  color: isLight ? '#231536' : '#D2D4EF',
+
+  span: {
+    marginRight: 4,
+  },
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    fontSize: 16,
+  },
+}));

--- a/src/stories/containers/RecognizedDelegatesReports/DelegatesActuals/DelegatesActuals.tsx
+++ b/src/stories/containers/RecognizedDelegatesReports/DelegatesActuals/DelegatesActuals.tsx
@@ -4,6 +4,7 @@ import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedI
 import { CustomLink } from '@ses/components/CustomLink/CustomLink';
 import { TransparencyEmptyTable } from '@ses/containers/TransparencyReport/components/Placeholders/TransparencyEmptyTable';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { ResourceType } from '@ses/core/models/interfaces/types';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { useDelegatesActuals } from './useDelegatesActuals';
@@ -48,7 +49,7 @@ const DelegatesActuals: React.FC<Props> = ({ currentMonth, budgetStatement }) =>
         style={{ marginBottom: '64px' }}
         cardsTotalPosition="top"
         longCode="DEL"
-        tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" isDelegate />}
+        tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" resource={ResourceType.Delegates} />}
       />
       {mainTableItemsActuals.length > 0 && (
         <TitleBreakdown isLight={isLight}>{currentMonth.toFormat('MMM yyyy')} Breakdown</TitleBreakdown>
@@ -59,7 +60,7 @@ const DelegatesActuals: React.FC<Props> = ({ currentMonth, budgetStatement }) =>
           items={breakdownItemsActuals}
           longCode="DEL"
           style={{ marginBottom: '64px' }}
-          tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" isDelegate />}
+          tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" resource={ResourceType.Delegates} />}
         />
       )}
     </Container>

--- a/src/stories/containers/RecognizedDelegatesReports/DelegatesForecast/DelegatesForecast.tsx
+++ b/src/stories/containers/RecognizedDelegatesReports/DelegatesForecast/DelegatesForecast.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
 import { TransparencyEmptyTable } from '@ses/containers/TransparencyReport/components/Placeholders/TransparencyEmptyTable';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { ResourceType } from '@ses/core/models/interfaces/types';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { useDelegatesForecast } from './useDelegatesForecast';
@@ -26,7 +27,7 @@ const DelegatesForecast: React.FC<Props> = ({ currentMonth, budgetStatement }) =
         style={{ marginBottom: '64px' }}
         cardsTotalPosition="top"
         longCode="DEL"
-        tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" isDelegate />}
+        tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" resource={ResourceType.Delegates} />}
       />
       {mainTableItemsForecast.length > 0 && (
         <TitleBreakdown isLight={isLight}>{currentMonth.toFormat('MMM yyyy')} Breakdown</TitleBreakdown>
@@ -38,7 +39,7 @@ const DelegatesForecast: React.FC<Props> = ({ currentMonth, budgetStatement }) =
           items={breakdownItemsForecast}
           longCode="DEL"
           style={{ marginBottom: '64px' }}
-          tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" isDelegate />}
+          tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" resource={ResourceType.Delegates} />}
         />
       )}
     </Container>

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -5,6 +5,7 @@ import Tabs from '@ses/components/Tabs/Tabs';
 import BudgetStatementPager from '@ses/components/TransparencyReporting/BudgetStatementPager/BudgetStatementPager';
 import { siteRoutes } from '@ses/config/routes';
 import { ModalCategoriesProvider } from '@ses/core/context/CategoryModalContext';
+import { ResourceType } from '@ses/core/models/interfaces/types';
 import React from 'react';
 import lightTheme from '../../../../styles/theme/light';
 import { CommentActivityContext } from '../../../core/context/CommentActivityContext';
@@ -16,6 +17,7 @@ import { CoreUnitSummary } from '../../components/CoreUnitSummary/CoreUnitSummar
 import { CustomLink } from '../../components/CustomLink/CustomLink';
 import { SEOHead } from '../../components/SEOHead/SEOHead';
 import AccountsSnapshotTabContainer from './components/AccountsSnapshot/AccountsSnapshotTabContainer';
+import CuHeadlineText from './components/CuHeadlineText/CuHeadlineText';
 import ExpenseReport from './components/ExpenseReport/ExpenseReport';
 import { TransparencyActuals } from './components/TransparencyActuals/TransparencyActuals';
 
@@ -63,6 +65,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
   } = useTransparencyReport(coreUnit);
   const [isEnabled] = useFlagsActive();
 
+  const headline = <CuHeadlineText cuLongCode={longCode} />;
   return (
     <Wrapper>
       <SEOHead
@@ -112,34 +115,38 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
             <Container>
               {tabsIndex === TRANSPARENCY_IDS_ENUM.ACTUALS && (
                 <TransparencyActuals
-                  code={code}
                   currentMonth={currentMonth}
                   budgetStatements={coreUnit?.budgetStatements}
                   longCode={longCode}
+                  headline={headline}
+                  resource={ResourceType.CoreUnit}
                 />
               )}
               {tabsIndex === TRANSPARENCY_IDS_ENUM.FORECAST && (
                 <TransparencyForecast
                   currentMonth={currentMonth}
                   budgetStatements={coreUnit?.budgetStatements}
-                  code={code}
                   longCode={longCode}
+                  headline={headline}
+                  resource={ResourceType.CoreUnit}
                 />
               )}
               {tabsIndex === TRANSPARENCY_IDS_ENUM.MKR_VESTING && (
                 <TransparencyMkrVesting
                   currentMonth={currentMonth}
                   budgetStatements={coreUnit?.budgetStatements}
-                  code={code}
                   longCode={longCode}
+                  headline={headline}
+                  resource={ResourceType.CoreUnit}
                 />
               )}
               {tabsIndex === TRANSPARENCY_IDS_ENUM.TRANSFER_REQUESTS && (
                 <TransparencyTransferRequest
                   currentMonth={currentMonth}
                   budgetStatements={coreUnit?.budgetStatements}
-                  code={code}
                   longCode={longCode}
+                  headline={headline}
+                  resource={ResourceType.CoreUnit}
                 />
               )}
               {tabsIndex === TRANSPARENCY_IDS_ENUM.AUDIT_REPORTS && isEnabled('FEATURE_AUDIT_REPORTS') && (
@@ -151,6 +158,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
                   currentMonth={currentMonth}
                   ownerId={coreUnit.id}
                   longCode={coreUnit.code}
+                  resource={ResourceType.CoreUnit}
                 />
               )}
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
@@ -4,6 +4,7 @@ import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import AccountsSnapshot from './AccountsSnapshot';
 import AccountsSnapshotSkeleton from './AccountsSnapshotSkeleton';
 import useAccountsSnapshotTab from './useAccountsSnapshotTab';
+import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { DateTime } from 'luxon';
 
 interface AccountsSnapshotTabContainerProps {
@@ -11,6 +12,7 @@ interface AccountsSnapshotTabContainerProps {
   currentMonth: DateTime;
   ownerId: string;
   longCode: string;
+  resource: ResourceType;
 }
 
 const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> = ({
@@ -18,8 +20,9 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
   currentMonth,
   ownerId,
   longCode,
+  resource,
 }) => {
-  const { isLoading, snapshot } = useAccountsSnapshotTab(ownerId, currentMonth);
+  const { isLoading, snapshot } = useAccountsSnapshotTab(ownerId, currentMonth, resource);
 
   return isLoading ? (
     <AccountsSnapshotSkeleton />
@@ -27,7 +30,7 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
     <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} />
   ) : (
     <Box sx={{ mb: '64px' }}>
-      <TransparencyEmptyTable longCode={longCode} />
+      <TransparencyEmptyTable longCode={longCode} resource={resource} />
     </Box>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshotTab.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshotTab.ts
@@ -3,17 +3,18 @@ import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 import { accountsSnapshotQuery } from './api/queries';
 import type { Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
+import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { DateTime } from 'luxon';
 
-const useAccountsSnapshotTab = (ownerId: string, currentMonth: DateTime) => {
+const useAccountsSnapshotTab = (ownerId: string, currentMonth: DateTime, resource: ResourceType) => {
   const { query, filter } = useMemo(
     () =>
       accountsSnapshotQuery({
-        ownerType: 'CoreUnit',
+        ownerType: resource,
         ownerId,
         period: currentMonth?.toFormat('yyyy/MM'),
       }),
-    [ownerId, currentMonth]
+    [resource, ownerId, currentMonth]
   );
 
   const { data: response, error: errorFetchingUser } = useSWRImmutable<{ snapshots: Snapshots[] }>(

--- a/src/stories/containers/TransparencyReport/components/CuHeadlineText/CuHeadlineText.tsx
+++ b/src/stories/containers/TransparencyReport/components/CuHeadlineText/CuHeadlineText.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
+import { CustomLink } from '@ses/components/CustomLink/CustomLink';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { MAKER_BURN_LINK } from '@ses/core/utils/const';
+import { getShortCode } from '@ses/core/utils/string';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface CuHeadlineTextProps {
+  cuLongCode: string;
+}
+
+const CuHeadlineText: React.FC<CuHeadlineTextProps> = ({ cuLongCode }) => {
+  const { isLight } = useThemeContext();
+  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
+
+  return (
+    <LinkDescription isLight={isLight}>
+      <span> Visit makerburn.com to</span>
+      <CustomLink
+        href={`${MAKER_BURN_LINK}/${cuLongCode}`}
+        style={{
+          color: '#447AFB',
+          letterSpacing: '0.3px',
+          lineHeight: '18px',
+          marginBottom: isMobile ? '0px' : '32px',
+          marginLeft: 0,
+          whiteSpace: 'break-spaces',
+          display: 'inline-block',
+        }}
+        fontSize={16}
+        fontWeight={500}
+        iconWidth={10}
+        iconHeight={10}
+        marginLeft="7px"
+      >
+        {`view the ${getShortCode(cuLongCode)} Core Unit on-chain transaction history`}
+      </CustomLink>
+    </LinkDescription>
+  );
+};
+
+export default CuHeadlineText;
+
+export const LinkDescription = styled.div<WithIsLight>(({ isLight }) => ({
+  fontFamily: 'Inter, sans-serif',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  fontSize: 14,
+  lineHeight: '22px',
+  color: isLight ? '#231536' : '#D2D4EF',
+
+  span: {
+    marginRight: 4,
+  },
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    fontSize: 16,
+  },
+}));

--- a/src/stories/containers/TransparencyReport/components/Placeholders/TransparencyEmptyTable.tsx
+++ b/src/stories/containers/TransparencyReport/components/Placeholders/TransparencyEmptyTable.tsx
@@ -3,20 +3,38 @@ import { useMediaQuery } from '@mui/material';
 import { LinkButton } from '@ses/components/LinkButton/LinkButton';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { ButtonType } from '@ses/core/enums/buttonTypeEnum';
+import { ResourceType } from '@ses/core/models/interfaces/types';
 import { MAKER_BURN_LINK } from '@ses/core/utils/const';
 import { getShortCode } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 
-interface Props {
+interface TransparencyEmptyTableProps {
   breakdown?: boolean;
   longCode: string;
-  isDelegate?: boolean;
+  resource?: ResourceType;
 }
 
-export const TransparencyEmptyTable = ({ breakdown = false, longCode, isDelegate = false }: Props) => {
+export const TransparencyEmptyTable: React.FC<TransparencyEmptyTableProps> = ({
+  breakdown = false,
+  longCode,
+  resource = ResourceType.CoreUnit,
+}) => {
   const { isLight } = useThemeContext();
   const isTable = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+
+  let title: string;
+  switch (resource) {
+    case ResourceType.Delegates:
+      title = 'No data reported by the Delegates Administrator';
+      break;
+    case ResourceType.EcosystemActor:
+      title = `No data reported by ${getShortCode(longCode)} Ecosystem Actor`;
+      break;
+    default:
+      // handle as a core unit
+      title = `No data reported by ${getShortCode(longCode)} Core Unit`;
+  }
 
   return (
     <>
@@ -274,16 +292,16 @@ export const TransparencyEmptyTable = ({ breakdown = false, longCode, isDelegate
           </Container>
         )}
         <ContainerIndications>
-          <Title>{`No data reported by ${
-            isDelegate ? 'the Delegates Administrator' : `${getShortCode(longCode)} Core Unit`
-          }`}</Title>
+          <Title>{title}</Title>
 
           <Description>View on-chain transfers on makerburn.com </Description>
 
           <ContainerButton>
             <LinkButton
               href={
-                isDelegate ? 'https://makerburn.com/#/expenses/core-units/DELEGATES' : `${MAKER_BURN_LINK}/${longCode}`
+                resource === ResourceType.Delegates
+                  ? 'https://makerburn.com/#/expenses/core-units/DELEGATES'
+                  : `${MAKER_BURN_LINK}/${longCode}`
               }
               label="Go to Makerburn"
               styleText={{
@@ -431,15 +449,15 @@ export const TransparencyEmptyTable = ({ breakdown = false, longCode, isDelegate
           </Container>
         )}
         <ContainerIndications>
-          <TitleMobile>{`No data reported by ${
-            isDelegate ? 'the Delegates Administrator' : `${getShortCode(longCode)} Core Unit`
-          }`}</TitleMobile>
+          <TitleMobile>{title}</TitleMobile>
 
           <Description>View on-chain transfers on makerburn.com </Description>
           <ContainerButton>
             <LinkButton
               href={
-                isDelegate ? 'https://makerburn.com/#/expenses/core-units/DELEGATES' : `${MAKER_BURN_LINK}/${longCode}`
+                resource === ResourceType.Delegates
+                  ? 'https://makerburn.com/#/expenses/core-units/DELEGATES'
+                  : `${MAKER_BURN_LINK}/${longCode}`
               }
               label="Go to Makerburn"
               styleText={{

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
@@ -1,12 +1,8 @@
 import styled from '@emotion/styled';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
 import CategoryModalComponent from '@ses/components/BasicModal/CategoryModalComponent';
-import { CustomLink } from '@ses/components/CustomLink/CustomLink';
 import Tabs from '@ses/components/Tabs/Tabs';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { MAKER_BURN_LINK } from '@ses/core/utils/const';
-import { getShortCode } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { Title } from '../../TransparencyReport';
@@ -14,19 +10,25 @@ import { ACTUALS_BREAKDOWN_QUERY_PARAM } from '../../utils/constants';
 import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import { useTransparencyActuals } from './useTransparencyActuals';
 import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatement';
+import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { DateTime } from 'luxon';
 
-interface Props {
+interface TransparencyActualsProps {
   currentMonth: DateTime;
   budgetStatements?: BudgetStatement[];
-  code: string;
   longCode: string;
+  headline: React.ReactNode;
+  resource: ResourceType;
 }
 
-export const TransparencyActuals = (props: Props) => {
+export const TransparencyActuals: React.FC<TransparencyActualsProps> = ({
+  currentMonth,
+  budgetStatements,
+  longCode,
+  headline,
+  resource,
+}) => {
   const { isLight } = useThemeContext();
-  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
-
   const {
     headerIds,
     breakdownTitleRef,
@@ -35,48 +37,28 @@ export const TransparencyActuals = (props: Props) => {
     mainTableColumns,
     mainTableItems,
     breakdownTabs,
-  } = useTransparencyActuals(props.currentMonth, props.budgetStatements);
+  } = useTransparencyActuals(currentMonth, budgetStatements);
 
   return (
     <Container>
-      <LinkDescription isLight={isLight}>
-        <span> Visit makerburn.com to</span>
-        <CustomLink
-          href={`${MAKER_BURN_LINK}/${props.longCode}`}
-          style={{
-            color: '#447AFB',
-            letterSpacing: '0.3px',
-            lineHeight: '18px',
-            marginBottom: isMobile ? '0px' : '32px',
-            marginLeft: 0,
-            whiteSpace: 'break-spaces',
-            display: 'inline-block',
-          }}
-          fontSize={16}
-          fontWeight={500}
-          iconWidth={10}
-          iconHeight={10}
-          marginLeft="7px"
-        >
-          {`view the ${getShortCode(props.code)} Core Unit on-chain transaction history`}
-        </CustomLink>
-      </LinkDescription>
-      <Title isLight={isLight}>{props.currentMonth.toFormat('MMM yyyy')} Totals</Title>
+      {headline}
+
+      <Title isLight={isLight}>{currentMonth.toFormat('MMM yyyy')} Totals</Title>
       <AdvancedInnerTable
         columns={mainTableColumns}
         items={mainTableItems}
         style={{ marginBottom: '64px' }}
         cardsTotalPosition="top"
-        longCode={props.longCode}
+        longCode={longCode}
         tablePlaceholder={
           <div style={{ marginBottom: 64 }}>
-            <TransparencyEmptyTable longCode={props.longCode} />
+            <TransparencyEmptyTable longCode={longCode} resource={resource} />
           </div>
         }
       />
       {mainTableItems.length > 0 && (
         <Title isLight={isLight} ref={breakdownTitleRef}>
-          {props.currentMonth.toFormat('MMM yyyy')} Breakdown
+          {currentMonth.toFormat('MMM yyyy')} Breakdown
         </Title>
       )}
 
@@ -95,12 +77,12 @@ export const TransparencyActuals = (props: Props) => {
           <AdvancedInnerTable
             columns={breakdownColumnsForActiveTab}
             items={breakdownItemsForActiveTab}
-            longCode={props.longCode}
+            longCode={longCode}
             style={{ marginBottom: 64 }}
             cardSpacingSize="small"
             tablePlaceholder={
               <div style={{ marginBottom: 64 }}>
-                <TransparencyEmptyTable breakdown longCode={props.longCode} />
+                <TransparencyEmptyTable breakdown longCode={longCode} resource={resource} />
               </div>
             }
           />
@@ -116,6 +98,7 @@ const Container = styled.div({
   flexDirection: 'column',
 });
 
+// TODO: delete this
 export const LinkDescription = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
@@ -1,32 +1,33 @@
 import styled from '@emotion/styled';
-import { useMediaQuery } from '@mui/material';
 import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
-
-import { CustomLink } from '@ses/components/CustomLink/CustomLink';
 import Tabs from '@ses/components/Tabs/Tabs';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { MAKER_BURN_LINK } from '@ses/core/utils/const';
-import { getShortCode } from '@ses/core/utils/string';
-import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { Title } from '../../TransparencyReport';
 import { FORECAST_BREAKDOWN_QUERY_PARAM } from '../../utils/constants';
 import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
-import { BreakdownTableWrapper, LinkDescription } from '../TransparencyActuals/TransparencyActuals';
+import { BreakdownTableWrapper } from '../TransparencyActuals/TransparencyActuals';
 import { useTransparencyForecast } from './useTransparencyForecast';
 import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatement';
+import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { DateTime } from 'luxon';
 
-interface Props {
+interface TransparencyForecastProps {
   currentMonth: DateTime;
   budgetStatements: BudgetStatement[];
-  code: string;
   longCode: string;
+  headline: React.ReactNode;
+  resource: ResourceType;
 }
 
-export const TransparencyForecast = (props: Props) => {
+export const TransparencyForecast: React.FC<TransparencyForecastProps> = ({
+  currentMonth,
+  budgetStatements,
+  longCode,
+  headline,
+  resource,
+}) => {
   const { isLight } = useThemeContext();
-  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
 
   const {
     headerIds,
@@ -36,36 +37,15 @@ export const TransparencyForecast = (props: Props) => {
     breakdownItems,
     breakdownTitleRef,
     breakdownTabs,
-  } = useTransparencyForecast(props.currentMonth, props.budgetStatements);
+  } = useTransparencyForecast(currentMonth, budgetStatements);
 
   return (
     <Container>
-      <LinkDescription isLight={isLight}>
-        <span> Visit makerburn.com to</span>
-        <CustomLink
-          href={`${MAKER_BURN_LINK}/${props.longCode}`}
-          style={{
-            flexWrap: 'wrap',
-            color: '#447AFB',
-            letterSpacing: '0.3px',
-            lineHeight: '18px',
-            marginBottom: isMobile ? '0px' : '32px',
-            whiteSpace: 'break-spaces',
-            display: 'inline-block',
-            marginLeft: 0,
-          }}
-          fontSize={16}
-          fontWeight={500}
-          iconWidth={10}
-          iconHeight={10}
-          marginLeft="7px"
-        >
-          {`view the ${getShortCode(props.code)} Core Unit on-chain transaction history`}
-        </CustomLink>
-      </LinkDescription>
-      <Title isLight={isLight}>{props.currentMonth.toFormat('MMM yyyy')} Totals</Title>
+      {headline}
+
+      <Title isLight={isLight}>{currentMonth.toFormat('MMM yyyy')} Totals</Title>
       <AdvancedInnerTable
-        longCode={props.longCode}
+        longCode={longCode}
         columns={mainTableColumns}
         items={mainTableItems}
         style={{ marginBottom: '64px' }}
@@ -73,7 +53,7 @@ export const TransparencyForecast = (props: Props) => {
       />
       {!!mainTableItems?.length && (
         <Title isLight={isLight} marginBottom={24} ref={breakdownTitleRef}>
-          {props.currentMonth.toFormat('MMM yyyy')} Breakdown
+          {currentMonth.toFormat('MMM yyyy')} Breakdown
         </Title>
       )}
 
@@ -90,11 +70,11 @@ export const TransparencyForecast = (props: Props) => {
       {!!mainTableItems?.length && (
         <BreakdownTableWrapper>
           <AdvancedInnerTable
-            longCode={props.longCode}
+            longCode={longCode}
             columns={breakdownColumnsForActiveTab}
             items={breakdownItems}
             cardSpacingSize="small"
-            tablePlaceholder={<TransparencyEmptyTable breakdown longCode={props.longCode} />}
+            tablePlaceholder={<TransparencyEmptyTable breakdown longCode={longCode} resource={resource} />}
           />
         </BreakdownTableWrapper>
       )}

--- a/src/stories/containers/TransparencyReport/components/TransparencyMkrVesting/TransparencyMkrVesting.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyMkrVesting/TransparencyMkrVesting.tsx
@@ -1,66 +1,49 @@
 import styled from '@emotion/styled';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
-import { CustomLink } from '@ses/components/CustomLink/CustomLink';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { MAKER_BURN_LINK } from '@ses/core/utils/const';
-import { getShortCode } from '@ses/core/utils/string';
-import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { Title } from '../../TransparencyReport';
-import { LinkDescription } from '../TransparencyActuals/TransparencyActuals';
+import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import MkrVestingInfo from './MkrVestingInfo';
 import MkrVestingTotalFTE from './MkrVestingTotalFTE';
 import { useTransparencyMkrVesting } from './useTransparencyMkrVesting';
 import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatement';
+import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { DateTime } from 'luxon';
 
 interface TransparencyMkrVestingProps {
   currentMonth: DateTime;
   budgetStatements: BudgetStatement[];
-  code: string;
   longCode: string;
+  headline: React.ReactNode;
+  resource: ResourceType;
 }
 
-export const TransparencyMkrVesting = (props: TransparencyMkrVestingProps) => {
-  const { mainTableItems, mainTableColumns, FTEs } = useTransparencyMkrVesting(
-    props.currentMonth,
-    props.budgetStatements
-  );
-  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
+export const TransparencyMkrVesting: React.FC<TransparencyMkrVestingProps> = ({
+  currentMonth,
+  budgetStatements,
+  longCode,
+  headline,
+  resource,
+}) => {
+  const { mainTableItems, mainTableColumns, FTEs } = useTransparencyMkrVesting(currentMonth, budgetStatements);
   const { isLight } = useThemeContext();
 
   return (
     <Container>
-      <LinkDescription isLight={isLight}>
-        <span> Visit makerburn.com to</span>
-        <CustomLink
-          href={`${MAKER_BURN_LINK}/${props.longCode}`}
-          style={{
-            flexWrap: 'wrap',
-            color: '#447AFB',
-            letterSpacing: '0.3px',
-            lineHeight: '18px',
-            marginBottom: isMobile ? '0px' : '32px',
-            whiteSpace: 'break-spaces',
-            display: 'inline-block',
-            marginLeft: 0,
-          }}
-          fontSize={16}
-          fontWeight={500}
-          iconWidth={10}
-          iconHeight={10}
-          marginLeft="7px"
-        >
-          {`view the ${getShortCode(props.code)} Core Unit on-chain transaction history`}
-        </CustomLink>
-      </LinkDescription>
+      {headline}
+
       <Title isLight={isLight} marginBottom={24}>
         MKR Vesting Overview
       </Title>
       <MkrVestingTotalFTE totalFTE={FTEs} />
 
-      <AdvancedInnerTable columns={mainTableColumns} items={mainTableItems} longCode={props.longCode} />
+      <AdvancedInnerTable
+        columns={mainTableColumns}
+        items={mainTableItems}
+        longCode={longCode}
+        tablePlaceholder={<TransparencyEmptyTable longCode={longCode} resource={resource} />}
+      />
       {mainTableItems.length > 0 && (
         <MkrInfoContainer>
           <MkrVestingInfo />

--- a/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/TransparencyTransferRequest.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/TransparencyTransferRequest.tsx
@@ -1,66 +1,45 @@
 import styled from '@emotion/styled';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { AdvancedInnerTable } from '@ses/components/AdvancedInnerTable/AdvancedInnerTable';
-import { CustomLink } from '@ses/components/CustomLink/CustomLink';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { MAKER_BURN_LINK } from '@ses/core/utils/const';
-import { getShortCode } from '@ses/core/utils/string';
-import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { Title } from '../../TransparencyReport';
-import { LinkDescription } from '../TransparencyActuals/TransparencyActuals';
+import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
 import { useTransparencyTransferRequest } from './useTransparencyTransferRequest';
 import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatement';
+import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { DateTime } from 'luxon';
 
-interface Props {
+interface TransparencyTransferRequestProps {
   currentMonth: DateTime;
   budgetStatements: BudgetStatement[];
-  code: string;
   longCode: string;
+  headline: React.ReactNode;
+  resource: ResourceType;
 }
 
-export const TransparencyTransferRequest = (props: Props) => {
+export const TransparencyTransferRequest: React.FC<TransparencyTransferRequestProps> = ({
+  currentMonth,
+  budgetStatements,
+  longCode,
+  headline,
+  resource,
+}) => {
   const { isLight } = useThemeContext();
-  const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
-  const { mainTableColumns, mainTableItems } = useTransparencyTransferRequest(
-    props.currentMonth,
-    props.budgetStatements
-  );
+  const { mainTableColumns, mainTableItems } = useTransparencyTransferRequest(currentMonth, budgetStatements);
 
   return (
     <Container>
-      <LinkDescription isLight={isLight}>
-        <span> Visit makerburn.com to</span>
-        <CustomLink
-          href={`${MAKER_BURN_LINK}/${props.longCode}`}
-          style={{
-            flexWrap: 'wrap',
-            color: '#447AFB',
-            letterSpacing: '0.3px',
-            lineHeight: '18px',
-            marginBottom: isMobile ? '0px' : '32px',
-            whiteSpace: 'break-spaces',
-            display: 'inline-block',
-            marginLeft: 0,
-          }}
-          fontSize={16}
-          fontWeight={500}
-          iconWidth={10}
-          iconHeight={10}
-          marginLeft="7px"
-        >
-          {`view the ${getShortCode(props.code)} Core Unit on-chain transaction history`}
-        </CustomLink>
-      </LinkDescription>
-      <Title isLight={isLight}>{props.currentMonth.toFormat('MMM yyyy')} Totals</Title>
+      {headline}
+
+      <Title isLight={isLight}>{currentMonth.toFormat('MMM yyyy')} Totals</Title>
       <div style={{ marginTop: 32 }}>
         <AdvancedInnerTable
           columns={mainTableColumns}
           items={mainTableItems}
           style={{ marginBottom: '64px' }}
           cardsTotalPosition={'top'}
-          longCode={props.longCode}
+          longCode={longCode}
+          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} resource={resource} />}
         />
       </div>
     </Container>


### PR DESCRIPTION
# Ticket
https://trello.com/c/KT93qSRs/288-user-story-ability-to-view-ecosystem-actor-expense-reports

# Description
Stabilize the first 4 tabs

# What solved
- [X] Should add the Actuals tab content
- [X] Should add the Forecast tab content 
- [X] Should add the MKR vesting tab content
- [X] Should add the Transfer request tab content 