### PR TITLE
[SES-288] Fix shortcode issues

### DIFF
--- a/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/stories/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -247,7 +247,7 @@ export const AdvancedInnerTable: React.FC<AdvancedInnerTableProps> = ({
       </CardsWrapper>
     </>
   ) : (
-    tablePlaceholder ?? <TransparencyEmptyTable longCode={longCode} />
+    tablePlaceholder ?? <TransparencyEmptyTable longCode={longCode} shortCode={longCode} />
   );
 };
 

--- a/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
@@ -59,7 +59,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
     comments,
   } = useActorsTransparencyReport(actor);
 
-  const headline = <TeamHeadLine teamLongCode={actor.code} />;
+  const headline = <TeamHeadLine teamLongCode={actor.code} teamShortCode={actor.shortCode} />;
   return (
     <Wrapper>
       <SEOHead
@@ -112,6 +112,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
                   currentMonth={currentMonth}
                   budgetStatements={actor?.budgetStatements}
                   longCode={actor.code}
+                  shortCode={actor.shortCode}
                   headline={headline}
                   resource={ResourceType.EcosystemActor}
                 />
@@ -121,6 +122,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
                   currentMonth={currentMonth}
                   budgetStatements={actor?.budgetStatements}
                   longCode={actor.code}
+                  shortCode={actor.shortCode}
                   headline={headline}
                   resource={ResourceType.EcosystemActor}
                 />
@@ -130,6 +132,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
                   currentMonth={currentMonth}
                   budgetStatements={actor?.budgetStatements}
                   longCode={actor.code}
+                  shortCode={actor.shortCode}
                   headline={headline}
                   resource={ResourceType.EcosystemActor}
                 />
@@ -139,6 +142,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
                   currentMonth={currentMonth}
                   budgetStatements={actor?.budgetStatements}
                   longCode={actor.code}
+                  shortCode={actor.shortCode}
                   headline={headline}
                   resource={ResourceType.EcosystemActor}
                 />
@@ -152,6 +156,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
                   currentMonth={currentMonth}
                   ownerId={actor.id}
                   longCode={actor.code}
+                  shortCode={actor.shortCode}
                   resource={ResourceType.EcosystemActor}
                 />
               )}
@@ -168,6 +173,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
                 currentMonth={currentMonth}
                 budgetStatements={actor?.budgetStatements}
                 longCode={actor.code}
+                resource={ResourceType.EcosystemActor}
               />
             )}
           </ModalCategoriesProvider>

--- a/src/stories/containers/ActorsTransparencyReport/components/TeamHeadlineText/TeamHeadlineText.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/components/TeamHeadlineText/TeamHeadlineText.tsx
@@ -3,16 +3,16 @@ import { useMediaQuery } from '@mui/material';
 import { CustomLink } from '@ses/components/CustomLink/CustomLink';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { MAKER_BURN_LINK } from '@ses/core/utils/const';
-import { getShortCode } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface TeamHeadlineTextProps {
   teamLongCode: string;
+  teamShortCode: string;
 }
 
