### PR TITLE
[SES-QC] Fix restoring expense report content

### DIFF
--- a/src/core/hooks/useTransparencyReportingTabs.tsx
+++ b/src/core/hooks/useTransparencyReportingTabs.tsx
@@ -156,7 +156,7 @@ const useTransparencyReportingTabs = ({
             undefined,
             { shallow: true }
           );
-          setTabsIndex(TRANSPARENCY_IDS_ENUM.EXPENSE_REPORT);
+          setTabsIndex(TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS);
         }
       }
     };


### PR DESCRIPTION
# Ticket
https://trello.com/c/udGDe7fW/278-qc-round-r

# Description
By default restoring the expense report content was showing the "Expense report" content in auditor view instead of "Account Snapshots"

# What solved
- [X] When clicking the Expense Reports, the expense reports page opens with the Snapshot Report tab activated, but the content shows the Expense Report, intended behavior is that it shows the corresponding Snapshot Report content.