### PR TITLE
[SES-291] Endgame page (3 first sections)

### DIFF
--- a/pages/endgame/index.tsx
+++ b/pages/endgame/index.tsx
@@ -1,0 +1,6 @@
+import EndgameContainer from '@ses/containers/Endgame/EndgameContainer';
+import React from 'react';
+
+const EndgamePage: React.FC = () => <EndgameContainer />;
+
+export default EndgamePage;

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -18,6 +18,7 @@ export const siteRoutes = {
   cookiesPolicy: '/cookies-policy',
   recognizedDelegateReport: '/recognized-delegates/finances/reports',
   recognizedDelegate: '/delegates',
+  endgame: '/endgame',
 
   // auth
   login: '/login',

--- a/src/stories/components/Header/Header.tsx
+++ b/src/stories/components/Header/Header.tsx
@@ -9,6 +9,7 @@ import { featureFlags } from '../../../../feature-flags/feature-flags';
 import lightTheme from '../../../../styles/theme/light';
 import { useAuthContext } from '../../../core/context/AuthContext';
 import { useThemeContext } from '../../../core/context/ThemeContext';
+import GlobalActivityFeedBtn from '../MenuNavigation/ActivityFeed/GlobalActivityFeedBtn';
 import LoginButton from '../MenuNavigation/LoginButton/LoginButton';
 import MenuTheme from '../MenuNavigation/MenuTheme/MenuTheme';
 import MenuUserOptions from '../MenuNavigation/MenuUser/MenuUserOptions';
@@ -40,17 +41,12 @@ const Header: React.FC = () => {
   const activeMenuItem: MenuType = useMemo(() => {
     if (router.pathname.startsWith('/core-unit')) {
       return featureFlags[CURRENT_ENVIRONMENT].FEATURE_FINANCES_OVERVIEW ? menuItems.coreUnits : menuItems.finances;
-    } else if (
-      router.pathname.startsWith('/activity-feed') &&
-      featureFlags[CURRENT_ENVIRONMENT].FEATURE_GLOBAL_ACTIVITIES
-    ) {
-      return featureFlags[CURRENT_ENVIRONMENT].FEATURE_FINANCES_OVERVIEW
-        ? menuItems.globalActivityFeed
-        : menuItems.finances;
-    } else if (router.pathname.startsWith('/delegates')) {
+    } else if (router.pathname.startsWith(siteRoutes.recognizedDelegate)) {
       return menuItems.recognizedDelegate;
-    } else if (router.pathname.startsWith('/ecosystem-actors')) {
+    } else if (router.pathname.startsWith(siteRoutes.ecosystemActors)) {
       return menuItems.ecosystemActors;
+    } else if (router.pathname.startsWith(siteRoutes.endgame)) {
+      return menuItems.endgame;
     } else return menuItems.finances;
   }, [router.pathname]);
 
@@ -96,6 +92,7 @@ const Header: React.FC = () => {
             ) : (
               <LoginButton />
             )}
+            <GlobalActivityFeedBtn />
           </RightElementsWrapper>
         </Navigation>
       </LeftPart>
@@ -243,10 +240,8 @@ const LogoLinksWrapper = styled.div({
 
 const WrapperIcon = styled.div({
   display: 'flex',
-  [lightTheme.breakpoints.between('table_375', 'table_834')]: {
-    display: 'none',
-  },
-  [lightTheme.breakpoints.down('table_375')]: {
+
+  [lightTheme.breakpoints.down('table_834')]: {
     display: 'none',
   },
 });

--- a/src/stories/components/Header/menuItems.ts
+++ b/src/stories/components/Header/menuItems.ts
@@ -9,7 +9,15 @@ export interface MenuType {
   titleMobile?: string;
 }
 
-const menuItems: { [key: string]: MenuType } = {};
+type RouteOnHeader =
+  | 'finances'
+  | 'ecosystemActors'
+  | 'coreUnits'
+  | 'recognizedDelegate'
+  | 'endgame'
+  | 'globalActivityFeed';
+
+const menuItems = {} as Record<RouteOnHeader, MenuType>;
 
 if (featureFlags[CURRENT_ENVIRONMENT].FEATURE_FINANCES_OVERVIEW) {
   menuItems.finances = {
@@ -42,12 +50,10 @@ if (featureFlags[CURRENT_ENVIRONMENT].FEATURE_RECOGNIZED_DELEGATES) {
   };
 }
 
-if (featureFlags[CURRENT_ENVIRONMENT].FEATURE_GLOBAL_ACTIVITIES) {
-  menuItems.globalActivityFeed = {
-    title: 'Activity Feed',
-    link: siteRoutes.globalActivityFeed,
-    marginRight: '32px',
-  };
-}
+menuItems.endgame = {
+  title: 'Endgame',
+  link: siteRoutes.endgame,
+  marginRight: '32px',
+};
 
 export default menuItems;

--- a/src/stories/components/MenuNavigation/ActivityFeed/GlobalActivityFeedBtn.tsx
+++ b/src/stories/components/MenuNavigation/ActivityFeed/GlobalActivityFeedBtn.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+import { siteRoutes } from '@ses/config/routes';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
+import Link from 'next/link';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+const GlobalActivityFeedBtn: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Link href={siteRoutes.globalActivityFeed}>
+      <Button isLight={isLight}>
+        <svg
+          width="20"
+          height="20"
+          style={{ marginRight: -1 }}
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M19.9986 7.41111C19.9986 7.68725 19.7748 7.91111 19.4986 7.91111H13.6483C13.2063 7.91111 12.9817 7.37968 13.2897 7.06268L15.5098 4.77778C12.4764 1.77778 7.56532 1.66667 4.53198 4.66667C1.49865 7.67778 1.49865 12.5333 4.53198 15.5444C7.56532 18.5556 12.4764 18.5556 15.5098 15.5444C16.7578 14.3147 17.4905 12.9107 17.7077 11.2196C17.7859 10.6109 18.2739 10.1111 18.8875 10.1111C19.5012 10.1111 20.0034 10.6103 19.9225 11.2186C19.6583 13.2071 18.7059 15.4781 17.0653 17.1C13.1653 20.9667 6.83198 20.9667 2.93198 17.1C-0.956907 13.2444 -0.990241 6.97778 2.90976 3.12222C6.80976 -0.733333 13.0653 -0.733333 16.9653 3.12222L19.14 0.883783C19.4529 0.561783 19.9986 0.783253 19.9986 1.23219V7.41111ZM9.72087 5.55556C10.1811 5.55556 10.5542 5.92865 10.5542 6.38889V10.2778L13.7701 12.1889C14.1417 12.4098 14.2638 12.8902 14.0427 13.2617C13.8219 13.6328 13.3423 13.7548 12.971 13.5345L8.88754 11.1111V6.38889C8.88754 5.92865 9.26063 5.55556 9.72087 5.55556Z"
+            fill={isLight ? '#231536' : '#EDEFFF'}
+          />
+        </svg>
+      </Button>
+    </Link>
+  );
+};
+
+export default GlobalActivityFeedBtn;
+
+const Button = styled.a<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 35,
+  height: 35,
+  background: isLight ? 'white' : 'transparent',
+  boxSizing: 'border-box',
+  border: `1px solid ${isLight ? '#D4D9E1' : '#31424E'}`,
+  borderRadius: '50%',
+  cursor: 'pointer',
+  marginRight: 4,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    marginRight: 0,
+    marginLeft: 24,
+  },
+}));

