### PR TITLE
[SES-268] Expense reporting logic improvements

### DIFF
--- a/src/core/hooks/useTransparencyReportingTabs.tsx
+++ b/src/core/hooks/useTransparencyReportingTabs.tsx
@@ -56,6 +56,7 @@ const useTransparencyReportingTabs = ({
 
   // tabs to shown when the tabs is expanded
   const tabItems: TableItems[] = [
+    ...(isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') ? [accountsSnapshotTab] : []),
     {
       item: 'Actuals',
       id: TRANSPARENCY_IDS_ENUM.ACTUALS,
@@ -76,7 +77,6 @@ const useTransparencyReportingTabs = ({
       item: 'Transfer Requests',
       id: TRANSPARENCY_IDS_ENUM.TRANSFER_REQUESTS,
     },
-    ...(isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') ? [accountsSnapshotTab] : []),
     ...(isEnabled('FEATURE_AUDIT_REPORTS')
       ? [
           {
@@ -90,11 +90,11 @@ const useTransparencyReportingTabs = ({
 
   // tabs to shown when the tabs is collapsed/compressed
   const compressedTabItems: TableItems[] = [
+    ...(isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') ? [accountsSnapshotTab] : []),
     {
       item: 'Expense Report',
       id: TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT,
     },
-    ...(isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') ? [accountsSnapshotTab] : []),
     ...(isEnabled('FEATURE_TRANSPARENCY_COMMENTS') ? [commentTab] : []),
   ];
 

--- a/src/stories/containers/ActorsTransparencyReport/useActorsTransparencyReport.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/useActorsTransparencyReport.tsx
@@ -18,10 +18,12 @@ const useActorsTransparencyReport = (actor: Team) => {
       switch (query?.section) {
         case TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS:
           return TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS;
+        case TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT:
+          return TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT;
         case TRANSPARENCY_IDS_ENUM.COMMENTS:
           return TRANSPARENCY_IDS_ENUM.COMMENTS;
         default:
-          return TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT;
+          return TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS;
       }
     } else {
       // default
@@ -41,7 +43,7 @@ const useActorsTransparencyReport = (actor: Team) => {
         case TRANSPARENCY_IDS_ENUM.COMMENTS:
           return TRANSPARENCY_IDS_ENUM.COMMENTS;
         default:
-          return TRANSPARENCY_IDS_ENUM.ACTUALS;
+          return TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS;
       }
     }
   }, [query?.section, query?.view]);

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -45,7 +45,8 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
   const {
     tabItems,
     code,
-    transparencyTableRef,
+    longCode,
+    pagerRef,
     currentMonth,
     handlePreviousMonth,
     handleNextMonth,
@@ -54,7 +55,6 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
     currentBudgetStatement,
     tabsIndex,
     lastUpdateForBudgetStatement,
-    longCode,
     comments,
     showExpenseReportStatusCTA,
     lastVisitHandler,
@@ -88,7 +88,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
               budgetStatus={currentBudgetStatement?.status || BudgetStatus.Draft}
               showExpenseReportStatusCTA={showExpenseReportStatusCTA}
               lastUpdate={lastUpdateForBudgetStatement}
-              ref={transparencyTableRef}
+              ref={pagerRef}
             />
 
             <TabsContainer>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -34,9 +34,19 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({
     <HeaderContainer>
       <SectionHeader
         title="MakerDAO Funding Overview"
-        subtitle={`Totals funds made available ${
-          snapshotOwner ? `to the ${snapshotOwner}` : ''
-        } over its entire lifetime${startDate ? `, since ${DateTime.fromISO(startDate).toFormat('LLLL yyyy')}` : ''}.`}
+        subtitle={
+          <>
+            Totals funds made available {snapshotOwner ? `to the ${snapshotOwner}` : ''} over its entire lifetime
+            {startDate ? (
+              <>
+                , since <b>{DateTime.fromISO(startDate).toFormat('LLLL yyyy')}</b>
+              </>
+            ) : (
+              ''
+            )}
+            .
+          </>
+        }
         tooltip={
           'Monitor funds made available to Core Units, track spending, returns, and reserves, differentiate internal/external \
           transactions, and gain insights into changes in MakerDAO’s Lifetime Balances.'
@@ -61,7 +71,7 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({
         leftText="Extra Funds Made Available"
         rightValue={balance?.inflow}
         rightValueColor="green"
-        rightText="Funds Returned via DSSBlow"
+        rightText="Funds Returned"
       />
       <SimpleStatCard
         date={endDate}

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -8,7 +8,7 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface SectionHeaderProps {
   title: string;
-  subtitle: string;
+  subtitle: React.ReactNode;
   tooltip?: React.ReactNode;
   isSubsection?: boolean;
 }

--- a/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
@@ -1,21 +1,8 @@
-import CommentsTab from '@ses/components/Tabs/CommentsTab/CommentsTab';
-import { getLastUpdateForBudgetStatement } from '@ses/core/businessLogic/coreUnits';
-import { useAuthContext } from '@ses/core/context/AuthContext';
-import { useCookiesContextTracking } from '@ses/core/context/CookiesContext';
-import useBudgetStatementComments from '@ses/core/hooks/useBudgetStatementComments';
-import useBudgetStatementPager from '@ses/core/hooks/useBudgetStatementPager';
 import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
-import { BudgetStatus } from '@ses/core/models/dto/coreUnitDTO';
-import { budgetStatementCommentsCollectionId } from '@ses/core/utils/collectionsIds';
-import { LastVisitHandler } from '@ses/core/utils/lastVisitHandler';
-import { removeEmptyProperties } from '@ses/core/utils/urls';
-import UserActivityManager from '@ses/core/utils/userActivity';
-import { DateTime } from 'luxon';
+import useTransparencyReporting from '@ses/core/hooks/useTransparencyReporting';
+import useTransparencyReportingTabs from '@ses/core/hooks/useTransparencyReportingTabs';
 import { useRouter } from 'next/router';
-import { useRef, useState, useEffect, useCallback, useMemo } from 'react';
-import { AUDITOR_VIEW_STORAGE_COLLECTION_KEY } from './utils/constants';
-import type { TableItems } from './TransparencyReport';
-import type { InternalTabsProps } from '@ses/components/Tabs/Tabs';
+import { useCallback } from 'react';
 import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
 
 export enum TRANSPARENCY_IDS_ENUM {
@@ -32,22 +19,21 @@ export enum TRANSPARENCY_IDS_ENUM {
 export const useTransparencyReport = (coreUnit: CoreUnit) => {
   const router = useRouter();
   const query = router.query;
-  const code = query.code as string;
-  const transparencyTableRef = useRef<HTMLDivElement>(null);
-  const { permissionManager } = useAuthContext();
-  const { isTimestampTrackingAccepted } = useCookiesContextTracking();
+  const [isEnabled] = useFlagsActive();
 
-  const [tabsIndex, setTabsIndex] = useState<TRANSPARENCY_IDS_ENUM>(() => {
+  const initTabIndex = useCallback(() => {
     // initialize quickly the correct tab to avoid tab flickering
     const view = query?.view ?? 'default';
     if (view === 'auditor') {
       switch (query?.section) {
         case TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS:
           return TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS;
+        case TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT:
+          return TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT;
         case TRANSPARENCY_IDS_ENUM.COMMENTS:
           return TRANSPARENCY_IDS_ENUM.COMMENTS;
         default:
-          return TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT;
+          return TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS;
       }
     } else {
       // default
@@ -67,216 +53,61 @@ export const useTransparencyReport = (coreUnit: CoreUnit) => {
         case TRANSPARENCY_IDS_ENUM.COMMENTS:
           return TRANSPARENCY_IDS_ENUM.COMMENTS;
         default:
-          return TRANSPARENCY_IDS_ENUM.ACTUALS;
+          return TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS;
       }
     }
+  }, [query?.section, query?.view]);
+
+  const {
+    pagerRef,
+    tabsIndex,
+    setTabsIndex,
+    lastVisitHandler,
+    currentBudgetStatement,
+    currentMonth,
+    handleNextMonth,
+    handlePreviousMonth,
+    hasNextMonth,
+    hasPreviousMonth,
+    lastUpdateForBudgetStatement,
+    showExpenseReportStatusCTA,
+    comments,
+    commentsLastVisitState,
+    numbersComments,
+    updateHasNewComments,
+  } = useTransparencyReporting<TRANSPARENCY_IDS_ENUM>(coreUnit, {
+    commentTabId: TRANSPARENCY_IDS_ENUM.COMMENTS,
+    initTabIndex,
   });
 
-  const [lastVisitHandler, setLastVisitHandler] = useState<LastVisitHandler>();
-
-  const onPrevious = useCallback(() => {
-    if (tabsIndex === TRANSPARENCY_IDS_ENUM.COMMENTS) {
-      lastVisitHandler?.visit(); // mark the current budget statement as visited before leave
-    }
-  }, [lastVisitHandler, tabsIndex]);
-
-  const onNext = useCallback(() => {
-    if (tabsIndex === TRANSPARENCY_IDS_ENUM.COMMENTS) {
-      lastVisitHandler?.visit(); // mark the current budget statement as visited before leave
-    }
-  }, [lastVisitHandler, tabsIndex]);
-
-  const { currentMonth, currentBudgetStatement, handleNextMonth, handlePreviousMonth, hasNextMonth, hasPreviousMonth } =
-    useBudgetStatementPager(coreUnit, {
-      onNext,
-      onPrevious,
-    });
-
-  useEffect(() => {
-    // update lastVisitHandler for the current budgetStatement
-    if (currentBudgetStatement) {
-      setLastVisitHandler(
-        new LastVisitHandler(budgetStatementCommentsCollectionId(currentBudgetStatement.id), permissionManager)
-      );
-    }
-  }, [currentBudgetStatement, permissionManager]);
-
-  const longCode = coreUnit?.code;
-
-  const lastUpdateForBudgetStatement = useMemo(
-    () => getLastUpdateForBudgetStatement(coreUnit, currentBudgetStatement?.id ?? '0'),
-    [currentBudgetStatement, coreUnit]
-  );
-
-  const [showExpenseReportStatusCTA, setShowExpenseReportStatusCTA] = useState<boolean>(false);
-  useEffect(() => {
-    switch (currentBudgetStatement?.status) {
-      case BudgetStatus.Draft:
-        if (!coreUnit.auditors?.length) {
-          setShowExpenseReportStatusCTA(false);
-          break;
-        }
-        setShowExpenseReportStatusCTA(permissionManager.coreUnit.isCoreUnitAdmin(coreUnit));
-        break;
-      case BudgetStatus.Review:
-      case BudgetStatus.Escalated:
-        setShowExpenseReportStatusCTA(permissionManager.coreUnit.isAuditor(coreUnit));
-        break;
-      default:
-        setShowExpenseReportStatusCTA(false);
-    }
-  }, [coreUnit, currentBudgetStatement, permissionManager]);
-
-  const { comments, numbersComments, commentsLastVisitState, updateHasNewComments } = useBudgetStatementComments(
-    currentBudgetStatement,
+  const { tabItems, compressedTabItems, onTabChange, onTabsExpand, onTabsInit } = useTransparencyReportingTabs({
+    commentsLastVisitState,
+    numbersComments,
+    updateHasNewComments,
     lastVisitHandler,
-    tabsIndex === TRANSPARENCY_IDS_ENUM.COMMENTS
-  );
-
-  const [isEnabled] = useFlagsActive();
-  const accountsSnapshotTab = {
-    item: 'Accounts Snapshot',
-    id: TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS,
-  };
-  const commentTab = {
-    item: (
-      <CommentsTab
-        hasNewComments={!commentsLastVisitState.isFetching && commentsLastVisitState.hasNewComments}
-        numbersComments={numbersComments}
-      />
-    ),
-    id: TRANSPARENCY_IDS_ENUM.COMMENTS,
-  };
-  const tabItems: TableItems[] = [
-    {
-      item: 'Actuals',
-      id: TRANSPARENCY_IDS_ENUM.ACTUALS,
-    },
-    {
-      item: 'Forecast',
-      id: TRANSPARENCY_IDS_ENUM.FORECAST,
-    },
-    ...(isEnabled('FEATURE_MKR_VESTING')
-      ? [
-          {
-            item: 'MKR Vesting',
-            id: TRANSPARENCY_IDS_ENUM.MKR_VESTING,
-          },
-        ]
-      : []),
-    {
-      item: 'Transfer Requests',
-      id: TRANSPARENCY_IDS_ENUM.TRANSFER_REQUESTS,
-    },
-    ...(isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') ? [accountsSnapshotTab] : []),
-    ...(isEnabled('FEATURE_AUDIT_REPORTS')
-      ? [
-          {
-            item: 'Audit Reports',
-            id: TRANSPARENCY_IDS_ENUM.AUDIT_REPORTS,
-          },
-        ]
-      : []),
-    ...(isEnabled('FEATURE_TRANSPARENCY_COMMENTS') ? [commentTab] : []),
-  ];
-
-  const compressedTabItems: TableItems[] = [
-    {
-      item: 'Expense Report',
-      id: TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT,
-    },
-    ...(isEnabled('FEATURE_ACCOUNTS_SNAPSHOT') ? [accountsSnapshotTab] : []),
-    commentTab,
-  ];
-
-  const onTabChange = useCallback(
-    (current?: string, previous?: string) => {
-      // changing from "comments tab" to any other tab should mark the budget statement as visited
-      if (isTimestampTrackingAccepted && previous === TRANSPARENCY_IDS_ENUM.COMMENTS) {
-        const visit = async () => {
-          const lastVisit = (await lastVisitHandler?.visit()) || DateTime.now().toMillis();
-          await updateHasNewComments(DateTime.fromMillis(lastVisit));
-        };
-        visit();
-      }
-      setTabsIndex(current as TRANSPARENCY_IDS_ENUM);
-    },
-    [isTimestampTrackingAccepted, lastVisitHandler, updateHasNewComments]
-  );
-
-  interface AuditorViewStoragePayload {
-    isAuditorViewEnabled: boolean;
-  }
-  const onTabsExpand = useCallback(
-    // save the auditor view status on the storage/server
-    async (isExpanded: boolean) => {
-      if (isTimestampTrackingAccepted) {
-        const manager = new UserActivityManager(permissionManager);
-        await manager.create({
-          userId: permissionManager.loggedUser?.id || '',
-          collection: AUDITOR_VIEW_STORAGE_COLLECTION_KEY,
-          data: {
-            isAuditorViewEnabled: !isExpanded,
-          },
-        });
-      }
-    },
-    [isTimestampTrackingAccepted, permissionManager]
-  );
-
-  // restore the auditor view status from the storage/server if needed
-  const [handleTabsExpand, setHandleTabsExpand] = useState<InternalTabsProps['setExpanded'] | undefined>();
-  const onTabsInit = useCallback(({ setExpanded }: InternalTabsProps) => {
-    setHandleTabsExpand(() => setExpanded);
-  }, []);
-
-  useEffect(() => {
-    const restoreAuditorViewFunction = async () => {
-      // restore the auditor view status form the storage/server if needed
-      // the auditor view status in the query param has priority over the stored value
-      if (!query.view && handleTabsExpand && isTimestampTrackingAccepted) {
-        const manager = new UserActivityManager(permissionManager);
-        const result = await manager.getLastActivity(AUDITOR_VIEW_STORAGE_COLLECTION_KEY);
-        if ((result?.data as AuditorViewStoragePayload)?.isAuditorViewEnabled) {
-          // activate the auditor view
-          handleTabsExpand(false);
-          router.replace(
-            {
-              pathname: router.pathname,
-              query: {
-                ...removeEmptyProperties(router.query),
-                view: 'auditor',
-              },
-            },
-            undefined,
-            { shallow: true }
-          );
-          setTabsIndex(TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT);
-        }
-      }
-    };
-    restoreAuditorViewFunction();
-  }, [handleTabsExpand, isTimestampTrackingAccepted, permissionManager, query.view, router]);
+    setTabsIndex,
+  });
 
   return {
-    tabItems,
-    code,
-    transparencyTableRef,
-    currentMonth,
-    handlePreviousMonth,
-    handleNextMonth,
-    hasNextMonth,
-    currentBudgetStatement,
+    isEnabled,
+    pagerRef,
     tabsIndex,
-    showExpenseReportStatusCTA,
-    lastUpdateForBudgetStatement,
-    longCode,
+    currentMonth,
+    currentBudgetStatement,
+    handleNextMonth,
+    handlePreviousMonth,
+    hasNextMonth,
     hasPreviousMonth,
-    comments,
-    lastVisitHandler,
-    onTabsInit,
-    onTabChange,
-    onTabsExpand,
+    lastUpdateForBudgetStatement,
+    showExpenseReportStatusCTA,
+    tabItems,
     compressedTabItems,
+    onTabsInit,
+    onTabsExpand,
+    onTabChange,
+    lastVisitHandler,
+    comments,
+    code: coreUnit.shortCode,
+    longCode: coreUnit.code,
   };
 };


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
A few improvements in the Account snapshot tab were made. The whole logic of the expense reporting pages is now fully reutilizable through hooks

# What solved
- [X] Remove the "via DSSBlow" text from the Funds Returned card.
- [X] The Snapshot Accounts should be displayed as the first tab and selected by default. 
- [X] The "since month" should be bolded. 