### PR TITLE
Fix/global activity feed

### DIFF
--- a/pages/activity-feed/index.tsx
+++ b/pages/activity-feed/index.tsx
@@ -2,26 +2,26 @@ import React from 'react';
 import { fetchGlobalActivityFeedData } from '../../src/stories/containers/GlobalActivity/GlobalActivityAPI';
 import GlobalActivityFeedContainer from '../../src/stories/containers/GlobalActivity/GlobalActivityFeedContainer';
 import type { ChangeTrackingEvent } from '@ses/core/models/interfaces/activity';
-import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
+import type { Team } from '@ses/core/models/interfaces/team';
 import type { GetServerSideProps, NextPage } from 'next';
 
 interface GlobalActivityPageProps {
-  coreUnits: CoreUnit[];
+  teams: Team[];
   activityFeed: ChangeTrackingEvent[];
 }
 
-const GlobalActivityPage: NextPage<GlobalActivityPageProps> = ({ coreUnits, activityFeed }) => (
-  <GlobalActivityFeedContainer coreUnits={coreUnits} activityFeed={activityFeed} />
+const GlobalActivityPage: NextPage<GlobalActivityPageProps> = ({ teams, activityFeed }) => (
+  <GlobalActivityFeedContainer teams={teams} activityFeed={activityFeed} />
 );
 
 export default GlobalActivityPage;
 
 export const getServerSideProps: GetServerSideProps = async () => {
-  const { activityFeed, coreUnits } = await fetchGlobalActivityFeedData();
+  const { activityFeed, teams } = await fetchGlobalActivityFeedData();
 
   return {
     props: {
-      coreUnits,
+      teams,
       activityFeed,
     },
   };

--- a/src/stories/components/CUActivityTable/ActivityTable.stories.tsx
+++ b/src/stories/components/CUActivityTable/ActivityTable.stories.tsx
@@ -36,7 +36,7 @@ const globalActivityTableArgs = {
           month: '2023-01',
         },
       },
-      coreUnit: {
+      team: {
         name: 'Sustainable Ecosystem Scaling',
         shortCode: 'SES',
         image: 'https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ses-001/logo.png',
@@ -57,7 +57,7 @@ const globalActivityTableArgs = {
           month: '2023-01',
         },
       },
-      coreUnit: {
+      team: {
         name: 'Collateral Engineering Services',
         shortCode: 'CES',
         image: 'https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ces-001/ces_logo.png',
@@ -66,7 +66,7 @@ const globalActivityTableArgs = {
   ],
   columns: [
     {
-      header: 'Core Unit',
+      header: 'Teams',
       styles: {
         minWidth: 360,
         paddingLeft: 32,
@@ -100,7 +100,7 @@ const args = [
     ...globalActivityTableArgs,
     activityFeed: globalActivityTableArgs.activityFeed.map((activity) => ({
       ...activity,
-      coreUnit: null,
+      team: null,
     })),
     columns: [
       {

--- a/src/stories/components/CUActivityTable/ActivityTable.tsx
+++ b/src/stories/components/CUActivityTable/ActivityTable.tsx
@@ -16,7 +16,7 @@ import ArrowUp from '../svg/arrow-up';
 import { ActivityPlaceholder } from './ActivityTablePlaceholder';
 import CUActivityItem from './CUActivityItem';
 import type { ChangeTrackingEvent } from '@ses/core/models/interfaces/activity';
-import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
+import type { Team } from '@ses/core/models/interfaces/team';
 
 export interface ActivityTableHeader {
   header: string;
@@ -28,7 +28,7 @@ export interface ActivityTableHeader {
 
 export interface Activity {
   activityFeed: ChangeTrackingEvent;
-  coreUnit?: CoreUnit;
+  team?: Team;
   isNew?: boolean;
 }
 

--- a/src/stories/components/CUActivityTable/CUActivityItem.stories.tsx
+++ b/src/stories/components/CUActivityTable/CUActivityItem.stories.tsx
@@ -33,7 +33,7 @@ const args = [
           month: '2023-01',
         },
       },
-      coreUnit: {
+      team: {
         name: 'Sustainable Ecosystem Scaling',
         shortCode: 'SES',
         image: 'https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ses-001/logo.png',

--- a/src/stories/components/CUActivityTable/CUActivityItem.tsx
+++ b/src/stories/components/CUActivityTable/CUActivityItem.tsx
@@ -10,27 +10,13 @@ import { useThemeContext } from '../../../core/context/ThemeContext';
 import { ButtonType } from '../../../core/enums/buttonTypeEnum';
 import { CircleAvatar } from '../CircleAvatar/CircleAvatar';
 import { CustomButton } from '../CustomButton/CustomButton';
-import { getCorrectCodeFromActivity } from './utils/helpers';
+import { getCorrectCodeFromActivity, getResourceType } from './utils/helpers';
 import type { Activity } from './ActivityTable';
-import type { ChangeTrackingEvent } from '@ses/core/models/interfaces/activity';
 
 interface CUActivityItemProps {
   activity: Activity;
   isNew: boolean;
 }
-
-// TODO: move to a utility file
-export const getResourceType = (changeTracking: ChangeTrackingEvent): ResourceType => {
-  if (changeTracking.params?.coreUnit) {
-    return changeTracking.params?.coreUnit?.shortCode === 'DEL' ? ResourceType.Delegates : ResourceType.CoreUnit;
-  }
-
-  if (changeTracking.params?.owner) {
-    return changeTracking.params?.owner?.type ?? ResourceType.EcosystemActor;
-  }
-
-  return ResourceType.CoreUnit;
-};
 
 export default function CUActivityItem({ activity, isNew }: CUActivityItemProps) {
   const activityCode = getCorrectCodeFromActivity(activity.activityFeed);
@@ -87,8 +73,7 @@ export default function CUActivityItem({ activity, isNew }: CUActivityItemProps)
         <FlexWrapper isGlobal={isGlobal}>
           {isGlobal &&
             (resourceType === ResourceType.Delegates ? (
-              // TODO: rename styled components to TeamXXX
-              <CoreUnit isGlobal={isGlobal}>
+              <TeamData isGlobal={isGlobal}>
                 <CircleAvatar
                   width="32px"
                   height="32px"
@@ -98,10 +83,10 @@ export default function CUActivityItem({ activity, isNew }: CUActivityItemProps)
                 <CoreUnitName style={{ marginLeft: 16 }} isLight={isLight}>
                   Recognized Delegates
                 </CoreUnitName>
-              </CoreUnit>
+              </TeamData>
             ) : (
               [ResourceType.CoreUnit, ResourceType.EcosystemActor].includes(resourceType) && (
-                <CoreUnit isGlobal={isGlobal}>
+                <TeamData isGlobal={isGlobal}>
                   <CircleAvatar
                     width="32px"
                     height="32px"
@@ -110,7 +95,7 @@ export default function CUActivityItem({ activity, isNew }: CUActivityItemProps)
                   />
                   <CoreUnitCode isLight={isLight}>{activity?.team?.shortCode}</CoreUnitCode>
                   <CoreUnitName isLight={isLight}>{activity?.team?.name}</CoreUnitName>
-                </CoreUnit>
+                </TeamData>
               )
             ))}
           <Timestamp isGlobal={isGlobal}>
@@ -275,7 +260,7 @@ const ButtonContainer = styled.div<{ isGlobal: boolean }>(({ isGlobal }) => ({
   },
 }));
 
-const CoreUnit = styled.div<{ isGlobal: boolean }>(({ isGlobal }) => ({
+const TeamData = styled.div<{ isGlobal: boolean }>(({ isGlobal }) => ({
   display: 'flex',
   alignItems: 'center',
   minWidth: '327px',

--- a/src/stories/components/CUActivityTable/utils/helpers.ts
+++ b/src/stories/components/CUActivityTable/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { ResourceType } from '@ses/core/models/interfaces/types';
 import type { ChangeTrackingEvent } from '@ses/core/models/interfaces/activity';
 
 export const getCorrectCodeFromActivity = (activityParams: ChangeTrackingEvent) => {
@@ -15,4 +16,16 @@ export const getCorrectCodeFromActivity = (activityParams: ChangeTrackingEvent) 
       shortCode: activityParams.params.coreUnit?.shortCode,
     };
   }
+};
+
+export const getResourceType = (changeTracking: ChangeTrackingEvent): ResourceType => {
+  if (changeTracking.params?.coreUnit) {
+    return changeTracking.params?.coreUnit?.shortCode === 'DEL' ? ResourceType.Delegates : ResourceType.CoreUnit;
+  }
+
+  if (changeTracking.params?.owner) {
+    return changeTracking.params?.owner?.type ?? ResourceType.EcosystemActor;
+  }
+
+  return ResourceType.CoreUnit;
 };

--- a/src/stories/components/TopBarSelect/TopBarSelect.tsx
+++ b/src/stories/components/TopBarSelect/TopBarSelect.tsx
@@ -56,7 +56,7 @@ export const TopBarSelect = (props: TopBarSelectProps) => {
             <Link href={item.link} passHref>
               <LinkWrapper
                 isLight={isLight}
-                isActive={item.title === props.selectedOption}
+                isActive={item.title === props.selectedOption || item.titleMobile === props.selectedOption}
                 key={item.title}
                 onClick={item.title === props.selectedOption ? togglePopup : undefined}
               >

--- a/src/stories/containers/Actors/components/ActorItem/ActorItem.stories.tsx
+++ b/src/stories/containers/Actors/components/ActorItem/ActorItem.stories.tsx
@@ -12,6 +12,7 @@ export default {
     chromatic: {
       viewports: [375, 834, 1194, 1440],
     },
+    date: new Date('2023-07-12T09:08:34.123'),
   },
 } as ComponentMeta<typeof ActorItem>;
 const variantsArgs = [

--- a/src/stories/containers/GlobalActivity/GlobalActivityAPI.ts
+++ b/src/stories/containers/GlobalActivity/GlobalActivityAPI.ts
@@ -1,7 +1,7 @@
 import { request, gql } from 'graphql-request';
 import { GRAPHQL_ENDPOINT } from '../../../config/endpoints';
 import type { ChangeTrackingEvent } from '@ses/core/models/interfaces/activity';
-import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
+import type { Team } from '@ses/core/models/interfaces/team';
 
 export const getGlobalActivityFeedQuery = () => ({
   query: gql`
@@ -13,11 +13,12 @@ export const getGlobalActivityFeedQuery = () => ({
         id
         params
       }
-      coreUnits {
+      teams {
         id
         shortCode
         name
         image
+        type
       }
     }
   `,
@@ -28,7 +29,7 @@ export const getGlobalActivityFeedQuery = () => ({
 });
 
 interface GlobalActivityFeedResponse {
-  coreUnits: Partial<CoreUnit>[];
+  teams: Partial<Team>[];
   activityFeed: ChangeTrackingEvent[];
 }
 

--- a/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.stories.tsx
+++ b/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.stories.tsx
@@ -49,7 +49,7 @@ const variantsArgs = [
         .withDescription('Increase Headcount Expense Forecast Lorem Ipsum test some text.')
         .withParams({
           coreUnit: {
-            shortCode: 'SES',
+            shortCode: 'CES',
           },
           month: '2022-09',
         })
@@ -70,10 +70,16 @@ const variantsArgs = [
         .withImage('https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ses-001/logo.png')
         .withShortCode('SES')
         .withName('Sustainable Ecosystem Scaling')
+
         .build(),
       new CoreUnitsBuilder()
         .withImage('https://makerdao-ses.github.io/ecosystem-dashboard/core-units/dux-001/dux_logo.png')
         .withShortCode('DUX')
+        .withName('Development & UX')
+        .build(),
+      new CoreUnitsBuilder()
+        .withImage('https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ces-001/ces_logo.png')
+        .withShortCode('CES')
         .withName('Development & UX')
         .build(),
     ],

--- a/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.stories.tsx
+++ b/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.stories.tsx
@@ -28,7 +28,7 @@ export default {
 const variantsArgs = [
   {
     activityFeed: [],
-    coreUnits: [],
+    teams: [],
   },
   {
     activityFeed: [
@@ -65,7 +65,7 @@ const variantsArgs = [
         })
         .build(),
     ],
-    coreUnits: [
+    teams: [
       new CoreUnitsBuilder()
         .withImage('https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ses-001/logo.png')
         .withShortCode('SES')

--- a/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.tsx
+++ b/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.tsx
@@ -64,7 +64,7 @@ const GlobalActivityFeedContainer: React.FC<Props> = ({ teams, activityFeed }) =
             </Reset>
             <CoreUnitsSelect filtersVisible={filtersVisible}>
               <CustomMultiSelect
-                label="Core Unit"
+                label="Team"
                 activeItems={activeElements}
                 items={selectElements}
                 width={138}
@@ -75,7 +75,7 @@ const GlobalActivityFeedContainer: React.FC<Props> = ({ teams, activityFeed }) =
                 popupContainerWidth={360}
                 listItemWidth={330}
                 customAll={{
-                  content: 'All Core Units',
+                  content: 'All Teams',
                   id: 'all',
                   params: { isAll: true },
                   count: 0,

--- a/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.tsx
+++ b/src/stories/containers/GlobalActivity/GlobalActivityFeedContainer.tsx
@@ -18,14 +18,14 @@ import { ButtonFilter, SmallSeparator } from '../CUTable/cuTableFilters';
 import { useGlobalActivity } from './useGlobalActivity';
 import type { SelectItemProps } from '../../components/CustomMultiSelect/CustomMultiSelect';
 import type { ChangeTrackingEvent } from '@ses/core/models/interfaces/activity';
-import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
+import type { Team } from '@ses/core/models/interfaces/team';
 
 interface Props {
-  coreUnits: CoreUnit[];
+  teams: Team[];
   activityFeed: ChangeTrackingEvent[];
 }
 
-const GlobalActivityFeedContainer: React.FC<Props> = ({ coreUnits, activityFeed }) => {
+const GlobalActivityFeedContainer: React.FC<Props> = ({ teams, activityFeed }) => {
   const { isLight } = useThemeContext();
   const {
     columns,
@@ -41,7 +41,7 @@ const GlobalActivityFeedContainer: React.FC<Props> = ({ coreUnits, activityFeed 
     handleSelectChange,
     filtersVisible,
     toggleFiltersVisible,
-  } = useGlobalActivity(coreUnits, activityFeed);
+  } = useGlobalActivity(teams, activityFeed);
 
   return (
     <Wrapper>

--- a/src/stories/containers/GlobalActivity/useGlobalActivity.ts
+++ b/src/stories/containers/GlobalActivity/useGlobalActivity.ts
@@ -7,9 +7,9 @@ import { SortEnum } from '../../../core/enums/sortEnum';
 import type { Activity, ActivityTableHeader } from '../../components/CUActivityTable/ActivityTable';
 import type { MultiSelectItem } from '../../components/CustomMultiSelect/CustomMultiSelect';
 import type { ChangeTrackingEvent } from '@ses/core/models/interfaces/activity';
-import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
+import type { Team } from '@ses/core/models/interfaces/team';
 
-export const useGlobalActivity = (coreUnits: CoreUnit[], activityFeed: ChangeTrackingEvent[]) => {
+export const useGlobalActivity = (teams: Team[], activityFeed: ChangeTrackingEvent[]) => {
   const [searchText, setSearchText] = useState('');
   const [activeElements, setActiveElements] = useState<string[]>([]);
   const [filtersVisible, setFiltersVisible] = useState(false);
@@ -61,22 +61,22 @@ export const useGlobalActivity = (coreUnits: CoreUnit[], activityFeed: ChangeTra
 
   const selectElements = useMemo(
     () =>
-      sortBy(coreUnits, (cu) => cu.name).map((coreUnits) => ({
-        id: coreUnits.shortCode,
-        content: coreUnits.name,
+      sortBy(teams, (team) => team.name).map((team) => ({
+        id: team.shortCode,
+        content: team.name,
         params: {
-          url: coreUnits.image,
-          code: coreUnits.shortCode,
+          url: team.image,
+          code: team.shortCode,
         },
       })) as MultiSelectItem[],
-    [coreUnits]
+    [teams]
   );
 
-  const coreUnitsMap = useMemo(() => {
-    const map = new Map<string, CoreUnit>();
-    coreUnits.forEach((cu) => map.set(cu.shortCode, cu));
+  const teamMap = useMemo(() => {
+    const map = new Map<string, Team>();
+    teams.forEach((team) => map.set(team.shortCode, team));
     return map;
-  }, [coreUnits]);
+  }, [teams]);
 
   const extendedActivityFeed = useMemo(
     () =>
@@ -86,18 +86,18 @@ export const useGlobalActivity = (coreUnits: CoreUnit[], activityFeed: ChangeTra
             (activity) =>
               ({
                 activityFeed: activity,
-                coreUnit: coreUnitsMap.get(getCorrectCodeFromActivity(activity).shortCode ?? ''),
+                team: teamMap.get(getCorrectCodeFromActivity(activity).shortCode ?? ''),
               } as Activity)
           )
           .filter(
             (activity) =>
-              (!activeElements.length || activeElements.includes(activity.coreUnit?.shortCode || '')) &&
+              (!activeElements.length || activeElements.includes(activity.team?.shortCode || '')) &&
               (!searchText || activity.activityFeed.description.toLowerCase().indexOf(searchText.toLowerCase()) > -1)
           ),
         // sort by:
         (activity) => DateTime.fromISO(activity.activityFeed.created_at)
       ),
-    [activeElements, activityFeed, coreUnitsMap, searchText]
+    [activeElements, activityFeed, searchText, teamMap]
   );
 
   return {


### PR DESCRIPTION
# Ticket

https://trello.com/c/HoQPLBoS/289-user-story-view-expense-report-updates-in-activity-feed-last-modified-column-of-ecosystem-actor-list

# What solved
- [X]  The Time is not displayed therefore the rest of the data is displayed in the wrong columns.
- [X]  The view should direct to the Ecosystem Actors Expense Reports view and the menu should indicate the Ecosystem Actors item. 

# Description
This shows the activity feed for the actors, delegate, and core units
