### PR TITLE
[SES-QC-278] Fix account snapshot skeleton hightlighted squares

### DIFF
--- a/src/stories/containers/FinancesOverview/components/EndgameIntroductionSection/EndgameIntroductionSection.tsx
+++ b/src/stories/containers/FinancesOverview/components/EndgameIntroductionSection/EndgameIntroductionSection.tsx
@@ -20,6 +20,7 @@ const EndgameIntroductionSection: React.FC = () => {
         <ImageWrapper>
           <Image
             src="/assets/img/maker_endgame.png"
+            alt="Endgame"
             layout="fill"
             objectFit="cover"
             placeholder="blur"

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCardSkeleton.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/FundChangeCardSkeleton.tsx
@@ -38,13 +38,13 @@ const Card = styled.div<WithIsLight>(({ isLight }) => ({
   boxShadow: isLight
     ? '0px 4px 6px 0px rgba(195, 195, 195, 0.25)'
     : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px -40px rgba(7, 22, 40, 0.40)',
-  padding: '24px 16px 26px',
+  padding: '14px 16px 16px',
   gap: 37,
 
   [lightTheme.breakpoints.up('table_834')]: {
     flexDirection: 'column',
     padding: 8,
-    gap: 21.75,
+    gap: 12.75,
     minWidth: 390,
     boxShadow: isLight
       ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
@@ -54,7 +54,7 @@ const Card = styled.div<WithIsLight>(({ isLight }) => ({
   [lightTheme.breakpoints.up('desktop_1194')]: {
     minWidth: 579,
     padding: 16,
-    gap: 30.75,
+    gap: 20.75,
   },
 }));
 
@@ -109,14 +109,13 @@ const ValuesContainer = styled.div({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
-  gap: 27.38,
+  gap: 8,
 
   [lightTheme.breakpoints.up('table_834')]: {
     flexDirection: 'row',
-    gap: 0,
   },
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    gap: 12,
+    gap: 24,
   },
 });

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCardMobileSkeleton.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCardMobileSkeleton.tsx
@@ -96,8 +96,10 @@ const Line = styled.div({
   },
 
   '&:nth-of-type(2), &:nth-of-type(3)': {
-    paddingTop: 8,
-    paddingBottom: 12.75,
+    padding: '8px 16px 12.75px',
+    marginLeft: -16,
+    marginRight: -16,
+    background: 'rgba(236, 239, 249, 0.30)',
   },
 });
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCardSkeleton.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCardSkeleton.tsx
@@ -227,20 +227,24 @@ const CurrencySkeleton = styled(BaseSkeleton)({
 const InflowContainer = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  padding: '16px 10px 19.75px 10px',
+  margin: '8px 4px 8px 2px',
+  padding: '8px 10px 11.5px 8px',
   width: '16.104%',
+  borderRadius: 6,
+  background: 'rgba(236, 239, 249, 0.30)',
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    padding: '16px 0 21px 24px',
-    width: '16.77%',
+    margin: '8px 16px',
+    padding: '8px 34.5px 12.75px 8px',
+    width: '13.9%',
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: '17.145%',
+    width: '14.4%',
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: '17.911%',
+    width: '15.4%',
   },
 });
 
@@ -277,19 +281,23 @@ const InflowValueSkeleton = styled(BaseSkeleton)({
 const OutflowContainer = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  padding: '16px 10px 19.75px 10px',
+  margin: '8px 2px',
+  padding: '8px 13px 11.5px 8px',
+  borderRadius: 6,
+  background: 'rgba(236, 239, 249, 0.30)',
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    padding: '16px 0 21px 24px',
-    width: '16.77%',
+    margin: '8px 16px',
+    padding: '8px 34.5px 12.75px 8px',
+    width: '13.9%',
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: '17.145%',
+    width: '14.4%',
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: '17.911%',
+    width: '15.4%',
   },
 });
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCardSkeleton.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/NumberWithSignCard/NumberWithSignCardSkeleton.tsx
@@ -52,16 +52,8 @@ const SignContainer = styled.div({
   alignItems: 'center',
   marginRight: 4,
 
-  [lightTheme.breakpoints.up('table_834')]: {
-    marginRight: 12,
-  },
-
   [lightTheme.breakpoints.up('desktop_1194')]: {
-    marginRight: 16.5,
-  },
-
-  [lightTheme.breakpoints.up('desktop_1440')]: {
-    marginRight: 40.5,
+    marginRight: 8,
   },
 });
 
@@ -91,9 +83,21 @@ const ValueContainer = styled.div({
   justifyContent: 'center',
   alignItems: 'center',
   width: '100%',
+  borderRadius: 6,
+  background: 'rgba(236, 239, 249, 0.30)',
+  padding: '8px 12px 11.38px',
 
   [lightTheme.breakpoints.up('table_834')]: {
     alignItems: 'flex-start',
+    padding: '8px 8px 11.38px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '8px 8px 16px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    padding: '10px 32.5px 16px',
   },
 });
 


### PR DESCRIPTION
# Ticket
https://trello.com/c/udGDe7fW/278-qc-round-r

# Description
Fixed issued on account snapshot skeletons UI

# What solved
- [X] The retangles are barebly visibles. **Visual Proof:** [image.png](https://trello.com/1/cards/6453d6ef7e7fa28f4ba92f1e/attachments/64afacc21fb78085212f5ec6/previews/64afacc31fb78085212f5eec/download/image.png)
