### PR TITLE
fix: apple devies endgame scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "graphql": "^16.5.0",
     "graphql-request": "^4.3.0",
     "identicon.js": "^2.3.3",
+    "intersection-observer": "^0.12.2",
     "jwt-decode": "^3.1.2",
     "luxon": "^2.4.0",
     "marked-react": "^1.1.2",

--- a/src/stories/containers/Endgame/EndgameContainer.tsx
+++ b/src/stories/containers/Endgame/EndgameContainer.tsx
@@ -1,12 +1,11 @@
+import 'intersection-observer'; // polyfill
 import styled from '@emotion/styled';
 import Container from '@ses/components/Container/Container';
 import PageContainer from '@ses/components/Container/PageContainer';
 import { SEOHead } from '@ses/components/SEOHead/SEOHead';
 import { toAbsoluteURL } from '@ses/core/utils/urls';
 import lightTheme from '@ses/styles/theme/light';
-
 import React from 'react';
-
 import BudgetStructureSection from './components/BudgetStructureSection/BudgetStructureSection';
 import BudgetTransitionStatusSection from './components/BudgetTransitionStatusSection/BudgetTransitionStatusSection';
 import EndgameIntroductionBanner from './components/EndgameIntroductionBanner/EndgameIntroductionBanner';

--- a/src/stories/containers/Endgame/components/NavigationTabs/NavigationTabs.tsx
+++ b/src/stories/containers/Endgame/components/NavigationTabs/NavigationTabs.tsx
@@ -66,7 +66,7 @@ export default NavigationTabs;
 
 const Sticky = styled.div({
   position: 'sticky',
-  top: 64,
+  top: 63,
   zIndex: 2,
 });
 

--- a/src/stories/containers/Endgame/useEndgameContainer.ts
+++ b/src/stories/containers/Endgame/useEndgameContainer.ts
@@ -1,5 +1,7 @@
+import { useMediaQuery } from '@mui/material';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
+import lightTheme from '@ses/styles/theme/light';
 import { useCallback, useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import type { IntersectionOptions } from 'react-intersection-observer';
@@ -10,16 +12,18 @@ export enum NavigationTabEnum {
   BUDGET_TRANSITION_STATUS = 'budget-transition-status',
 }
 
-const INTERSECTION_OPTIONS: IntersectionOptions = {
-  threshold: 0.7,
-  fallbackInView: false,
-  rootMargin: '130px 0px 0px 0px',
-};
-
 const useEndgameContainer = () => {
   const { isLight } = useThemeContext();
   const [isEnabled] = useFlagsActive();
   const [pauseUrlUpdate, setPauseUrlUpdate] = useState<boolean>(false);
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+  const isUpDesktop1440 = useMediaQuery(lightTheme.breakpoints.up('desktop_1440'));
+
+  const INTERSECTION_OPTIONS: IntersectionOptions = {
+    threshold: isMobile ? 0.5 : isUpDesktop1440 ? 0.9 : 0.7,
+    fallbackInView: false,
+    rootMargin: '130px 0px 0px 0px',
+  };
 
   useEffect(() => {
     // scroll into a section on page load
@@ -43,9 +47,13 @@ const useEndgameContainer = () => {
     setTimeout(() => setPauseUrlUpdate(false), 700);
   }, []);
 
-  const { ref: keyChangesRef, inView: keyInView } = useInView(INTERSECTION_OPTIONS);
-  const { ref: structureRef, inView: structureInView } = useInView(INTERSECTION_OPTIONS);
-  const { ref: transitionStatusRef, inView: transitionInView } = useInView(INTERSECTION_OPTIONS);
+  const [keyChangesRef, keyInView, keyEntry] = useInView(INTERSECTION_OPTIONS);
+  const [structureRef, structureInView, structureEntry] = useInView(INTERSECTION_OPTIONS);
+  const [transitionStatusRef, transitionInView, transitionEntry] = useInView(INTERSECTION_OPTIONS);
+
+  const keyEntryTopY = keyEntry?.boundingClientRect?.y ?? 0;
+  const structureEntryTopY = structureEntry?.boundingClientRect?.y ?? 0;
+  const transitionEntryTopY = transitionEntry?.boundingClientRect?.y ?? 0;
 
   const [activeTab, setActiveTab] = useState<NavigationTabEnum>(NavigationTabEnum.KEY_CHANGES);
   useEffect(() => {
@@ -74,9 +82,33 @@ const useEndgameContainer = () => {
     } else if (structureInView) {
       activate(NavigationTabEnum.BUDGET_STRUCTURE);
     } else {
-      activate(NavigationTabEnum.KEY_CHANGES);
+      const hasBoundingData = keyEntryTopY !== 0 && structureEntryTopY !== 0 && transitionEntryTopY !== 0;
+      if (
+        !keyInView &&
+        !transitionInView &&
+        !structureInView &&
+        hasBoundingData &&
+        keyEntryTopY < 0 &&
+        transitionEntryTopY < 0
+      ) {
+        // it is close to the footer and any section is in the view
+        // activate this as is the last one
+        activate(NavigationTabEnum.BUDGET_TRANSITION_STATUS);
+      } else {
+        activate(NavigationTabEnum.KEY_CHANGES);
+      }
     }
-  }, [structureInView, transitionInView, keyInView, pauseUrlUpdate]);
+  }, [
+    structureInView,
+    transitionInView,
+    keyInView,
+    pauseUrlUpdate,
+    keyEntryTopY,
+    transitionEntryTopY,
+    transitionEntry,
+    structureEntry,
+    structureEntryTopY,
+  ]);
 
   return {
     isLight,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8737,6 +8737,11 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+intersection-observer@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.2.tgz#4a45349cc0cd91916682b1f44c28d7ec737dc375"
+  integrity sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==
+
 ip@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"


### PR DESCRIPTION
# Ticket
https://trello.com/c/ERuAdkUG/292-user-story-detailed-insight-into-endgame-budget-structure

# Description
Solved issue on iphone devices in the endgame navigation component

# What solved
- [X] **Expected Output:** The section should be displayed at the top of the screen the tab should be marked. **Current Output:** The section is displayed at the top of the screen but the Key Changes tab is still marked (scrolling down has the same behavior). 