### PR TITLE
[SES-292] Add total budget UI

### DIFF
--- a/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.stories.tsx
+++ b/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.stories.tsx
@@ -1,0 +1,83 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import BudgetStructureSection from './BudgetStructureSection';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/Endgame/Budget Structure Section',
+  component: BudgetStructureSection,
+  parameters: {
+    chromatic: {
+      viewports: [375, 834, 1194, 1280, 1440],
+      pauseAnimationAtEnd: true,
+    },
+  },
+} as ComponentMeta<typeof BudgetStructureSection>;
+
+const variantsArgs = [{}];
+
+export const [[LightMode, DarkMode]] = createThemeModeVariants(BudgetStructureSection, variantsArgs);
+
+LightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=21089:238282',
+        options: {
+          componentStyle: {
+            width: 343,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      834: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=21235:239248',
+        options: {
+          componentStyle: {
+            width: 834,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1194: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20947:243382',
+        options: {
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1280: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20872:236912',
+        options: {
+          componentStyle: {
+            width: 1184,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20804:270289',
+        options: {
+          componentStyle: {
+            width: 1312,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
+++ b/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
@@ -1,13 +1,68 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import SectionHeader from '../SectionHeader/SectionHeader';
+import TotalBudgetContent from '../TotalBudgetContent/TotalBudgetContent';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
-const BudgetStructureSection: React.FC = () => (
-  <div>
-    <SectionHeader
-      title="Endgame Budget Structure"
-      subtitle="Some simple but poignant text about what endgame budgets are about"
-    />
-  </div>
-);
+const BudgetStructureSection: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Content>
+      <SectionHeader
+        title="Endgame Budget Structure"
+        subtitle="Some simple but poignant text about what endgame budgets are about"
+      />
+
+      <Card isLight={isLight}>
+        <TotalBudgetContent />
+        <div
+          style={{
+            width: '100%',
+            height: 240,
+            background: '#00000011',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          Doughnut Chart here...
+        </div>
+      </Card>
+    </Content>
+  );
+};
 
 export default BudgetStructureSection;
+
+const Content = styled.section({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 40,
+});
+
+const Card = styled.div<WithIsLight>(({ isLight }) => ({
+  padding: '31px 15px 0px 15px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 32,
+  borderRadius: 6,
+  border: `1px solid ${isLight ? 'rgba(212, 217, 225, 0.25)' : 'red'}`,
+  background: isLight ? '#FFF' : 'red',
+  boxShadow: isLight
+    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
+    : '0px 1px 3px 0px red, 0px 20px 40px 0px red',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    flexDirection: 'row',
+    padding: '31px 15px',
+    gap: 24,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    padding: '31px 63px',
+    gap: 64,
+  },
+}));

--- a/src/stories/containers/Endgame/components/TotalBudgetContent/TotalBudgetContent.tsx
+++ b/src/stories/containers/Endgame/components/TotalBudgetContent/TotalBudgetContent.tsx
@@ -1,0 +1,185 @@
+import styled from '@emotion/styled';
+import { LinkButton } from '@ses/components/LinkButton/LinkButton';
+import { siteRoutes } from '@ses/config/routes';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { ButtonType } from '@ses/core/enums/buttonTypeEnum';
+import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+type BarVariant = 'blue' | 'gray';
+
+const TotalBudgetContent: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Content>
+      <BudgetCapNumber isLight={isLight}>
+        {usLocalizedNumber(51932625)}
+        <Currency isLight={isLight}>DAI</Currency>
+      </BudgetCapNumber>
+      <AvgBudgetCapUtilization isLight={isLight}>
+        Avg Budget Cap Utilization: <AvgPercentage>60.1%</AvgPercentage>
+      </AvgBudgetCapUtilization>
+
+      <Divider isLight={isLight} />
+
+      <Legend>
+        <LegendItem isLight={isLight} variant="gray">
+          Endgame Budgets
+        </LegendItem>
+        <LegendItem isLight={isLight} variant="blue">
+          Legacy Budgets
+        </LegendItem>
+      </Legend>
+      <Bar defaultVariant="blue" isLight={isLight}>
+        <BarContent isLight={isLight} variant="gray" width="70.2%" />
+      </Bar>
+      <Values>
+        <Value isLight={isLight}>36.4M (70.2%)</Value>
+        <Value isLight={isLight}>15.4M (29.8%)</Value>
+      </Values>
+
+      <FinancesLink
+        href={siteRoutes.home}
+        buttonType={ButtonType.Primary}
+        label="Legacy Expenses (Return to Finances)"
+      />
+    </Content>
+  );
+};
+
+export default TotalBudgetContent;
+
+const getColor = (variant: BarVariant, isLight: boolean): string => {
+  if (variant === 'gray') {
+    return isLight ? '#D2D4EF' : 'red';
+  } else {
+    // it is blue
+    return isLight ? '#447AFB' : 'red';
+  }
+};
+
+const Content = styled.div({
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    minWidth: 388,
+  },
+});
+
+const BudgetCapNumber = styled.div<WithIsLight>(({ isLight }) => ({
+  textAlign: 'center',
+  fontSize: 30,
+  fontWeight: 500,
+  lineHeight: 'normal',
+  letterSpacing: 0.4,
+  color: isLight ? '#231536' : 'red',
+
+  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
+    fontSize: 24,
+    fontWeight: 600,
+  },
+}));
+
+const Currency = styled.span<WithIsLight>(({ isLight }) => ({
+  fontSize: 24,
+  fontWeight: 600,
+  lineHeight: 'normal',
+  color: isLight ? '#9FAFB9' : 'red',
+  marginLeft: 6,
+
+  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
+    fontSize: 20,
+  },
+}));
+
+const AvgBudgetCapUtilization = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 12,
+  lineHeight: 'normal',
+  color: isLight ? '#708390' : 'red',
+  textAlign: 'center',
+  marginTop: 8,
+}));
+
+const AvgPercentage = styled.span({
+  marginLeft: 3,
+});
+
+const Divider = styled.div<WithIsLight>(({ isLight }) => ({
+  height: 1,
+  width: 'calc(100% - 17px)',
+  background: isLight ? '#D4D9E1' : 'red',
+  margin: '24px 8.5px',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    width: 'calc(100% - 10px)',
+    margin: '23px 5px 24px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    width: 'calc(100% - 94px)',
+    margin: '23px 47px 24px',
+  },
+}));
+
+const Legend = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+});
+
+const LegendItem = styled.div<WithIsLight & { variant: BarVariant }>(({ isLight, variant }) => ({
+  fontSize: 11,
+  lineHeight: 'normal',
+  color: isLight ? '#708390' : 'red',
+  position: 'relative',
+  paddingLeft: 12,
+
+  '&::before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    left: 0,
+    top: 2,
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    background: getColor(variant, isLight),
+  },
+}));
+
+const Bar = styled.div<WithIsLight & { defaultVariant: BarVariant }>(({ isLight, defaultVariant }) => ({
+  width: '100%',
+  height: 16,
+  borderRadius: 6,
+  position: 'relative',
+  overflow: 'hidden',
+  background: getColor(defaultVariant, isLight),
+  margin: '16px 0',
+}));
+
+const BarContent = styled.div<WithIsLight & { variant: BarVariant; width: string }>(({ isLight, variant, width }) => ({
+  width,
+  height: '100%',
+  position: 'absolute',
+  left: 0,
+  top: 0,
+  background: getColor(variant, isLight),
+}));
+
+const Values = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+});
+
+const Value = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 14,
+  lineHeight: 'normal',
+  color: isLight ? '#231536' : 'red',
+}));
+
+const FinancesLink = styled(LinkButton)({
+  display: 'flex',
+  width: '100%',
+  padding: '7px 23px',
+  marginTop: 32,
+});


### PR DESCRIPTION
# Ticket
https://trello.com/c/ERuAdkUG/292-user-story-detailed-insight-into-endgame-budget-structure

# Description
Added the Total Budget UI to the Endgame Budget Structure section

# What solved
- [X] Should add the Avg budget cap
- [X] Should add the budget bar
- [X] Should add a button link to finances
- [X] Should show the data in two columns from tablet up