### PR TITLE
[SES-308] Account Snapshots Reserve card focus

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/Cards/ReserveCard.tsx
@@ -134,6 +134,10 @@ const Card = styled(MuiAccordionSummary)<WithIsLight & { hasTransactions: boolea
       padding: 0,
     },
 
+    '&.Mui-focusVisible': {
+      backgroundColor: isLight ? '#ffffff' : '#1E2C37',
+    },
+
     '&.Mui-expanded': {
       [lightTheme.breakpoints.down('table_834')]: {
         borderRadius: '6px 6px 0 0',


### PR DESCRIPTION
# Ticket
https://trello.com/c/OTAKvqeH/308-user-story-delegates-and-keepers-snapshot-reports

# Description
Fixed focus color

# What solved
- [X] Recognized Delegates. Select the Include Off-Chain Reserves checkbox. **Expected Output:** The Off Chain Reserves section should be displayed as active. The same behavior is displayed in the Snapshot view. **Current Output:** The section is displayed with the focus property active.