### PR TITLE
[SES-268] Add correct since month

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -9,9 +9,10 @@ import type { Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
 interface AccountsSnapshotProps {
   snapshot: Snapshots;
   snapshotOwner?: string;
+  sinceDate?: Date;
 }
 
-const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotOwner }) => {
+const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotOwner, sinceDate }) => {
   const {
     enableCurrencyPicker,
     expensesComparisonRows,
@@ -37,6 +38,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
         endDate={endDate}
         balance={mainBalance}
         transactionHistory={transactionHistory}
+        sinceDate={sinceDate}
       />
       <CUReserves
         snapshotOwner={snapshotOwner}

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
@@ -24,12 +24,12 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
   shortCode,
   resource,
 }) => {
-  const { isLoading, snapshot } = useAccountsSnapshotTab(ownerId, currentMonth, resource);
+  const { isLoading, snapshot, sinceDate } = useAccountsSnapshotTab(ownerId, currentMonth, resource);
 
   return isLoading ? (
     <AccountsSnapshotSkeleton />
   ) : snapshot ? (
-    <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} />
+    <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} sinceDate={sinceDate} />
   ) : (
     <Box sx={{ mb: '64px' }}>
       <TransparencyEmptyTable longCode={longCode} shortCode={shortCode} resource={resource} />

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
@@ -64,6 +64,19 @@ export const accountsSnapshotQuery = (filter: SnapshotFilter) => ({
   },
 });
 
