### PR TITLE
[SES-290] Add external link to the endgame proposal

### DIFF
--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
@@ -9,7 +9,7 @@ import { toAbsoluteURL } from '@ses/core/utils/urls';
 import React from 'react';
 import lightTheme from 'styles/theme/light';
 import CostBreakdownTable from './components/CostBreakdownTable/CostBreakdownTable';
-import EndgameIntroductionSection from './components/EndgameIntroductionSection/EndgameIntroductionSection';
+import EndgameIntroductionBanner from './components/EndgameIntroductionBanner/EndgameIntroductionBanner';
 import ExpensesChart from './components/ExpensesChart/ExpensesChart';
 import NavigationButtons from './components/NavigationButtons/NavigationButtons';
 import QuarterCarousel from './components/QuarterCarousel/QuarterCarousel';
@@ -71,7 +71,7 @@ const FinancesOverviewContainer: React.FC<FinancesOverviewContainerProps> = ({
       />
       {isEnabled('FEATURE_FINANCES_ENDGAME_BANNER_SECTION') && (
         <EndgameIntroContainer>
-          <EndgameIntroductionSection />
+          <EndgameIntroductionBanner />
         </EndgameIntroContainer>
       )}
 

--- a/src/stories/containers/FinancesOverview/components/EndgameIntroductionBanner/EndgameIntroductionBanner.tsx
+++ b/src/stories/containers/FinancesOverview/components/EndgameIntroductionBanner/EndgameIntroductionBanner.tsx
@@ -9,7 +9,7 @@ import Image from 'next/image';
 import React from 'react';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
-const EndgameIntroductionSection: React.FC = () => {
+const EndgameIntroductionBanner: React.FC = () => {
   const { isLight } = useThemeContext();
 
   return (
@@ -31,8 +31,8 @@ const EndgameIntroductionSection: React.FC = () => {
           <Title isLight={isLight}>Endgame has arrived</Title>
           <Paragraph isLight={isLight}>
             On <Date>17-Feb-2023</Date> Maker Governance approved the{' '}
-            <ExternalLink href="#">Endgame proposal</ExternalLink>. This kicks off the biggest restructuring of MakerDAO
-            since the dissolution of the Maker Foundation in June 2021.
+            <ExternalLink href="https://vote.makerdao.com/polling/QmTmS5Nf">Endgame proposal</ExternalLink>. This kicks
+            off the biggest restructuring of MakerDAO since the dissolution of the Maker Foundation in June 2021.
           </Paragraph>
           <LearMore isLight={isLight} href="#" buttonType={ButtonType.Primary} label="Learn More" />
         </InfoContainer>
@@ -41,7 +41,7 @@ const EndgameIntroductionSection: React.FC = () => {
   );
 };
 
-export default EndgameIntroductionSection;
+export default EndgameIntroductionBanner;
 
 const EndgameContainer = styled.div<WithIsLight>(({ isLight }) => ({
   position: 'relative',

--- a/src/stories/containers/FinancesOverview/components/EndgameIntroductionBanner/EndgameIntroductionEndgameIntroductionBanner.stories.tsx
+++ b/src/stories/containers/FinancesOverview/components/EndgameIntroductionBanner/EndgameIntroductionEndgameIntroductionBanner.stories.tsx
@@ -1,12 +1,12 @@
 import { withoutSBPadding } from '@ses/core/utils/storybook/decorators';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
-import EndgameIntroductionSection from './EndgameIntroductionSection';
+import EndgameIntroductionBanner from './EndgameIntroductionBanner';
 import type { ComponentMeta } from '@storybook/react';
 import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
 
 export default {
-  title: 'Components/Finances/Endgame Introduction Section',
-  component: EndgameIntroductionSection,
+  title: 'Components/Finances/Endgame Introduction Banner',
+  component: EndgameIntroductionBanner,
   decorators: [withoutSBPadding],
   parameters: {
     chromatic: {
@@ -14,11 +14,11 @@ export default {
       pauseAnimationAtEnd: true,
     },
   },
-} as ComponentMeta<typeof EndgameIntroductionSection>;
+} as ComponentMeta<typeof EndgameIntroductionBanner>;
 
 const variantsArgs = [{}];
 
-export const [[LightMode, DarkMode]] = createThemeModeVariants(EndgameIntroductionSection, variantsArgs);
+export const [[LightMode, DarkMode]] = createThemeModeVariants(EndgameIntroductionBanner, variantsArgs);
 
 LightMode.parameters = {
   figma: {


### PR DESCRIPTION
# Ticket
https://trello.com/c/FWSdBoo4/290-user-story-expense-dashboard-transition-to-endgame-v1

# Description
Added the Endgame proposal link to the endgame introduction banner

# What solved
- [X] Should the "Endgame proposal" go to the external proposal as an external link