### PR TITLE
Check BreadCrumb in mobile

### DIFF
--- a/src/stories/containers/ActorsAbout/ActorSummary/ActorSummary.tsx
+++ b/src/stories/containers/ActorsAbout/ActorSummary/ActorSummary.tsx
@@ -95,7 +95,7 @@ const ActorSummary: React.FC<ActorSummaryProps> = ({ actors: data = [], breadcru
         totalElements={filteredData.length}
         onClickLeft={changeCoreUnitCode(-1)}
         onClickRight={changeCoreUnitCode(1)}
-        breadcrumbTitleMobile={buildCULabel()}
+        breadcrumbTitleMobile={breadcrumbTitle}
         hasStyleMobileItem={[buildCULabel(), undefined].includes(breadcrumbTitle)}
         trailingAddress={trailingAddress}
         router={router}

--- a/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
@@ -69,7 +69,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
         twitterCard={actor.image ? 'summary' : 'summary_large_image'}
         canonicalURL={siteRoutes.ecosystemActorReports(actor.code)}
       />
-      <ActorSummary actors={actors} trailingAddress={['Expense Report']} breadcrumbTitle="Expense Reports" />
+      <ActorSummary actors={actors} trailingAddress={['Expense Reports']} breadcrumbTitle="Expense Reports" />
       <PageContainer hasImageBackground={true}>
         <PageSeparator>
           <Container>


### PR DESCRIPTION
# Ticket

https://trello.com/c/QAVgnXw4/287-user-story-ecosystem-actor-profile-page

# What solved
- [X]  The view name is displayed with grey color not showing that it's the current view where you are in. 
- [X] Should say Expense Reports with "s" at the end. **Current Output:** The s letter is missing.  


# Description
Fix the highlight of text in the mobile