+export const allAccountsSnapshotsForStartDateQuery = (filter: SnapshotFilter) => ({
+  query: gql`
+    query Snapshots($filter: SnapshotFilter) {
+      snapshots(filter: $filter) {
+        start
+      }
+    }
+  `,
+  filter: {
+    filter,
+  },
+});
+
 export const coreUnitShortCodeQuery = (id: string) => ({
   query: gql`
     query CoreUnits($filter: CoreUnitFilter) {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
@@ -18,6 +18,7 @@ const CommonArgs = {
   snapshotOwner: 'SES Core Unit',
   startDate: '2023-05-12T22:52:54.494Z',
   endDate: '2023-06-14T22:52:54.494Z',
+  sinceDate: new Date('2023-05-12T22:52:54.494Z'),
   balance: {
     initialBalance: 3685648,
     newBalance: -3743328,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/FundingOverview/FundingOverview.tsx
@@ -16,6 +16,7 @@ interface FundingOverviewProps {
   endDate?: string;
   balance?: SnapshotAccountBalance;
   transactionHistory: SnapshotAccountTransaction[];
+  sinceDate?: Date;
 
   // Only used for storybook
   defaultExpanded?: boolean;
@@ -26,6 +27,7 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({
   snapshotOwner,
   startDate,
   endDate,
+  sinceDate,
   balance,
   transactionHistory,
   defaultExpanded = false,
@@ -37,9 +39,9 @@ const FundingOverview: React.FC<FundingOverviewProps> = ({
         subtitle={
           <>
             Totals funds made available {snapshotOwner ? `to the ${snapshotOwner}` : ''} over its entire lifetime
-            {startDate ? (
+            {sinceDate ? (
               <>
-                , since <b>{DateTime.fromISO(startDate).toFormat('LLLL yyyy')}</b>
+                , since <b>{DateTime.fromJSDate(sinceDate).toFormat('LLLL yyyy')}</b>
               </>
             ) : (
               ''

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -66,7 +66,6 @@ const TooltipWrapper = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  marginLeft: 8,
 });
 
 const IconWrapper = styled.div({

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -23,11 +23,13 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({ title, subtitle, tooltip,
           {title}
         </Title>
         {tooltip && (
-          <SESTooltip content={tooltip} placement="bottom-start">
-            <IconWrapper>
-              <Information />
-            </IconWrapper>
-          </SESTooltip>
+          <TooltipWrapper>
+            <SESTooltip content={tooltip} placement="bottom-start">
+              <IconWrapper>
+                <Information />
+              </IconWrapper>
+            </SESTooltip>
+          </TooltipWrapper>
         )}
       </TitleWrapper>
       <Subtitle isLight={isLight}>{subtitle}</Subtitle>
@@ -57,6 +59,15 @@ const Title = styled.h2<WithIsLight & { isSubsection: boolean }>(({ isLight, isS
   letterSpacing: isSubsection ? 0 : 0.4,
   margin: 0,
 }));
+
+const TooltipWrapper = styled.div({
+  width: 24,
+  height: 24,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginLeft: 8,
+});
 
 const IconWrapper = styled.div({
   width: 24,

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -66,10 +66,11 @@ const TooltipWrapper = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  marginLeft: 4,
 });
 
 const IconWrapper = styled.div({
-  width: 24,
+  width: 'fit-content',
   height: 'fit-content',
   display: 'flex',
   alignItems: 'center',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -60,7 +60,7 @@ const Title = styled.h2<WithIsLight & { isSubsection: boolean }>(({ isLight, isS
 
 const IconWrapper = styled.div({
   width: 24,
-  height: 24,
+  height: 'fit-content',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshotTab.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshotTab.ts
@@ -1,7 +1,7 @@
 import { fetcher } from '@ses/core/utils/fetcher';
 import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
-import { accountsSnapshotQuery } from './api/queries';
+import { accountsSnapshotQuery, allAccountsSnapshotsForStartDateQuery } from './api/queries';
 import type { Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { DateTime } from 'luxon';
@@ -17,7 +17,7 @@ const useAccountsSnapshotTab = (ownerId: string, currentMonth: DateTime, resourc
     [resource, ownerId, currentMonth]
   );
 
-  const { data: response, error: errorFetchingUser } = useSWRImmutable<{ snapshots: Snapshots[] }>(
+  const { data: response, error: errorFetchingSnapshots } = useSWRImmutable<{ snapshots: Snapshots[] }>(
     {
       query,
       input: filter,
@@ -25,9 +25,39 @@ const useAccountsSnapshotTab = (ownerId: string, currentMonth: DateTime, resourc
     fetcher
   );
 
+  const { query: dateQuery, filter: dateFilter } = useMemo(
+    () =>
+      allAccountsSnapshotsForStartDateQuery({
+        ownerType: resource,
+        ownerId,
+      }),
+    [resource, ownerId]
+  );
+
+  const { data: dateResponse, error: errorFetchingDateSnapshots } = useSWRImmutable<{
+    snapshots: Pick<Snapshots, 'start'>[];
+  }>(
+    {
+      query: dateQuery,
+      input: dateFilter,
+    },
+    fetcher
+  );
+
+  const sinceDate = useMemo(() => {
+    const validDates: Date[] | undefined = dateResponse?.snapshots
+      ?.filter((snapshot) => snapshot.start !== null)
+      ?.map((snapshot) => new Date(snapshot.start as string));
+
+    if (!validDates || validDates.length === 0) return;
+
+    return new Date(Math.min(...validDates.map((date) => date.getTime())));
+  }, [dateResponse?.snapshots]);
+
   return {
-    isLoading: !response && !errorFetchingUser,
+    isLoading: (!response && !errorFetchingSnapshots) || (!dateResponse && !errorFetchingDateSnapshots),
     snapshot: response?.snapshots?.[0],
+    sinceDate,
   };
 };
 


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Added the `since date` to the account snapshots tab as the start date of the first snapshot

# What solved
- [X] To display the date should query all the snapshot accounts of that core unit and take the first month of the snapshot report. The "since month" should be displayed in bold. 
- [X] FIX: MakerDao Funding Overview, Total Core Units Reserves, On Chain Reserves, Off Chain Reserves sections. Touching the info icon.  **Current Output:** There is a big space between the tooltip and the info icon. 