### PR TITLE
[SES-292] Updated the behavior of the expandable sections on Key Changes

### DIFF
--- a/src/stories/containers/Endgame/components/EndgameIntroductionBanner/EndgameIntroductionBanner.tsx
+++ b/src/stories/containers/Endgame/components/EndgameIntroductionBanner/EndgameIntroductionBanner.tsx
@@ -36,8 +36,9 @@ const EndgameIntroductionBanner: React.FC<EndgameIntroductionBannerProps> = ({ i
           <Title isLight={isLight}>{isKeyChanges ? 'Key Changes' : 'Endgame has arrived'}</Title>
           <Paragraph isLight={isLight}>
             On <Date>17-Feb-2023</Date> Maker Governance approved the{' '}
-            <ExternalLink href="https://vote.makerdao.com/polling/QmTmS5Nf">Endgame proposal</ExternalLink>. This kicks
-            off the biggest restructuring of MakerDAO since the dissolution of the Maker Foundation in June 2021.
+            <ExternalLink href="https://vote.makerdao.com/polling/QmTmS5Nf#poll-detail">Endgame proposal</ExternalLink>.
+            This kicks off the biggest restructuring of MakerDAO since the dissolution of the Maker Foundation in June
+            2021.
           </Paragraph>
           {isKeyChanges ? (
             <Paragraph isLight={isLight} noMargin={true}>

--- a/src/stories/containers/Endgame/components/KeyChangesSections/KeyChangesSections.tsx
+++ b/src/stories/containers/Endgame/components/KeyChangesSections/KeyChangesSections.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable spellcheck/spell-checker */
 import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import KeyChangeSection from '../KeyChangeSection/KeyChangeSection';
@@ -10,19 +10,31 @@ import TokenUpgradesSection from './Sections/TokenUpgradesSection';
 import { KeyChangesSectionsEnum } from './SectionsEnum';
 
 const KeyChangesSections: React.FC = () => {
-  const [activeSection, setActiveSection] = React.useState<KeyChangesSectionsEnum | undefined>(
-    KeyChangesSectionsEnum.GOVERNANCE
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+  const [activeSections, setActiveSections] = React.useState<Set<KeyChangesSectionsEnum>>(
+    new Set([KeyChangesSectionsEnum.GOVERNANCE])
   );
 
   const handleExpand = (section: KeyChangesSectionsEnum) => () => {
-    setActiveSection(activeSection === section ? undefined : section);
+    if (isMobile) {
+      // only one can be expanded at the time
+      setActiveSections(new Set(activeSections.has(section) ? [] : [section]));
+      return;
+    }
+    const newActiveSections = new Set(activeSections);
+    if (newActiveSections.has(section)) {
+      newActiveSections.delete(section);
+    } else {
+      newActiveSections.add(section);
+    }
+    setActiveSections(newActiveSections);
   };
 
   return (
     <KeyChangesSectionsContainer>
       <KeyChangeSection
         title="Governance"
-        expanded={activeSection === KeyChangesSectionsEnum.GOVERNANCE}
+        expanded={activeSections.has(KeyChangesSectionsEnum.GOVERNANCE)}
         onExpand={handleExpand(KeyChangesSectionsEnum.GOVERNANCE)}
       >
         <SectionContainer>
@@ -32,7 +44,7 @@ const KeyChangesSections: React.FC = () => {
 
       <KeyChangeSection
         title="Operations"
-        expanded={activeSection === KeyChangesSectionsEnum.OPERATIONS}
+        expanded={activeSections.has(KeyChangesSectionsEnum.OPERATIONS)}
         onExpand={handleExpand(KeyChangesSectionsEnum.OPERATIONS)}
       >
         <SectionContainer>
@@ -42,7 +54,7 @@ const KeyChangesSections: React.FC = () => {
 
       <KeyChangeSection
         title="Token upgrades"
-        expanded={activeSection === KeyChangesSectionsEnum.TOKEN_UPGRADES}
+        expanded={activeSections.has(KeyChangesSectionsEnum.TOKEN_UPGRADES)}
         onExpand={handleExpand(KeyChangesSectionsEnum.TOKEN_UPGRADES)}
       >
         <SectionContainer>


### PR DESCRIPTION
# Ticket
https://trello.com/c/ERuAdkUG/292-user-story-detailed-insight-into-endgame-budget-structure

# Description
Now all the key section can be expanded at the same time, except in mobile that only one can be expanded at the same time

# What solved
- [X] Should not collapse already opened points after opening the next one (for tablet and desktop) [video](https://trello.com/1/cards/648851dcf78a166c3a54e741/attachments/64e8c5ad295a33b421f8786d/download/20230825_171529.mp4)
- [X] Should redirect you to this link https://vote.makerdao.com/polling/QmTmS5Nf#poll-detail after clicking on the 'Endgame proposal' link in both the Home and Endgame Pages [image](https://trello.com/1/cards/648851dcf78a166c3a54e741/attachments/64e8c6567670acaa862ac82c/download/image.png)