### PR TITLE
[No-ticket-278]Add correct link

### DIFF
--- a/src/core/businessLogic/coreUnits.ts
+++ b/src/core/businessLogic/coreUnits.ts
@@ -341,7 +341,7 @@ export const getLast3MonthsWithDataFormatted = (cu: CoreUnit) => {
 
 export const getMipUrlFromCoreUnit = (cu: CoreUnit) => {
   if (cu?.cuMip.length === 0) return '';
-  return cu?.cuMip[0].mipUrl ?? '';
+  return cu?.cuMip[cu.cuMip.length - 1].mipUrl ?? '';
 };
 
 export const getAllCommentsBudgetStatementLine = (budgetStatement?: BudgetStatement) => {


### PR DESCRIPTION
# Ticket
https://trello.com/c/udGDe7fW/278-qc-round-r

# What solved
- [X]  Core Units, CU About views. Selecting the *since* date link. **Current Output:** The links for the obsolete mips when clicked take you to the onboarding mips, e.g. the Gov Alpha offboarded since link takes you to 'MIP39c2-SP3 ' - it should go to 'MIP39c3-SP10'.

# Description
Add correct link in the absolute CU also