### PR TITLE
[SES-292] Add hover to expandable key sections

### DIFF
--- a/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.tsx
+++ b/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.tsx
@@ -9,17 +9,16 @@ const BudgetTransitionStatusSection: React.FC = () => (
       subtitle="Some context about the trends that will be occurring, as it relates to expense and endgame that visually telegraph the changes."
     />
 
-    <div>
-      here <br />
-      here <br />
-      here <br />
-      here <br />
-      here <br />
-      here <br />
-      here <br />
-      here <br />
-      here <br />
-      here <br />
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: 350,
+        background: '#e5e5e5',
+      }}
+    >
+      Chart...
     </div>
   </Content>
 );

--- a/src/stories/containers/Endgame/components/KeyChangeSection/KeyChangeSection.tsx
+++ b/src/stories/containers/Endgame/components/KeyChangeSection/KeyChangeSection.tsx
@@ -51,7 +51,14 @@ const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters
 
 const AccordionSummary = styled(MuiAccordionSummary)<WithIsLight>(({ isLight }) => ({
   minHeight: 'auto',
-  padding: 0,
+  padding: 8,
+  marginLeft: -8,
+  marginRight: -8,
+  borderRadius: 8,
+
+  '&:hover': {
+    background: isLight ? '#F6F8F9' : '#10191F',
+  },
 
   '& .MuiAccordionSummary-content': {
     margin: 0,
@@ -71,5 +78,5 @@ const AccordionSummary = styled(MuiAccordionSummary)<WithIsLight>(({ isLight }) 
 
 const AccordionDetails = styled(MuiAccordionDetails)({
   padding: 0,
-  marginTop: 32,
+  marginTop: 24,
 });

--- a/src/stories/containers/Endgame/components/KeyChangesSections/KeyChangesSections.tsx
+++ b/src/stories/containers/Endgame/components/KeyChangesSections/KeyChangesSections.tsx
@@ -72,7 +72,7 @@ export default KeyChangesSections;
 const KeyChangesSectionsContainer = styled.section({
   display: 'flex',
   flexDirection: 'column',
-  gap: 40,
+  gap: 32,
 });
 
 export const SectionContainer = styled.div({

--- a/src/stories/containers/Endgame/useEndgameContainer.ts
+++ b/src/stories/containers/Endgame/useEndgameContainer.ts
@@ -11,8 +11,9 @@ export enum NavigationTabEnum {
 }
 
 const INTERSECTION_OPTIONS: IntersectionOptions = {
-  threshold: 0.5,
+  threshold: 0.7,
   fallbackInView: false,
+  rootMargin: '130px 0px 0px 0px',
 };
 
 const useEndgameContainer = () => {
@@ -52,10 +53,10 @@ const useEndgameContainer = () => {
       updateUrl(tab === NavigationTabEnum.KEY_CHANGES ? undefined : tab);
     };
 
-    if (structureInView) {
-      activate(NavigationTabEnum.BUDGET_STRUCTURE);
-    } else if (transitionInView) {
+    if (transitionInView) {
       activate(NavigationTabEnum.BUDGET_TRANSITION_STATUS);
+    } else if (structureInView) {
+      activate(NavigationTabEnum.BUDGET_STRUCTURE);
     } else {
       activate(NavigationTabEnum.KEY_CHANGES);
     }


### PR DESCRIPTION
# Ticket
https://trello.com/c/ERuAdkUG/292-user-story-detailed-insight-into-endgame-budget-structure

# Description
Add hover to the key change expandable sections

# What solved
- [X] Should display a hover (#F6F8F9) after hovering over each of those options [image](https://trello.com/1/cards/648851dcf78a166c3a54e741/attachments/64e8c9478c028b3970b08085/download/image.png)
- [X] Should each expandable line have the padding of size 0.5 em