### PR TITLE
[SES-268] Fix issues on Account snapshot 

### DIFF
--- a/src/core/businessLogic/builders/accountSnapshot/snapshotAccountTransactionBuilder.ts
+++ b/src/core/businessLogic/builders/accountSnapshot/snapshotAccountTransactionBuilder.ts
@@ -31,6 +31,11 @@ export class SnapshotAccountTransactionBuilder {
     return this;
   }
 
+  withTxLabel(txLabel: string): SnapshotAccountTransactionBuilder {
+    this._snapshotAccountTransaction.txLabel = txLabel;
+    return this;
+  }
+
   withToken(token: Token): SnapshotAccountTransactionBuilder {
     this._snapshotAccountTransaction.token = token;
     return this;

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.stories.tsx
@@ -155,13 +155,13 @@ WithSingularLightMode.parameters = {
   figma: {
     component: {
       0: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18675%3A210832',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18698:216049',
         options: {
           componentStyle: {
             width: 343,
           },
           style: {
-            top: 0,
+            top: -20,
             left: -40,
           },
         },
@@ -171,6 +171,42 @@ WithSingularLightMode.parameters = {
         options: {
           componentStyle: {
             width: 770,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1194: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19866:244466',
+        options: {
+          componentStyle: {
+            width: 1130,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1280: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19865:238757',
+        options: {
+          componentStyle: {
+            width: 1184,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20719:254463',
+        options: {
+          componentStyle: {
+            width: 1312,
           },
           style: {
             top: -20,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.stories.tsx
@@ -217,3 +217,70 @@ WithSingularLightMode.parameters = {
     },
   } as FigmaParams,
 };
+
+WithGroupLightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18698:215790',
+        options: {
+          componentStyle: {
+            width: 343,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      834: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19867:248234',
+        options: {
+          componentStyle: {
+            width: 770,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1194: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19866:244404',
+        options: {
+          componentStyle: {
+            width: 1130,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1280: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19865:238695',
+        options: {
+          componentStyle: {
+            width: 1184,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20719:254401',
+        options: {
+          componentStyle: {
+            width: 1312,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.stories.tsx
@@ -1,0 +1,183 @@
+import { SnapshotAccountBuilder } from '@ses/core/businessLogic/builders/accountSnapshot/accountSnapshotBuilder';
+import { SnapshotAccountBalanceBuilder } from '@ses/core/businessLogic/builders/accountSnapshot/snapshotAccountBalanceBuilder';
+import { SnapshotAccountTransactionBuilder } from '@ses/core/businessLogic/builders/accountSnapshot/snapshotAccountTransactionBuilder';
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import ReserveCard from './ReserveCard';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/CUTransparencyReport/Accounts Snapshot/Reserve Card',
+  component: ReserveCard,
+} as ComponentMeta<typeof ReserveCard>;
+
+const variantsArgs = [
+  {
+    account: new SnapshotAccountBuilder()
+      .withId('1')
+      .withAccountLabel('Auditor')
+      .withAccountAddress('0x232b6335224ae8482')
+      .withAccountType('singular')
+      .addSnapshotAccountBalance(
+        new SnapshotAccountBalanceBuilder()
+          .withInitialBalance(500000)
+          .withNewBalance(550000)
+          .withInflow(300000)
+          .withOutflow(-250000)
+          .build()
+      )
+      .addSnapshotAccountTransaction(
+        new SnapshotAccountTransactionBuilder()
+          .withAmount(300000)
+          .withCounterParty('0x232b56628482')
+          .withCounterPartyName('DSS Vest')
+          .withTimestamp('2023-03-29T14:45:00Z')
+          .withToken('DAI')
+          .withTxHash('0xe079d59dbf813d54875aec552a')
+          .withTxLabel('Top up (Internal)')
+          .build()
+      )
+      .addSnapshotAccountTransaction(
+        new SnapshotAccountTransactionBuilder()
+          .withAmount(-250000)
+          .withCounterParty('0x232b56628482')
+          .withCounterPartyName('Operational Wallet')
+          .withTimestamp('2023-03-28T11:41:00Z')
+          .withToken('DAI')
+          .withTxHash('0xe079d59dbf813d54875aec552a')
+          .withTxLabel('Top up')
+          .build()
+      )
+      .build(),
+    currency: 'DAI',
+    defaultExpanded: true,
+  },
+  {
+    account: {
+      ...new SnapshotAccountBuilder()
+        .withId('1')
+        .withAccountLabel('DSS Vest')
+        .withAccountType('group')
+        .addSnapshotAccountBalance(
+          new SnapshotAccountBalanceBuilder()
+            .withInitialBalance(100000)
+            .withNewBalance(100000)
+            .withInflow(300000)
+            .withOutflow(-300000)
+            .build()
+        )
+
+        .build(),
+      children: [
+        new SnapshotAccountBuilder()
+          .withId('2')
+          .withAccountLabel('Stream #13')
+          .withAccountAddress('0x232b5454ae48482')
+          .withAccountType('singular')
+          .addSnapshotAccountBalance(
+            new SnapshotAccountBalanceBuilder()
+              .withInitialBalance(153480)
+              .withNewBalance(153480)
+              .withInflow(150000)
+              .withOutflow(-50000)
+              .build()
+          )
+          .addSnapshotAccountTransaction(
+            new SnapshotAccountTransactionBuilder()
+              .withAmount(300000)
+              .withCounterParty('0x232b56628482')
+              .withCounterPartyName('Maker Protocol')
+              .withTimestamp('2023-04-17T11:36:00Z')
+              .withToken('DAI')
+              .withTxHash('0xe079d59dbf813d54875aec552a')
+              .withTxLabel('Top up (Internal)')
+              .build()
+          )
+          .addSnapshotAccountTransaction(
+            new SnapshotAccountTransactionBuilder()
+              .withAmount(-300000)
+              .withCounterParty('0x232b56628482')
+              .withCounterPartyName('Auditor Wallet')
+              .withTimestamp('2023-04-15T10:05:00Z')
+              .withToken('DAI')
+              .withTxHash('0xe079d59dbf813d54875aec552a')
+              .withTxLabel('Top up')
+              .build()
+          )
+          .build(),
+        new SnapshotAccountBuilder()
+          .withId('2')
+          .withAccountLabel('Stream #14')
+          .withAccountAddress('0x232b5454ae48482')
+          .withAccountType('singular')
+          .addSnapshotAccountBalance(
+            new SnapshotAccountBalanceBuilder()
+              .withInitialBalance(153480)
+              .withNewBalance(153480)
+              .withInflow(150000)
+              .withOutflow(-50000)
+              .build()
+          )
+          .addSnapshotAccountTransaction(
+            new SnapshotAccountTransactionBuilder()
+              .withAmount(300000)
+              .withCounterParty('0x232b56628482')
+              .withCounterPartyName('Maker Protocol')
+              .withTimestamp('2023-03-28T17:32:00Z')
+              .withToken('DAI')
+              .withTxHash('0xe079d59dbf813d54875aec552a')
+              .withTxLabel('Top up (Internal)')
+              .build()
+          )
+          .addSnapshotAccountTransaction(
+            new SnapshotAccountTransactionBuilder()
+              .withAmount(-300000)
+              .withCounterParty('0x232b56628482')
+              .withCounterPartyName('Auditor Wallet')
+              .withTimestamp('2023-03-28T09:45:00Z')
+              .withToken('DAI')
+              .withTxHash('0xe079d59dbf813d54875aec552a')
+              .withTxLabel('Top up')
+              .build()
+          )
+          .build(),
+      ],
+    },
+    currency: 'DAI',
+    defaultExpanded: true,
+  },
+];
+
+export const [[WithSingularLightMode, WithSingularDarkMode], [WithGroupLightMode, WithGroupDarkMode]] =
+  createThemeModeVariants(ReserveCard, variantsArgs);
+
+WithSingularLightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18675%3A210832',
+        options: {
+          componentStyle: {
+            width: 343,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      834: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19867:248296',
+        options: {
+          componentStyle: {
+            width: 770,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -308,11 +308,7 @@ const Inflow = styled.div<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const Outflow = styled(Inflow)({
-  [lightTheme.breakpoints.down('table_834')]: {
-    marginTop: 7,
-  },
-});
+const Outflow = styled(Inflow)({});
 
 const NewBalance = styled(InitialBalance)({
   marginTop: 7,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -16,12 +16,15 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 interface ReserveCardProps {
   account: UIReservesData;
   currency?: Token;
+
+  // intended to be use in the stories
+  defaultExpanded?: boolean;
 }
 
-const ReserveCard: React.FC<ReserveCardProps> = ({ account, currency = 'DAI' }) => {
+const ReserveCard: React.FC<ReserveCardProps> = ({ account, currency = 'DAI', defaultExpanded = false }) => {
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
-  const [expanded, setExpanded] = React.useState<boolean>(false);
+  const [expanded, setExpanded] = React.useState<boolean>(defaultExpanded);
 
   const isGroup = account.accountType === 'group';
   const initialBalance = account.snapshotAccountBalance?.[0]?.initialBalance ?? 0;
@@ -53,7 +56,7 @@ const ReserveCard: React.FC<ReserveCardProps> = ({ account, currency = 'DAI' }) 
   );
 
   return (
-    <Accordion onChange={() => hasTransactions && setExpanded(!expanded)}>
+    <Accordion expanded={expanded} onChange={() => hasTransactions && setExpanded(!expanded)}>
       <Card isLight={isLight} hasTransactions={hasTransactions}>
         <NameContainer>
           {isGroup ? (

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -220,7 +220,7 @@ const InitialBalance = styled.div({
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
     padding: 16,
-    width: '16.4%',
+    width: '16.8%',
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
@@ -228,7 +228,7 @@ const InitialBalance = styled.div({
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: '17.3%',
+    width: '17.9%',
   },
 });
 
@@ -302,12 +302,20 @@ const Inflow = styled.div<WithIsLight>(({ isLight }) => ({
   [lightTheme.breakpoints.up('desktop_1280')]: {
     minWidth: 'calc(17.2% - 32px)',
   },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    minWidth: 'calc(18% - 32px)',
+  },
 }));
 
-const Outflow = styled(Inflow)({});
+const Outflow = styled(Inflow)({
+  [lightTheme.breakpoints.down('table_834')]: {
+    marginTop: 7,
+  },
+});
 
 const NewBalance = styled(InitialBalance)({
-  marginTop: 8,
+  marginTop: 7,
 
   [lightTheme.breakpoints.up('table_834')]: {
     padding: 2,
@@ -345,7 +353,6 @@ const ArrowContainer = styled.div({
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: 106,
     marginLeft: 32,
   },
 });

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
@@ -82,7 +82,7 @@ export default GroupItem;
 const GroupItemContainer = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'flex',
   flexDirection: 'column',
-  padding: '16px 16px 24px',
+  padding: '20px 16px 24px',
   borderRadius: 6,
   overflow: 'hidden',
   background: isLight ? alpha('#ECEFF9', 0.5) : '#26313F',
@@ -93,7 +93,7 @@ const GroupItemContainer = styled.div<WithIsLight>(({ isLight }) => ({
   [lightTheme.breakpoints.up('table_834')]: {
     background: isLight ? alpha('#ECEFF9', 0.5) : '#283341',
     flexDirection: 'row',
-    padding: '16px 32px 16px 16px',
+    padding: '20px 32px 16px 16px',
     borderRadius: 0,
     boxShadow: 'none',
 
@@ -103,15 +103,15 @@ const GroupItemContainer = styled.div<WithIsLight>(({ isLight }) => ({
   },
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    padding: '16px 56px 16px 16px',
+    padding: '19px 56px 16px 16px',
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    padding: '16px 64px 16px 20px',
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    padding: '19px 64px 16px 16px',
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    padding: '16px 80px 16px 20px',
+    padding: '19px 80px 16px 16px',
   },
 }));
 
@@ -120,7 +120,7 @@ const WalletContainer = styled.div({
 
   [lightTheme.breakpoints.up('table_834')]: {
     marginBottom: 0,
-    width: 'calc(204px + 17%)',
+    width: 'calc(205px + 16.1%)',
 
     '& > div': {
       marginTop: 0,
@@ -128,7 +128,11 @@ const WalletContainer = styled.div({
   },
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    width: 'calc(295px + 16%)',
+    width: 'calc(295px + 16.4%)',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: 'calc(295px + 16.7%)',
   },
 });
 
@@ -213,6 +217,11 @@ const Currency = styled.span<WithIsLight>(({ isLight }) => ({
   letterSpacing: 1,
   textTransform: 'uppercase',
   color: isLight ? '#9FAFB9' : '#9FAFB9',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    fontSize: 14,
+    lineHeight: '17px',
+  },
 }));
 
 const Inflow = styled.div({
@@ -226,11 +235,19 @@ const Inflow = styled.div({
     flexDirection: 'column',
     justifyContent: 'normal',
     gap: 8,
-    minWidth: '18%',
+    minWidth: '19.2%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: '19.9%',
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: '21.5%',
+    width: '20.6%',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: '22.5%',
   },
 });
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/GroupItem/GroupItem.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { alpha } from '@mui/material';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
@@ -84,13 +85,13 @@ const GroupItemContainer = styled.div<WithIsLight>(({ isLight }) => ({
   padding: '16px 16px 24px',
   borderRadius: 6,
   overflow: 'hidden',
-  background: isLight ? '#F5F6FB' : '#26313F',
+  background: isLight ? alpha('#ECEFF9', 0.5) : '#26313F',
   boxShadow: isLight
     ? '0px 4px 6px rgba(196, 196, 196, 0.25)'
     : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
 
   [lightTheme.breakpoints.up('table_834')]: {
-    background: isLight ? '#F5F6FB' : '#283341',
+    background: isLight ? alpha('#ECEFF9', 0.5) : '#283341',
     flexDirection: 'row',
     padding: '16px 32px 16px 16px',
     borderRadius: 0,
@@ -98,10 +99,6 @@ const GroupItemContainer = styled.div<WithIsLight>(({ isLight }) => ({
 
     '&:hover': {
       background: isLight ? '#F6F8F9' : '#1F2931',
-    },
-
-    '&:not(:first-of-type)': {
-      borderTop: `1px solid ${isLight ? '#D4D9E1' : '#405361'}`,
     },
   },
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/InitialBalanceRow.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/InitialBalanceRow.tsx
@@ -30,7 +30,7 @@ const Wrapper = styled.div<WithIsLight>(({ isLight }) => ({
   alignItems: 'flex-end',
   justifyContent: 'center',
   gap: 8,
-  padding: '16px 32px 13px 20px',
+  padding: '21px 32px 13px 20px',
 
   [lightTheme.breakpoints.up('table_834')]: {
     display: 'flex',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/Transaction.tsx
@@ -68,12 +68,22 @@ export default Transaction;
 
 const TransactionContainer = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'grid',
-  gridTemplateColumns: '204px 17% max-content 1fr',
+  gridTemplateColumns: '204px 15.7% max-content 1fr',
   padding: '16px 32px 13px 20px',
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
     gridTemplateColumns: '295px 16% max-content 1fr',
     padding: '16px 56px 14px 20px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    gridTemplateColumns: '295px 16.1% max-content 1fr',
+    padding: '16px 64px 14px 20px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    gridTemplateColumns: '295px 16.4% max-content 1fr',
+    padding: '16px 80px 14px 20px',
   },
 
   '&:hover': {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Transaction/segments/TransactionHeader.tsx
@@ -41,7 +41,6 @@ const Wrapper = styled.div({
   display: 'flex',
   gap: 16,
   gridColumn: '1 / 3',
-  padding: '0 16px',
 });
 
 const commonArrowStyles = {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
@@ -118,6 +118,18 @@ const GroupContainer = styled.div<WithIsLight>(({ isLight }) => ({
   flexDirection: 'column',
   gap: 8,
 
+  [lightTheme.breakpoints.down('table_834')]: {
+    '&:not(:first-of-type)::before': {
+      display: 'block',
+      content: '""',
+      width: 'calc(100% + 16px)',
+      marginLeft: -8,
+      height: 1,
+      background: isLight ? '#D4D9E1' : '#405361',
+      marginBottom: -1,
+    },
+  },
+
   [lightTheme.breakpoints.up('table_834')]: {
     gap: 0,
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
@@ -35,7 +35,7 @@ const TransactionList: React.FC<TransactionListProps> = ({ items, highlightPosit
         {!items?.length && <EmptyList isLight={isLight}>No transactions this month</EmptyList>}
         {items?.map((item: SnapshotAccountTransaction | SnapshotAccount) =>
           isSnapshotAccount(item) ? (
-            <GroupContainer key={item.id}>
+            <GroupContainer isLight={isLight} key={item.id}>
               <GroupItem
                 name={item.accountLabel}
                 address={item.accountAddress}
@@ -113,15 +113,19 @@ const TransactionCard = styled.div<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const GroupContainer = styled.div({
+const GroupContainer = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: 8,
 
   [lightTheme.breakpoints.up('table_834')]: {
     gap: 0,
+
+    '&:not(:first-of-type)': {
+      borderTop: `1px solid ${isLight ? '#D4D9E1' : '#405361'}`,
+    },
   },
-});
+}));
 
 const EmptyList = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'flex',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
@@ -154,9 +154,10 @@ export const getTotals = (values: ActualsComparison[]): ActualsComparison =>
     (acc, curr) => {
       acc.reportedActuals += curr.reportedActuals;
       acc.netExpenses.onChainOnly.amount += curr.netExpenses.onChainOnly.amount;
-      acc.netExpenses.onChainOnly.difference += curr.netExpenses.onChainOnly.difference;
+      acc.netExpenses.onChainOnly.difference = (acc.reportedActuals * 100) / acc.netExpenses.onChainOnly.amount - 100;
       acc.netExpenses.offChainIncluded.amount += curr.netExpenses.offChainIncluded.amount;
-      acc.netExpenses.offChainIncluded.difference += curr.netExpenses.offChainIncluded.difference;
+      acc.netExpenses.offChainIncluded.difference =
+        (acc.reportedActuals * 100) / acc.netExpenses.offChainIncluded.amount - 100;
 
       return acc;
     },


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Fixed some issues in the CU reserves section

# What solved
- [X] Should have a stronger line after the Initial Balance of each group.
- [X] On Chain Reserves section.**Expected Output:**  The group name row should have a background with color: #ECEFF9 50%. **Current Output:** The background is displayed with color: #f5f6fb.
- [X] On-Chain Reserves, Off-Chain Reserves sections. Expanding the sections.  **Expected Output:** The 'Amount' values should be aligned with the 'New Balance' value.
- [X] Expenses Reports view, Comparison section. **Expected Output:** The percent should be calculated **(reported actuals * 100 / ON-CHAIN ONLY) - 100** **Current Output:** The percent is calculated with the sum of the Difference column. 