### PR TITLE
[SES-QC-278] account snapshot sorting

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/reserveUtils.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/reserveUtils.ts
@@ -45,5 +45,5 @@ export const getReserveAccounts = (
             })),
         } as UIReservesData)
     )
-    .sort((a, b) => parseInt(a.id) - parseInt(b.id));
+    .sort((a, b) => parseInt(b.upstreamAccountId) - parseInt(a.upstreamAccountId));
 };


### PR DESCRIPTION
# Ticket
https://trello.com/c/udGDe7fW/278-qc-round-r

# Description
Change the Account snapshots sorting in the "Total Core Unit Reserves" section

# What solved
- []  (Core Units and Ecosystem Actors) Expense Reports view, Accounts Snapshot tab. On Chain Reserves and Off-Chain Reserves sections. **Expected Output:** The wallets should be sorted by upstreamAccountId.