### PR TITLE
[SES-278] Fix tooltip too close to the viewport

### DIFF
--- a/src/stories/components/SESTooltip/SESTooltip.tsx
+++ b/src/stories/components/SESTooltip/SESTooltip.tsx
@@ -155,5 +155,12 @@ const tooltipProps = (borderColor: React.CSSProperties['color'], isLight = true)
       margin: '-0.95em 0',
       scale: '1 1.81',
     },
+
+    [lightTheme.breakpoints.down('table_834')]: {
+      // prevent the tooltip to be too close to the windows edge
+      maxWidth: 343,
+      marginRight: '16px',
+      marginLeft: '16px',
+    },
   },
 });


### PR DESCRIPTION
# Ticket 
https://trello.com/c/udGDe7fW/278-qc-round-r

# Description
Prevent the tooltip to be too close to the edge of the window

# What solved
- [X] The tooltip is closer to the right edge.