-const TeamHeadLine: React.FC<TeamHeadlineTextProps> = ({ teamLongCode }) => {
+const TeamHeadLine: React.FC<TeamHeadlineTextProps> = ({ teamLongCode, teamShortCode }) => {
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
 
@@ -36,7 +36,7 @@ const TeamHeadLine: React.FC<TeamHeadlineTextProps> = ({ teamLongCode }) => {
         iconHeight={10}
         marginLeft="7px"
       >
-        {`view the ${getShortCode(teamLongCode)} Ecosystem Actor on-chain transaction history`}
+        {`view the ${teamShortCode} Ecosystem Actor on-chain transaction history`}
       </CustomLink>
     </LinkDescription>
   );

--- a/src/stories/containers/RecognizedDelegatesReports/DelegatesActuals/DelegatesActuals.tsx
+++ b/src/stories/containers/RecognizedDelegatesReports/DelegatesActuals/DelegatesActuals.tsx
@@ -49,7 +49,9 @@ const DelegatesActuals: React.FC<Props> = ({ currentMonth, budgetStatement }) =>
         style={{ marginBottom: '64px' }}
         cardsTotalPosition="top"
         longCode="DEL"
-        tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" resource={ResourceType.Delegates} />}
+        tablePlaceholder={
+          <TransparencyEmptyTable breakdown longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
+        }
       />
       {mainTableItemsActuals.length > 0 && (
         <TitleBreakdown isLight={isLight}>{currentMonth.toFormat('MMM yyyy')} Breakdown</TitleBreakdown>
@@ -60,7 +62,9 @@ const DelegatesActuals: React.FC<Props> = ({ currentMonth, budgetStatement }) =>
           items={breakdownItemsActuals}
           longCode="DEL"
           style={{ marginBottom: '64px' }}
-          tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" resource={ResourceType.Delegates} />}
+          tablePlaceholder={
+            <TransparencyEmptyTable breakdown longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
+          }
         />
       )}
     </Container>

--- a/src/stories/containers/RecognizedDelegatesReports/DelegatesForecast/DelegatesForecast.tsx
+++ b/src/stories/containers/RecognizedDelegatesReports/DelegatesForecast/DelegatesForecast.tsx
@@ -27,7 +27,9 @@ const DelegatesForecast: React.FC<Props> = ({ currentMonth, budgetStatement }) =
         style={{ marginBottom: '64px' }}
         cardsTotalPosition="top"
         longCode="DEL"
-        tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" resource={ResourceType.Delegates} />}
+        tablePlaceholder={
+          <TransparencyEmptyTable breakdown longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
+        }
       />
       {mainTableItemsForecast.length > 0 && (
         <TitleBreakdown isLight={isLight}>{currentMonth.toFormat('MMM yyyy')} Breakdown</TitleBreakdown>
@@ -39,7 +41,9 @@ const DelegatesForecast: React.FC<Props> = ({ currentMonth, budgetStatement }) =
           items={breakdownItemsForecast}
           longCode="DEL"
           style={{ marginBottom: '64px' }}
-          tablePlaceholder={<TransparencyEmptyTable breakdown longCode="DEL" resource={ResourceType.Delegates} />}
+          tablePlaceholder={
+            <TransparencyEmptyTable breakdown longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
+          }
         />
       )}
     </Container>

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -118,6 +118,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
                   currentMonth={currentMonth}
                   budgetStatements={coreUnit?.budgetStatements}
                   longCode={longCode}
+                  shortCode={coreUnit.shortCode}
                   headline={headline}
                   resource={ResourceType.CoreUnit}
                 />
@@ -127,6 +128,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
                   currentMonth={currentMonth}
                   budgetStatements={coreUnit?.budgetStatements}
                   longCode={longCode}
+                  shortCode={coreUnit.shortCode}
                   headline={headline}
                   resource={ResourceType.CoreUnit}
                 />
@@ -136,6 +138,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
                   currentMonth={currentMonth}
                   budgetStatements={coreUnit?.budgetStatements}
                   longCode={longCode}
+                  shortCode={coreUnit.shortCode}
                   headline={headline}
                   resource={ResourceType.CoreUnit}
                 />
@@ -145,6 +148,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
                   currentMonth={currentMonth}
                   budgetStatements={coreUnit?.budgetStatements}
                   longCode={longCode}
+                  shortCode={coreUnit.shortCode}
                   headline={headline}
                   resource={ResourceType.CoreUnit}
                 />
@@ -158,6 +162,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
                   currentMonth={currentMonth}
                   ownerId={coreUnit.id}
                   longCode={coreUnit.code}
+                  shortCode={coreUnit.shortCode}
                   resource={ResourceType.CoreUnit}
                 />
               )}
@@ -171,10 +176,11 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
 
             {tabsIndex === TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT && (
               <ExpenseReport
-                code={code}
+                code={coreUnit.shortCode}
                 currentMonth={currentMonth}
                 budgetStatements={coreUnit?.budgetStatements}
                 longCode={longCode}
+                resource={ResourceType.CoreUnit}
               />
             )}
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
@@ -12,6 +12,7 @@ interface AccountsSnapshotTabContainerProps {
   currentMonth: DateTime;
   ownerId: string;
   longCode: string;
+  shortCode: string;
   resource: ResourceType;
 }
 
