### PR TITLE
[No-ticket] Fix links for absolutes

### DIFF
--- a/src/core/businessLogic/coreUnits.ts
+++ b/src/core/businessLogic/coreUnits.ts
@@ -340,8 +340,9 @@ export const getLast3MonthsWithDataFormatted = (cu: CoreUnit) => {
 };
 
 export const getMipUrlFromCoreUnit = (cu: CoreUnit) => {
+  const mipStatus = getStatusMip39AcceptedOrObsolete(cu);
   if (cu?.cuMip.length === 0) return '';
-  return cu?.cuMip[cu.cuMip.length - 1].mipUrl ?? '';
+  return mipStatus === CuMipStatus.Obsolete ? cu.cuMip[cu.cuMip.length - 1].mipUrl : cu.cuMip[0].mipUrl;
 };
 
 export const getAllCommentsBudgetStatementLine = (budgetStatement?: BudgetStatement) => {

--- a/src/stories/components/TitleNavigationCuAbout/TitleNavigationCuAbout.tsx
+++ b/src/stories/components/TitleNavigationCuAbout/TitleNavigationCuAbout.tsx
@@ -7,6 +7,7 @@ import lightTheme from '../../../../styles/theme/light';
 import {
   getLatestMip39FromCoreUnit,
   getLinksFromCoreUnit,
+  getMipUrlFromCoreUnit,
   getStatusMip39AcceptedOrObsolete,
   getSubmissionDateFromCuMip,
 } from '../../../core/businessLogic/coreUnits';
@@ -17,7 +18,6 @@ import { CuTableColumnLinks } from '../CuTableColumnLinks/CuTableColumnLinks';
 import { CustomLink } from '../CustomLink/CustomLink';
 import { StatusChip } from '../StatusChip/StatusChip';
 import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
-import type { CuMipStatus } from '@ses/core/models/interfaces/types';
 
 interface Props {
   coreUnitAbout?: CoreUnit;
@@ -59,11 +59,11 @@ export const TitleNavigationCuAbout = ({ coreUnitAbout }: Props) => {
                 flexDirection: 'row',
               }}
             >
-              {mipStatus && <StatusChip status={mipStatus as CuMipStatus} />}
+              {mipStatus && <StatusChip status={mipStatus} />}
               <Row>
                 {newDate && (
                   <CustomLink
-                    href={coreUnitAbout.cuMip[0].mipUrl || '#'}
+                    href={getMipUrlFromCoreUnit(coreUnitAbout)}
                     withArrow
                     styleIcon={{
                       marginTop: '3px',


### PR DESCRIPTION
# Ticket

https://trello.com/c/JHKHOrzX/294-feature-budget-summary-navigation

# What solved
- [X]  Core Units, CU About views. Selecting the *since* date link. **Current Output:** The links for the obsolete mips when clicked take you to the onboarding mips, e.g. the Gov Alpha offboarded since link takes you to 'MIP39c2-SP3 ' - it should go to 'MIP39c3-SP10'.

# Description
Fix function to get correct link


