### PR TITLE
[SES-268] Show modal sheet on real mobile devices

### DIFF
--- a/src/core/hooks/useMobileDetector.ts
+++ b/src/core/hooks/useMobileDetector.ts
@@ -1,0 +1,14 @@
+import MobileDetect from 'mobile-detect';
+import { useMemo } from 'react';
+
+const useMobileDetector = () => {
+  const mobileDetector = useMemo(() => {
+    if (typeof window !== 'undefined') {
+      return new MobileDetect(window.navigator?.userAgent);
+    }
+  }, []);
+
+  return mobileDetector;
+};
+
+export default useMobileDetector;

--- a/src/stories/components/CustomPopover/CustomPopover.tsx
+++ b/src/stories/components/CustomPopover/CustomPopover.tsx
@@ -127,6 +127,9 @@ const ArrowUp = {
   horizontal: 'left',
 };
 
+/**
+ * @deprecated use `SESTooltip` instead
+ */
 export const CustomPopover = ({
   leaveOnChildrenMouseOut = false,
   popoverStyle,

--- a/src/stories/components/SESTooltip/ModalBottomSheet.tsx
+++ b/src/stories/components/SESTooltip/ModalBottomSheet.tsx
@@ -1,0 +1,72 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { zIndexEnum } from '@ses/core/enums/zIndexEnum';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface ModalBottomSheetProps extends React.PropsWithChildren {
+  open: boolean;
+  content: React.ReactNode;
+  handleOpen: () => void;
+  handleClose: () => void;
+}
+
+const ModalBottomSheet: React.FC<ModalBottomSheetProps> = ({ children, content, open, handleOpen, handleClose }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <>
+      {React.cloneElement(children as React.ReactElement, {
+        onClick: handleOpen,
+      })}
+
+      {open && (
+        <>
+          <Overlay isLight={isLight} onClick={handleClose} />
+          <ModalSheet>
+            <Container isLight={isLight}>{content}</Container>
+          </ModalSheet>
+        </>
+      )}
+    </>
+  );
+};
+
+export default ModalBottomSheet;
+
+const Overlay = styled.div<WithIsLight>(({ isLight }) => ({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  background: isLight ? 'rgba(52, 52, 66, 0.1)' : 'rgba(0, 22, 78, 0.1);',
+  backdropFilter: isLight ? 'blur(2px)' : 'blur(4px)',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  zIndex: zIndexEnum.OVERLAY_MOBILE_TOOLTIP,
+}));
+
+const ModalSheet = styled.div({
+  width: '100%',
+  zIndex: 5,
+  textAlign: 'left',
+  position: 'fixed',
+  bottom: 0,
+  left: 0,
+  right: 0,
+});
+
+const Container = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'flex-start',
+  background: isLight ? 'white' : '#000A13',
+  border: isLight ? '1px solid #D4D9E1' : '1px solid #231536',
+  boxShadow: isLight
+    ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
+    : '10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
+  borderRadius: '22px 22px 0px 0px',
+  padding: 16,
+}));

--- a/src/stories/components/SESTooltip/SESTooltip.stories.tsx
+++ b/src/stories/components/SESTooltip/SESTooltip.stories.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { tooltipClasses } from '@mui/material/Tooltip';
+import { withThemeContext } from '@ses/core/utils/storybook/decorators';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import React from 'react';
 import SESTooltip from './SESTooltip';
@@ -23,6 +24,7 @@ const ALIGNMENTS = [
 export default {
   title: 'Components/General/SESTooltip',
   component: SESTooltip,
+  decorators: [withThemeContext(true, false)],
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -33,6 +35,10 @@ export default {
         options: ALIGNMENTS,
       },
       defaultValue: 'bottom-start',
+    },
+    arrow: {
+      type: 'boolean',
+      defaultValue: false,
     },
   },
 } as ComponentMeta<typeof SESTooltip>;
@@ -151,6 +157,16 @@ DelayedClose.args = {
 export const NonInteractive = getCustomBtnTemplate('Non-interactive').bind({});
 NonInteractive.args = {
   disableInteractive: true,
+};
+
+/**
+ * The tooltip can be set to be opened as a modal bottom sheet on mobile devices by setting the
+ * showAsModalBottomSheet prop to true. This prop is ignored on tablet or desktop devices even if it
+ * has mobile resolutions.
+ */
+export const ModalBottomSheet = getCustomBtnTemplate('Open as Modal Bottom (real mobile only)').bind({});
+ModalBottomSheet.args = {
+  showAsModalBottomSheet: true,
 };
 
 export const [[withArrowLight, withArrowDark]] = createThemeModeVariants(getCustomBtnTemplate('With Arrow'), [


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Allow showing the tooltips as a modal bottom sheet in real mobile devices

# Important
The `CustomPopover` component was marked as deprecated in favor of `SESTooltip`

# What solved
- [X] Should allow showing a modal sheet instead the popover on real mobile devices