### PR TITLE
[SES-268] Fix account snapshots tooltips on mobile

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/headers.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/ExpensesComparison/headers.tsx
@@ -32,6 +32,8 @@ const NetExpenseTransactions = () => {
           'On-chain view offers valuable insights into on-chain dynamics, but excludes external (off-chain) transactions.'
         }
         placement="bottom-start"
+        enterTouchDelay={0}
+        leaveTouchDelay={15000}
       >
         <InfoWrapper>
           <Information />
@@ -104,6 +106,8 @@ export const EXPENSES_COMPARISON_TABLE_HEADER = [
                 'On-chain view offers valuable insights into on-chain dynamics, but excludes external (off-chain) transactions.'
               }
               placement="bottom-start"
+              enterTouchDelay={0}
+              leaveTouchDelay={15000}
             >
               <InfoWrapper>
                 <Information />
@@ -139,6 +143,8 @@ export const EXPENSES_COMPARISON_TABLE_HEADER = [
             <SESTooltip
               content={'Enhance financial tracking and expense analysis by including off-chain transactions.'}
               placement="bottom-start"
+              enterTouchDelay={0}
+              leaveTouchDelay={15000}
             >
               <InfoWrapper>
                 <Information />

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -24,7 +24,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({ title, subtitle, tooltip,
         </Title>
         {tooltip && (
           <TooltipWrapper>
-            <SESTooltip content={tooltip} placement="bottom-start">
+            <SESTooltip content={tooltip} placement="bottom-start" enterTouchDelay={0} leaveTouchDelay={15000}>
               <IconWrapper>
                 <Information />
               </IconWrapper>


### PR DESCRIPTION
# Ticket
https://trello.com/c/OpG0QrVy/268-feature-onchaindatareconciliation-v2

# Description
Fixed the tooltips of the account snapshot section on mobile devices

# What solved
- [X] **Steps to Reproduce:** MakerDao Funding Overview, Total Core Units Reserves, On Chain Reserves, Off Chain Reserves sections. Touching the info icon. **Expected Output:**  The tooltip should be displayed. **Current Output:** The tooltip is displayed but disappears faster not allowing to read the text.