### PR TITLE
[SES-293] add card & toggle button group

### DIFF
--- a/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.stories.tsx
+++ b/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.stories.tsx
@@ -1,0 +1,86 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import BudgetTransitionStatusSection from './BudgetTransitionStatusSection';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/Endgame/Budget Transition Status Section',
+  component: BudgetTransitionStatusSection,
+  parameters: {
+    chromatic: {
+      viewports: [375, 834, 1194, 1280, 1440],
+      pauseAnimationAtEnd: true,
+    },
+  },
+} as ComponentMeta<typeof BudgetTransitionStatusSection>;
+
+const variantsArgs = [{}];
+
+export const [[LightMode, DarkMode]] = createThemeModeVariants(BudgetTransitionStatusSection, variantsArgs);
+
+LightMode.parameters = {
+  figma: {
+    component: {
+      375: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=21089:238342',
+        options: {
+          componentStyle: {
+            width: 343,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      834: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=21235:239308',
+        options: {
+          componentStyle: {
+            width: 770,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1194: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20947:243442',
+        options: {
+          componentStyle: {
+            width: 1130,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1280: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20872:236972',
+        options: {
+          componentStyle: {
+            width: 1184,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20804:270349',
+        options: {
+          componentStyle: {
+            width: 1312,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.tsx
+++ b/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.tsx
@@ -1,27 +1,29 @@
 import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import SectionHeader from '../SectionHeader/SectionHeader';
+import TransitionDataPicker from '../TransitionDataPicker/TransitionDataPicker';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
-const BudgetTransitionStatusSection: React.FC = () => (
-  <Content id="budget-transition-status">
-    <SectionHeader
-      title="Budget Transition Status"
-      subtitle="Some context about the trends that will be occurring, as it relates to expense and endgame that visually telegraph the changes."
-    />
+const BudgetTransitionStatusSection: React.FC = () => {
+  const { isLight } = useThemeContext();
 
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        height: 350,
-        background: '#e5e5e5',
-      }}
-    >
-      Chart...
-    </div>
-  </Content>
-);
+  return (
+    <Content id="budget-transition-status">
+      <SectionHeader
+        title="Budget Transition Status"
+        subtitle="Some context about the trends that will be occurring, as it relates to expense and endgame that visually telegraph the changes."
+      />
+
+      <Card isLight={isLight}>
+        <WidthRestriction>
+          <TransitionDataPicker />
+        </WidthRestriction>
+      </Card>
+    </Content>
+  );
+};
 
 export default BudgetTransitionStatusSection;
 
@@ -31,3 +33,33 @@ const Content = styled.section({
   gap: 40,
   scrollMarginTop: 130, // here
 });
+
+const WidthRestriction = styled.div({
+  margin: '0 auto',
+  width: '100%',
+
+  [lightTheme.breakpoints.up('desktop_1194')]: {
+    maxWidth: 932,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    maxWidth: 1028,
+  },
+});
+
+const Card = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+  borderRadius: 6,
+  padding: '16px 8px 24px',
+  background: isLight ? '#fff' : 'red',
+  border: `1px solid ${isLight ? 'rgba(212, 217, 225, 0.25)' : 'red'}`,
+  boxShadow: isLight
+    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
+    : '0px 1px 3px 0px red, 0px 20px 40px 0px red',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    padding: '16px 54px 32px',
+  },
+}));

--- a/src/stories/containers/Endgame/components/TransitionDataPicker/TransitionDataPicker.tsx
+++ b/src/stories/containers/Endgame/components/TransitionDataPicker/TransitionDataPicker.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled';
+import { CustomButton } from '@ses/components/CustomButton/CustomButton';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+const TransitionDataPicker: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <Content>
+      <DataButton isLight={isLight} label={'Actuals'} />
+      <DataButton isLight={isLight} selected={true} label={'Budget Cap'} />
+    </Content>
+  );
+};
+
+export default TransitionDataPicker;
+
+const Content = styled.div({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: 16,
+});
+
+const DataButton = styled(CustomButton)<WithIsLight & { selected?: boolean }>(({ isLight, selected }) => ({
+  background: isLight ? (selected ? '#1AAB9B' : 'transparent') : selected ? '#098C7D' : 'transparent',
+  borderColor: isLight ? (selected ? '#1AAB9B' : '#D4D9E1') : selected ? '#098C7D' : '#708390',
+  borderRadius: '22px',
+  fontFamily: 'Inter, sans serif',
+  fontStyle: 'normal',
+  padding: '7px 23px',
+  //   width: 83,
+  //   height: 34,
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    // width: 120,
+    // height: 48,
+  },
+
+  '& > div': {
+    color: isLight ? (selected ? '#FFFFFF' : '#9FAFB9') : selected ? '#FFFFFF' : '#ADAFD4',
+    fontWeight: 500,
+    fontSize: 14,
+    lineHeight: '18px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+
+    [lightTheme.breakpoints.up('table_834')]: {
+      //   fontSize: '16px!important',
+      //   lineHeight: '19px!important',
+    },
+  },
+
+  ...(!selected
+    ? {
+        '&:hover': {
+          background: isLight ? '#F6F8F9' : '#10191F',
+          border: `1px solid ${isLight ? '#ECF1F3' : '#1E2C37'}}`,
+
+          '&:hover > div': {
+            color: `${isLight ? '#787A9B' : '#D2D4EF'}!important`,
+          },
+        },
+      }
+    : {}),
+}));

--- a/src/stories/containers/Endgame/components/TransitionDataPicker/TransitionDataPicker.tsx
+++ b/src/stories/containers/Endgame/components/TransitionDataPicker/TransitionDataPicker.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import { CustomButton } from '@ses/components/CustomButton/CustomButton';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
@@ -31,13 +30,6 @@ const DataButton = styled(CustomButton)<WithIsLight & { selected?: boolean }>(({
   fontFamily: 'Inter, sans serif',
   fontStyle: 'normal',
   padding: '7px 23px',
-  //   width: 83,
-  //   height: 34,
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    // width: 120,
-    // height: 48,
-  },
 
   '& > div': {
     color: isLight ? (selected ? '#FFFFFF' : '#9FAFB9') : selected ? '#FFFFFF' : '#ADAFD4',
@@ -47,11 +39,6 @@ const DataButton = styled(CustomButton)<WithIsLight & { selected?: boolean }>(({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-
-    [lightTheme.breakpoints.up('table_834')]: {
-      //   fontSize: '16px!important',
-      //   lineHeight: '19px!important',
-    },
   },
 
   ...(!selected


### PR DESCRIPTION
# Ticket
https://trello.com/c/K6BCBa9u/293-user-story-visualization-of-budget-transition-status

# Description
Added the card for the Transition status section of the endgame page + the button group (without behavior)

# What solved
- [X] Should add a card to contain the chart
- [X] Should add a toggle button group to select between the Actuals and the Budget cap