--- a/src/stories/components/MenuNavigation/LoginButton/LoginButton.tsx
+++ b/src/stories/components/MenuNavigation/LoginButton/LoginButton.tsx
@@ -50,5 +50,5 @@ const MobileIcon = styled.div<WithIsLight>(({ isLight }) => ({
   borderRadius: '50%',
   border: `1px solid ${isLight ? '#D4D9E1' : '#31424E'}`,
   cursor: 'pointer',
-  marginRight: 16,
+  marginRight: 4,
 }));

--- a/src/stories/containers/Endgame/EndgameContainer.tsx
+++ b/src/stories/containers/Endgame/EndgameContainer.tsx
@@ -19,6 +19,7 @@ const EndgameContainer: React.FC = () => (
     </BannerContainer>
 
     <Container>
+      {/* TODO: this should be removed when the remaining sections are added */}
       <div style={{ height: 800 }} />
     </Container>
   </EndgamePageContainer>

--- a/src/stories/containers/Endgame/EndgameContainer.tsx
+++ b/src/stories/containers/Endgame/EndgameContainer.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import Container from '@ses/components/Container/Container';
+import PageContainer from '@ses/components/Container/PageContainer';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import IntroductoryHeadline from './components/IntroductoryHeadline/IntroductoryHeadline';
+import NavigationTabs from './components/NavigationTabs/NavigationTabs';
+
+const EndgameContainer: React.FC = () => (
+  <EndgamePageContainer>
+    <Container>
+      <IntroductoryHeadline />
+      <NavigationTabs />
+
+      <div style={{ height: 800 }} />
+    </Container>
+  </EndgamePageContainer>
+);
+
+export default EndgameContainer;
+
+const EndgamePageContainer = styled(PageContainer)({
+  marginTop: 32,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    marginTop: 40,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    marginTop: 64,
+  },
+});

