### PR TITLE
[SES-268] Add tooltips in the Account Snapshot tab

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -39,7 +39,11 @@ const CUReserves: React.FC<CUReservesProps> = ({
         <SectionHeader
           title="Total Core Unit Reserves"
           subtitle={`On-chain and off-chain reserves accessible${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
-          tooltip={'pending...'}
+          tooltip={
+            'Explore on and off-chain balances in DAI and other currencies, identify the flow of funds and track the \
+             total inflow from the Maker Protocol to internal operational wallets, as well as the outflow to external \
+             wallets (e.g., Payment Processor) wallets.'
+          }
         />
         {!!offChainData?.length && (
           <CheckContainer isLight={isLight}>
@@ -82,7 +86,11 @@ const CUReserves: React.FC<CUReservesProps> = ({
         <SectionHeader
           title="On Chain Reserves"
           subtitle={`Unspent on-chain reserves${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
-          tooltip={'pending...'}
+          tooltip={
+            <>
+              Track and analyze the movement of <br /> on-chain assets.
+            </>
+          }
           isSubsection
         />
 
@@ -98,7 +106,12 @@ const CUReserves: React.FC<CUReservesProps> = ({
           <SectionHeader
             title="Off Chain Reserves"
             subtitle={`Unspent off-chain reserves${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
-            tooltip={'pending...'}
+            tooltip={
+              <>
+                Discover essential details about the <br />
+                off-chain balances.
+              </>
+            }
             isSubsection
           />
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
@@ -20,7 +20,10 @@ const ExpensesComparison: React.FC<ExpensesComparisonProps> = ({ rows, hasOffCha
       <SectionHeader
         title="Reported Expenses Comparison"
         subtitle={'Reported actuals compared to expense and revenue transactions.'}
-        tooltip={'pending...'}
+        tooltip={
+          'Understand the differences between reported and net transactions. Easily spot variations \
+          and improve financial tracking for comprehensive expense  and revenue analysis.'
+        }
       />
 
       <TableWrapper>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/headers.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/headers.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
+import SESTooltip from '@ses/components/SESTooltip/SESTooltip';
 import Information from '@ses/components/svg/information';
 import lightTheme from '@ses/styles/theme/light';
 import type { RowProps } from '@ses/components/AdvanceTable/types';
@@ -15,12 +16,27 @@ const HeaderWithIcon = styled.div({
   },
 });
 
+const InfoWrapper = styled.div({
+  display: 'flex',
+  cursor: 'pointer',
+});
+
 const NetExpenseTransactions = () => {
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
 
   return (
     <HeaderWithIcon>
-      Net {isMobile ? 'Exp' : 'Expense'} transactions <Information />
+      Net {isMobile ? 'Exp' : 'Expense'} transactions
+      <SESTooltip
+        content={
+          'On-chain view offers valuable insights into on-chain dynamics, but excludes external (off-chain) transactions.'
+        }
+        placement="bottom-start"
+      >
+        <InfoWrapper>
+          <Information />
+        </InfoWrapper>
+      </SESTooltip>
     </HeaderWithIcon>
   );
 };
@@ -82,7 +98,17 @@ export const EXPENSES_COMPARISON_TABLE_HEADER = [
       {
         value: (
           <HeaderWithIcon>
-            On-Chain Only <Information />
+            On-Chain Only
+            <SESTooltip
+              content={
+                'On-chain view offers valuable insights into on-chain dynamics, but excludes external (off-chain) transactions.'
+              }
+              placement="bottom-start"
+            >
+              <InfoWrapper>
+                <Information />
+              </InfoWrapper>
+            </SESTooltip>
           </HeaderWithIcon>
         ),
         alignment: 'right',
@@ -109,7 +135,15 @@ export const EXPENSES_COMPARISON_TABLE_HEADER = [
       {
         value: (
           <HeaderWithIcon>
-            Including off-chain <Information />
+            Including off-chain
+            <SESTooltip
+              content={'Enhance financial tracking and expense analysis by including off-chain transactions.'}
+              placement="bottom-start"
+            >
+              <InfoWrapper>
+                <Information />
+              </InfoWrapper>
+            </SESTooltip>
           </HeaderWithIcon>
         ),
         alignment: 'right',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -37,7 +37,10 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({
         subtitle={`Totals funds made available ${
           snapshotOwner ? `to the ${snapshotOwner}` : ''
         } over its entire lifetime${startDate ? `, since ${DateTime.fromISO(startDate).toFormat('LLLL yyyy')}` : ''}.`}
-        tooltip={'pending...'}
+        tooltip={
+          'Monitor funds made available to Core Units, track spending, returns, and reserves, differentiate internal/external \
+          transactions, and gain insights into changes in MakerDAO’s Lifetime Balances.'
+        }
       />
       {enableCurrencyPicker && <CurrencyPicker />}
     </HeaderContainer>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
-import { CustomPopover } from '@ses/components/CustomPopover/CustomPopover';
+import SESTooltip from '@ses/components/SESTooltip/SESTooltip';
 import Information from '@ses/components/svg/information';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { toKebabCase } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -10,7 +9,7 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 interface SectionHeaderProps {
   title: string;
   subtitle: string;
-  tooltip?: string;
+  tooltip?: React.ReactNode;
   isSubsection?: boolean;
 }
 
@@ -24,11 +23,11 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({ title, subtitle, tooltip,
           {title}
         </Title>
         {tooltip && (
-          <CustomPopover id={toKebabCase(title)} title={tooltip}>
+          <SESTooltip content={tooltip} placement="bottom-start">
             <IconWrapper>
               <Information />
             </IconWrapper>
-          </CustomPopover>
+          </SESTooltip>
         )}
       </TitleWrapper>
       <Subtitle isLight={isLight}>{subtitle}</Subtitle>


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Added tooltips content to the Account Snapshot sections

# What solved
- [X] Should add the tooltip contents to the sections