@@ -20,6 +21,7 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
   currentMonth,
   ownerId,
   longCode,
+  shortCode,
   resource,
 }) => {
   const { isLoading, snapshot } = useAccountsSnapshotTab(ownerId, currentMonth, resource);
@@ -30,7 +32,7 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
     <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} />
   ) : (
     <Box sx={{ mb: '64px' }}>
-      <TransparencyEmptyTable longCode={longCode} resource={resource} />
+      <TransparencyEmptyTable longCode={longCode} shortCode={shortCode} resource={resource} />
     </Box>
   );
 };

--- a/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReport/ExpenseReport.tsx
@@ -4,6 +4,7 @@ import CategoryModalComponent from '@ses/components/BasicModal/CategoryModalComp
 import Container from '@ses/components/Container/Container';
 import { CustomLink } from '@ses/components/CustomLink/CustomLink';
 import Tabs from '@ses/components/Tabs/Tabs';
+import { ResourceType } from '@ses/core/models/interfaces/types';
 import { MAKER_BURN_LINK } from '@ses/core/utils/const';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
@@ -28,9 +29,10 @@ interface ExpenseReportProps {
   budgetStatements?: BudgetStatement[];
   code: string;
   longCode: string;
+  resource: ResourceType;
 }
 
-const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetStatements, code, longCode }) => {
+const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetStatements, code, longCode, resource }) => {
   const {
     isLight,
     L2SectionInner,
@@ -60,7 +62,9 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
             iconHeight={10}
             marginLeft="7px"
           >
-            {`${code} Core Unit on-chain transaction history`}
+            {`${code} ${
+              resource === ResourceType.CoreUnit ? 'Core Unit' : 'Ecosystem Actor'
+            } on-chain transaction history`}
           </ActualViewOnChainLink>
 
           <BudgetDateTitle isLight={isLight}>{currentMonth.toFormat('MMMM yyyy')} Expense Report</BudgetDateTitle>
@@ -74,6 +78,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
           items={actualsData.mainTableItems}
           cardsTotalPosition="top"
           longCode={longCode}
+          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={code} resource={resource} />}
         />
 
         {actualsData.mainTableItems?.length > 0 && (
@@ -103,7 +108,9 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                   items={actualsData.breakdownItemsForActiveTab}
                   longCode={longCode}
                   cardSpacingSize="small"
-                  tablePlaceholder={<TransparencyEmptyTable breakdown longCode={longCode} />}
+                  tablePlaceholder={
+                    <TransparencyEmptyTable breakdown longCode={longCode} shortCode={code} resource={resource} />
+                  }
                 />
               </BreakdownTableWrapper>
             ) : (
@@ -123,7 +130,12 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                         cardSpacingSize="small"
                         tablePlaceholder={
                           <div style={{ marginTop: 16 }}>
-                            <TransparencyEmptyTable breakdown longCode={longCode} />
+                            <TransparencyEmptyTable
+                              breakdown
+                              longCode={longCode}
+                              shortCode={code}
+                              resource={resource}
+                            />
                           </div>
                         }
                       />
@@ -145,6 +157,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
           items={forecastData.mainTableItems}
           style={{ marginBottom: 32 }}
           cardsTotalPosition={'top'}
+          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={code} resource={resource} />}
         />
 
         {forecastData.mainTableItems?.length > 0 && (
@@ -174,7 +187,9 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                   columns={forecastData.breakdownColumnsForActiveTab}
                   items={forecastData.breakdownItems}
                   cardSpacingSize="small"
-                  tablePlaceholder={<TransparencyEmptyTable breakdown longCode={longCode} />}
+                  tablePlaceholder={
+                    <TransparencyEmptyTable breakdown longCode={longCode} shortCode={code} resource={resource} />
+                  }
                 />
               </BreakdownTableWrapper>
             ) : (
@@ -194,7 +209,12 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                         cardSpacingSize="small"
                         tablePlaceholder={
                           <div style={{ marginTop: 16 }}>
-                            <TransparencyEmptyTable breakdown longCode={longCode} />
+                            <TransparencyEmptyTable
+                              breakdown
+                              longCode={longCode}
+                              shortCode={code}
+                              resource={resource}
+                            />
                           </div>
                         }
                       />
@@ -215,6 +235,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
           columns={mkrVestingData.mainTableColumns}
           items={mkrVestingData.mainTableItems}
           longCode={longCode}
+          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={code} resource={resource} />}
         />
 
         {mkrVestingData.mainTableItems?.length > 0 && (
@@ -231,6 +252,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
           items={transferRequestsData.mainTableItems}
           cardsTotalPosition={'top'}
           longCode={longCode}
+          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={code} resource={resource} />}
         />
       </ExpenseSection>
     </ExpenseReportWrapper>

--- a/src/stories/containers/TransparencyReport/components/Placeholders/TransparencyEmptyTable.tsx
+++ b/src/stories/containers/TransparencyReport/components/Placeholders/TransparencyEmptyTable.tsx
@@ -5,19 +5,20 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { ButtonType } from '@ses/core/enums/buttonTypeEnum';
 import { ResourceType } from '@ses/core/models/interfaces/types';
 import { MAKER_BURN_LINK } from '@ses/core/utils/const';
-import { getShortCode } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 
 interface TransparencyEmptyTableProps {
   breakdown?: boolean;
   longCode: string;
+  shortCode: string;
   resource?: ResourceType;
 }
 
 export const TransparencyEmptyTable: React.FC<TransparencyEmptyTableProps> = ({
   breakdown = false,
   longCode,
+  shortCode,
   resource = ResourceType.CoreUnit,
 }) => {
   const { isLight } = useThemeContext();
@@ -29,11 +30,11 @@ export const TransparencyEmptyTable: React.FC<TransparencyEmptyTableProps> = ({
       title = 'No data reported by the Delegates Administrator';
       break;
     case ResourceType.EcosystemActor:
-      title = `No data reported by ${getShortCode(longCode)} Ecosystem Actor`;
+      title = `No data reported by ${shortCode} Ecosystem Actor`;
       break;
     default:
       // handle as a core unit
-      title = `No data reported by ${getShortCode(longCode)} Core Unit`;
+      title = `No data reported by ${shortCode} Core Unit`;
   }
 
   return (

--- a/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyActuals/TransparencyActuals.tsx
@@ -17,6 +17,7 @@ interface TransparencyActualsProps {
   currentMonth: DateTime;
   budgetStatements?: BudgetStatement[];
   longCode: string;
+  shortCode: string;
   headline: React.ReactNode;
   resource: ResourceType;
 }
@@ -25,6 +26,7 @@ export const TransparencyActuals: React.FC<TransparencyActualsProps> = ({
   currentMonth,
   budgetStatements,
   longCode,
+  shortCode,
   headline,
   resource,
 }) => {
@@ -52,7 +54,7 @@ export const TransparencyActuals: React.FC<TransparencyActualsProps> = ({
         longCode={longCode}
         tablePlaceholder={
           <div style={{ marginBottom: 64 }}>
-            <TransparencyEmptyTable longCode={longCode} resource={resource} />
+            <TransparencyEmptyTable longCode={longCode} shortCode={shortCode} resource={resource} />
           </div>
         }
       />
@@ -82,7 +84,7 @@ export const TransparencyActuals: React.FC<TransparencyActualsProps> = ({
             cardSpacingSize="small"
             tablePlaceholder={
               <div style={{ marginBottom: 64 }}>
-                <TransparencyEmptyTable breakdown longCode={longCode} resource={resource} />
+                <TransparencyEmptyTable breakdown longCode={longCode} shortCode={shortCode} resource={resource} />
               </div>
             }
           />

--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/TransparencyForecast.tsx
@@ -16,6 +16,7 @@ interface TransparencyForecastProps {
   currentMonth: DateTime;
   budgetStatements: BudgetStatement[];
   longCode: string;
+  shortCode: string;
   headline: React.ReactNode;
   resource: ResourceType;
 }
@@ -24,6 +25,7 @@ export const TransparencyForecast: React.FC<TransparencyForecastProps> = ({
   currentMonth,
   budgetStatements,
   longCode,
+  shortCode,
   headline,
   resource,
 }) => {
@@ -50,6 +52,9 @@ export const TransparencyForecast: React.FC<TransparencyForecastProps> = ({
         items={mainTableItems}
         style={{ marginBottom: '64px' }}
         cardsTotalPosition={'top'}
+        tablePlaceholder={
+          <TransparencyEmptyTable breakdown longCode={longCode} shortCode={shortCode} resource={resource} />
+        }
       />
       {!!mainTableItems?.length && (
         <Title isLight={isLight} marginBottom={24} ref={breakdownTitleRef}>
@@ -74,7 +79,9 @@ export const TransparencyForecast: React.FC<TransparencyForecastProps> = ({
             columns={breakdownColumnsForActiveTab}
             items={breakdownItems}
             cardSpacingSize="small"
-            tablePlaceholder={<TransparencyEmptyTable breakdown longCode={longCode} resource={resource} />}
+            tablePlaceholder={
+              <TransparencyEmptyTable breakdown longCode={longCode} shortCode={shortCode} resource={resource} />
+            }
           />
         </BreakdownTableWrapper>
       )}

--- a/src/stories/containers/TransparencyReport/components/TransparencyMkrVesting/TransparencyMkrVesting.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyMkrVesting/TransparencyMkrVesting.tsx
@@ -15,6 +15,7 @@ interface TransparencyMkrVestingProps {
   currentMonth: DateTime;
   budgetStatements: BudgetStatement[];
   longCode: string;
+  shortCode: string;
   headline: React.ReactNode;
   resource: ResourceType;
 }
@@ -23,6 +24,7 @@ export const TransparencyMkrVesting: React.FC<TransparencyMkrVestingProps> = ({
   currentMonth,
   budgetStatements,
   longCode,
+  shortCode,
   headline,
   resource,
 }) => {
@@ -42,7 +44,7 @@ export const TransparencyMkrVesting: React.FC<TransparencyMkrVestingProps> = ({
         columns={mainTableColumns}
         items={mainTableItems}
         longCode={longCode}
-        tablePlaceholder={<TransparencyEmptyTable longCode={longCode} resource={resource} />}
+        tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={shortCode} resource={resource} />}
       />
       {mainTableItems.length > 0 && (
         <MkrInfoContainer>

--- a/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/TransparencyTransferRequest.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyTransferRequest/TransparencyTransferRequest.tsx
@@ -13,6 +13,7 @@ interface TransparencyTransferRequestProps {
   currentMonth: DateTime;
   budgetStatements: BudgetStatement[];
   longCode: string;
+  shortCode: string;
   headline: React.ReactNode;
   resource: ResourceType;
 }
@@ -21,6 +22,7 @@ export const TransparencyTransferRequest: React.FC<TransparencyTransferRequestPr
   currentMonth,
   budgetStatements,
   longCode,
+  shortCode,
   headline,
   resource,
 }) => {
@@ -39,7 +41,7 @@ export const TransparencyTransferRequest: React.FC<TransparencyTransferRequestPr
           style={{ marginBottom: '64px' }}
           cardsTotalPosition={'top'}
           longCode={longCode}
-          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} resource={resource} />}
+          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={shortCode} resource={resource} />}
         />
       </div>
     </Container>


### PR DESCRIPTION
# Ticket
https://trello.com/c/KT93qSRs/288-user-story-ability-to-view-ecosystem-actor-expense-reports

# Description
Fix the issues

# What solved
- [X] When there is no data to show, a message should be displayed including the ecosystem actor shortcode.
- [X] The "Visit makerburn.com view the... " text should have the same shortcode in all tabs of this view.  **Current Output:** The Auditor view takes a different value than the rest of the tabs.
- [X] When there is no data to show, a message should be displayed referring to Ecosystem Actor after the shortcode.