--- a/src/stories/containers/Endgame/EndgameContainer.tsx
+++ b/src/stories/containers/Endgame/EndgameContainer.tsx
@@ -3,6 +3,7 @@ import Container from '@ses/components/Container/Container';
 import PageContainer from '@ses/components/Container/PageContainer';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
+import EndgameIntroductionBanner from '../FinancesOverview/components/EndgameIntroductionBanner/EndgameIntroductionBanner';
 import IntroductoryHeadline from './components/IntroductoryHeadline/IntroductoryHeadline';
 import NavigationTabs from './components/NavigationTabs/NavigationTabs';
 
@@ -10,8 +11,14 @@ const EndgameContainer: React.FC = () => (
   <EndgamePageContainer>
     <Container>
       <IntroductoryHeadline />
-      <NavigationTabs />
+    </Container>
+    <NavigationTabs />
 
+    <BannerContainer>
+      <EndgameIntroductionBanner isKeyChanges={true} />
+    </BannerContainer>
+
+    <Container>
       <div style={{ height: 800 }} />
     </Container>
   </EndgamePageContainer>
@@ -28,5 +35,15 @@ const EndgamePageContainer = styled(PageContainer)({
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
     marginTop: 64,
+  },
+});
+
+const BannerContainer = styled.div({
+  marginTop: 48,
+  marginBottom: 48,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    marginTop: 64,
+    marginBottom: 64,
   },
 });

--- a/src/stories/containers/Endgame/components/IntroductoryHeadline/IntroductoryHeadline.tsx
+++ b/src/stories/containers/Endgame/components/IntroductoryHeadline/IntroductoryHeadline.tsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+const IntroductoryHeadline: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Section>
+      <HeadlineTitle isLight={isLight}>The Maker Endgame</HeadlineTitle>
+      <HeadlineSubtext isLight={isLight}>
+        Lorem ipsum dolor sit amet consectetur. Odio ac erat facilisis non aenean vitae. Integer fames vitae tempus
+        ultricies. Faucibus sit congue nunc laoreet morbi diam a. Augue in egestas commodo donec eu
+      </HeadlineSubtext>
+    </Section>
+  );
+};
+
+export default IntroductoryHeadline;
+
+const Section = styled.section({
+  textAlign: 'center',
+  marginBottom: 48,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    maxWidth: 672,
+    marginBottom: 64,
+  },
+});
+
+const HeadlineTitle = styled.h1<WithIsLight>(({ isLight }) => ({
+  margin: 0,
+  fontSize: 24,
+  fontWeight: 600,
+  letterSpacing: 0.4,
+  color: isLight ? '#231536' : 'red',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    fontSize: 32,
+  },
+}));
+
+const HeadlineSubtext = styled.p<WithIsLight>(({ isLight }) => ({
+  marginBottom: 0,
+  marginTop: 32,
+  fontSize: 14,
+  color: isLight ? '#231536' : 'red',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    fontSize: 16,
+    lineHeight: '22px',
+  },
+}));

--- a/src/stories/containers/Endgame/components/IntroductoryHeadline/IntroductoryHeadline.tsx
+++ b/src/stories/containers/Endgame/components/IntroductoryHeadline/IntroductoryHeadline.tsx
@@ -22,13 +22,13 @@ export default IntroductoryHeadline;
 
 const Section = styled.section({
   textAlign: 'center',
-  marginBottom: 48,
+  marginBottom: 38,
 
   [lightTheme.breakpoints.up('table_834')]: {
     marginLeft: 'auto',
     marginRight: 'auto',
     maxWidth: 672,
-    marginBottom: 64,
+    marginBottom: 54,
   },
 });
 

