### PR TITLE
[SES-QC-278] Actuals breakdown for non headcount expenses without value

### DIFF
--- a/src/stories/containers/TransparencyReport/utils/budgetStatementsUtils.ts
+++ b/src/stories/containers/TransparencyReport/utils/budgetStatementsUtils.ts
@@ -14,7 +14,7 @@ export const hasWalletGroups = (wallet: BudgetStatementWallet) =>
 
 export const hasGroupExpenses = (wallet: BudgetStatementWallet, group: string, month: string, isHeadcount = true) =>
   wallet.budgetStatementLineItem
-    ?.filter((item) => item.headcountExpense === isHeadcount && (item.group === group || (!item.group && !group)))
+    ?.filter((item) => !!item.headcountExpense === isHeadcount && (item.group === group || (!item.group && !group)))
     .some((x) => (x.actual || x.forecast) && x.month === month);
 
 export const getGroupActual = (group: BudgetStatementLineItem[], month: string) =>


### PR DESCRIPTION
# Ticket
https://trello.com/c/udGDe7fW/278-qc-round-r

# Description
The issue was when the headcountExpense is undefined instead of a boolean, now it is handles as false in those cases

# What solved
- [X]  The response in the API suggests that maybe the canonical categories that are blank are being hidden but the values included in the total. For example 'feeds' and 'marketing costs'. [image.png](https://trello.com/1/cards/647070a1163c44350d910535/attachments/64c75cf8805cc6ffabf58362/download/image.png)