### PR TITLE
feat: add support to keepers & delegates

### DIFF
--- a/pages/snapshots/[...data].tsx
+++ b/pages/snapshots/[...data].tsx
@@ -29,8 +29,18 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   }
 
   const { query } = context;
-  const { ownerType, ownerId } = query;
-  if (!ownerType || !ownerId || isNaN(ownerId as unknown as number)) {
+
+  const { data } = query;
+  if (!(data?.length === 1 || data?.length === 2)) {
+    return {
+      // wrong amount of params
+      notFound: true,
+    };
+  }
+  const ownerType = data[0];
+  const ownerId = data.length === 2 ? data[1] : null;
+
+  if (!ownerType || (ownerId !== null && isNaN(ownerId as unknown as number))) {
     return {
       notFound: true,
     };

--- a/src/core/models/interfaces/types.ts
+++ b/src/core/models/interfaces/types.ts
@@ -2,6 +2,7 @@ export enum ResourceType {
   AlignedDelegates = 'AlignedDelegates',
   CoreUnit = 'CoreUnit',
   Delegates = 'Delegates',
+  Keepers = 'Keepers',
   EcosystemActor = 'EcosystemActor',
   System = 'System',
 }

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
@@ -160,11 +160,16 @@ export const generateSnapshotOwnerString = async (ownerType: string, ownerId: st
         return `${shortCode} Core Unit`;
       }
       case 'DelegatesDraft':
+      case 'Delegates':
         return 'Recognized Delegates';
+      case 'EcosystemActor':
       case 'EcosystemActorDraft': {
         const shortCode = await getTeamsShortCode(ownerId);
         return `${shortCode} Ecosystem Actor`;
       }
+      case 'Keepers':
+      case 'KeepersDraft':
+        return 'Keepers';
     }
   } catch (error) {}
   return '';


### PR DESCRIPTION
# Ticket
https://trello.com/c/OTAKvqeH/308-user-story-delegates-and-keepers-snapshot-reports

# Description
Add support for recognized delegates and keepers in the temporary snapshot page

# What solved
- [X] Should show the snapshot data for recognized delegates on the snapshots page
- [X] Should add types and utilities support for keepers
- [X] Should show the snapshots data for keepers in the snapshots page