--- a/src/stories/containers/Endgame/components/NavigationTabs/NavigationTabs.tsx
+++ b/src/stories/containers/Endgame/components/NavigationTabs/NavigationTabs.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import Container from '@ses/components/Container/Container';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import Link from 'next/link';
@@ -9,38 +10,55 @@ const NavigationTabs: React.FC = () => {
   const { isLight } = useThemeContext();
 
   return (
-    <SpaceLimitation>
-      <Navigation isLight={isLight}>
-        <Link href="#" passHref>
-          <Tab isLight={isLight} active={true}>
-            Key Changes
-          </Tab>
-        </Link>
-        <Link href="#" passHref>
-          <Tab isLight={isLight}>Endgame Budget Structure</Tab>
-        </Link>
-        <Link href="#" passHref>
-          <Tab isLight={isLight}>Budget Transition Status</Tab>
-        </Link>
-      </Navigation>
-    </SpaceLimitation>
+    <Sticky>
+      <Wrapper isLight={isLight}>
+        <Container>
+          <Navigation isLight={isLight}>
+            <Link href="#" passHref>
+              <Tab isLight={isLight} active={true}>
+                Key Changes
+              </Tab>
+            </Link>
+            <Link href="#" passHref>
+              <Tab isLight={isLight}>Endgame Budget Structure</Tab>
+            </Link>
+            <Link href="#" passHref>
+              <Tab isLight={isLight}>Budget Transition Status</Tab>
+            </Link>
+          </Navigation>
+        </Container>
+      </Wrapper>
+    </Sticky>
   );
 };
 
 export default NavigationTabs;
 
-const SpaceLimitation = styled.div({
-  width: '100%',
-});
-
-const Navigation = styled.nav<WithIsLight>(({ isLight }) => ({
+const Sticky = styled.div({
   position: 'sticky',
   top: 64,
+  zIndex: 2,
+});
+
+const Wrapper = styled.div<WithIsLight>(({ isLight }) => ({
+  backgroundColor: isLight ? 'white' : 'red',
+  width: '100%',
+  overflowX: 'scroll',
+  msOverflowStyle: 'none',
+  scrollbarWidth: 'none',
+
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
+}));
+
+const Navigation = styled.nav<WithIsLight>(({ isLight }) => ({
   borderBottom: `1px solid ${isLight ? '#B6EDE7' : 'red'}`,
   display: 'flex',
   justifyContent: 'center',
   gap: 16,
   minWidth: 'fit-content',
+  width: '100%',
 
   [lightTheme.breakpoints.up('table_834')]: {
     gap: 56,
@@ -55,6 +73,7 @@ const Tab = styled.a<WithIsLight & { active?: boolean }>(({ isLight, active = fa
     fontSize: 14,
     color: active ? activeColor : defaultColor,
     paddingBottom: 10,
+    paddingTop: 10,
     borderBottom: `2px solid ${active ? activeColor : 'transparent'}`,
     whiteSpace: 'nowrap',
 

--- a/src/stories/containers/Endgame/components/NavigationTabs/NavigationTabs.tsx
+++ b/src/stories/containers/Endgame/components/NavigationTabs/NavigationTabs.tsx
@@ -1,0 +1,66 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
+import Link from 'next/link';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+const NavigationTabs: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <SpaceLimitation>
+      <Navigation isLight={isLight}>
+        <Link href="#" passHref>
+          <Tab isLight={isLight} active={true}>
+            Key Changes
+          </Tab>
+        </Link>
+        <Link href="#" passHref>
+          <Tab isLight={isLight}>Endgame Budget Structure</Tab>
+        </Link>
+        <Link href="#" passHref>
+          <Tab isLight={isLight}>Budget Transition Status</Tab>
+        </Link>
+      </Navigation>
+    </SpaceLimitation>
+  );
+};
+
+export default NavigationTabs;
+
+const SpaceLimitation = styled.div({
+  width: '100%',
+});
+
+const Navigation = styled.nav<WithIsLight>(({ isLight }) => ({
+  position: 'sticky',
+  top: 64,
+  borderBottom: `1px solid ${isLight ? '#B6EDE7' : 'red'}`,
+  display: 'flex',
+  justifyContent: 'center',
+  gap: 16,
+  minWidth: 'fit-content',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    gap: 56,
+  },
+}));
+
+const Tab = styled.a<WithIsLight & { active?: boolean }>(({ isLight, active = false }) => {
+  const activeColor = isLight ? '#1AAB9B' : 'red';
+  const defaultColor = isLight ? '#708390' : 'red';
+
+  return {
+    fontSize: 14,
+    color: active ? activeColor : defaultColor,
+    paddingBottom: 10,
+    borderBottom: `2px solid ${active ? activeColor : 'transparent'}`,
+    whiteSpace: 'nowrap',
+
+    [lightTheme.breakpoints.up('table_834')]: {
+      fontSize: 16,
+      lineHeight: '22px',
+    },
+  };
+});

--- a/src/stories/containers/FinancesOverview/components/EndgameIntroductionBanner/EndgameIntroductionBanner.tsx
+++ b/src/stories/containers/FinancesOverview/components/EndgameIntroductionBanner/EndgameIntroductionBanner.tsx
@@ -9,7 +9,11 @@ import Image from 'next/image';
 import React from 'react';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
-const EndgameIntroductionBanner: React.FC = () => {
+interface EndgameIntroductionBannerProps {
+  isKeyChanges?: boolean;
+}
+
+const EndgameIntroductionBanner: React.FC<EndgameIntroductionBannerProps> = ({ isKeyChanges = false }) => {
   const { isLight } = useThemeContext();
 
   return (
@@ -28,13 +32,19 @@ const EndgameIntroductionBanner: React.FC = () => {
       </ImageContainer>
       <Container>
         <InfoContainer>
-          <Title isLight={isLight}>Endgame has arrived</Title>
+          <Title isLight={isLight}>{isKeyChanges ? 'Key Changes' : 'Endgame has arrived'}</Title>
           <Paragraph isLight={isLight}>
             On <Date>17-Feb-2023</Date> Maker Governance approved the{' '}
             <ExternalLink href="https://vote.makerdao.com/polling/QmTmS5Nf">Endgame proposal</ExternalLink>. This kicks
             off the biggest restructuring of MakerDAO since the dissolution of the Maker Foundation in June 2021.
           </Paragraph>
-          <LearMore isLight={isLight} href="#" buttonType={ButtonType.Primary} label="Learn More" />
+          {isKeyChanges ? (
+            <Paragraph isLight={isLight} noMargin={true}>
+              Below are some key changes that will take place as a result of the transition.{' '}
+            </Paragraph>
+          ) : (
+            <LearMore isLight={isLight} href="#" buttonType={ButtonType.Primary} label="Learn More" />
+          )}
         </InfoContainer>
       </Container>
     </EndgameContainer>
@@ -150,12 +160,12 @@ const Title = styled.h2<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const Paragraph = styled.p<WithIsLight>(({ isLight }) => ({
+const Paragraph = styled.p<WithIsLight & { noMargin?: boolean }>(({ isLight, noMargin = false }) => ({
   fontSize: 14,
   lineHeight: '22px',
   color: '#D2D4EF',
   marginBottom: 0,
-  marginTop: 14,
+  marginTop: noMargin ? 0 : 14,
 
   [lightTheme.breakpoints.up('table_834')]: {
     fontSize: 16,
@@ -163,7 +173,7 @@ const Paragraph = styled.p<WithIsLight>(({ isLight }) => ({
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
     color: isLight ? '#25273D' : '#D2D4EF',
-    marginTop: 15,
+    marginTop: noMargin ? 0 : 15,
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {


### PR DESCRIPTION
# Ticket
https://trello.com/c/SBCUMF7y/291-user-story-summarized-overview-of-key-changes

# Description

# What solved
- [X] Create the `endgame` page/url
- [X] Should add a new element entitled “Endgame” as the last navigation link on the right hand side
- [X] Should remove the "Activity Feed" item of the menu
- [X] Should add the activity feed item as a hyperlinked icon, beside the login button
- [X] Should create an introductory headline that contains subtext and inbound link that navigate to each subsection within the page (Key Changes, Endgame Budget Structure, Budget Transition Status)
- [X] Should the tabs be sticky at the top below the header
- [X] Should add the Key changes section