### PR TITLE
Add actors Breakdown

### DIFF
--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
@@ -150,11 +150,26 @@ const variantsArgs = [
         .extend('DUX', 'Development & UX')
         .build(),
       new TotalExpenseReportsBuilder()
+        .withPrediction(779481)
+        .withActuals(329481)
+        .withAnnualPeriod(2023)
+        .withBudget('/makerdao/ecosystem-actors')
+        .extend('DEWIZ', 'DEWIZ')
+
+        .build(),
+      new TotalExpenseReportsBuilder()
         .withPrediction(425631)
         .withActuals(1082362)
         .withAnnualPeriod(2023)
         .extend('TEST', 'Testing')
         .build(),
+      new TotalExpenseReportsBuilder()
+        .withPrediction(425631)
+        .withActuals(1082362)
+        .withAnnualPeriod(2023)
+        .extend('TEST', 'Testing')
+        .build(),
+
       new TotalExpenseReportsBuilder()
         .withBudget('delegates')
         .withPrediction(415631)
@@ -248,7 +263,8 @@ LightMode.parameters = {
   figma: {
     component: {
       0: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=15491:165746',
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=15491:165746&mode=dev',
         options: {
           componentStyle: {
             width: 343,
@@ -257,7 +273,8 @@ LightMode.parameters = {
         },
       },
       834: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20804:267229',
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20804:267229&mode=dev',
         options: {
           componentStyle: {
             width: 802,
@@ -266,7 +283,8 @@ LightMode.parameters = {
         },
       },
       1194: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399:144041',
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399-144041&mode=dev',
         options: {
           componentStyle: {
             width: 1162,
@@ -275,7 +293,8 @@ LightMode.parameters = {
         },
       },
       1280: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399:143348',
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399-143348&mode=dev',
         options: {
           componentStyle: {
             width: 1248,
@@ -284,7 +303,8 @@ LightMode.parameters = {
         },
       },
       1440: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=15343:199079',
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=15343:199079&mode=dev',
         options: {
           componentStyle: {
             width: 1408,
@@ -293,7 +313,8 @@ LightMode.parameters = {
         },
       },
       1920: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399:142663',
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399:142663&mode=dev',
         options: {
           componentStyle: {
             width: 1888,

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
@@ -284,7 +284,7 @@ LightMode.parameters = {
       },
       1194: {
         component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399-144041&mode=dev',
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399:144041&mode=design&t=iwdjYJMPNwmgoBQ3-4',
         options: {
           componentStyle: {
             width: 1162,
@@ -294,7 +294,7 @@ LightMode.parameters = {
       },
       1280: {
         component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399-143348&mode=dev',
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399:143348&mode=dev',
         options: {
           componentStyle: {
             width: 1248,

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.tsx
@@ -54,6 +54,7 @@ const FinancesOverviewContainer: React.FC<FinancesOverviewContainerProps> = ({
     remainingCategories,
     maxValueByCategory,
     costBreakdownTotal,
+    remainingEcosystemActors,
   } = useFinancesOverview(quarterExpenses, monthlyExpenses, byBudgetBreakdownExpenses, byCategoryBreakdownExpenses);
 
   return (
@@ -96,6 +97,7 @@ const FinancesOverviewContainer: React.FC<FinancesOverviewContainerProps> = ({
 
           <BreakdownTableColumn>
             <CostBreakdownTable
+              remainingEcosystemActors={remainingEcosystemActors}
               selectedFilter={selectedFilter}
               setSelectedFilter={setSelectedFilter}
               byBudgetExpenses={byBudgetExpenses}

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
@@ -14,7 +14,7 @@ interface ByBudgetTableRowProps {
   expense: ExtendedExpense;
   total: number;
   relativePercentage?: number;
-  rowType: 'coreUnit' | 'delegate' | 'remaining';
+  rowType: 'coreUnit' | 'delegate' | 'remaining' | 'ecosystemActor';
 }
 
 const ByBudgetTableRow: React.FC<ByBudgetTableRowProps> = ({
@@ -31,6 +31,8 @@ const ByBudgetTableRow: React.FC<ByBudgetTableRowProps> = ({
       ? siteRoutes.coreUnitReports(expense.shortCode ?? '')
       : rowType === 'delegate' || expense.shortCode === 'DEL'
       ? siteRoutes.recognizedDelegateReport
+      : rowType === 'ecosystemActor'
+      ? siteRoutes.ecosystemActorReports(expense.shortCode ?? '')
       : siteRoutes.coreUnitsOverview;
 
   return (

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -5,7 +5,7 @@ import { percentageRespectTo } from '@ses/core/utils/math';
 import { pascalCaseToNormalString } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
-import { isCoreUnitExpense } from '../../utils/costBreakdown';
+import { isCoreUnitExpense, isEcosystemActorExpense } from '../../utils/costBreakdown';
 import CostBreakdownFilter from '../CostBreakdownFilter/CostBreakdownFilter';
 import ByBudgetTableHeader from './ByBudgetTableHeader';
 import ByBudgetTableRow from './ByBudgetTableRow';
@@ -23,6 +23,7 @@ export interface CostBreakdownTableProps {
   byBudgetExpenses: ExtendedExpense[];
   remainingBudgetCU: ExtendedExpense;
   remainingBudgetDelegates: ExtendedExpense;
+  remainingEcosystemActors: ExtendedExpense;
   maxValueByBudget: number;
   byCategoryExpenses: {
     headcount: ExpenseDto[];
@@ -40,6 +41,7 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
   byBudgetExpenses,
   remainingBudgetCU,
   remainingBudgetDelegates,
+  remainingEcosystemActors,
   maxValueByBudget,
   byCategoryExpenses,
   remainingCategories,
@@ -65,7 +67,13 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
                   expense={budget}
                   total={total}
                   relativePercentage={percentageRespectTo(budget.prediction, maxValueByBudget)}
-                  rowType={isCoreUnitExpense(budget) ? 'coreUnit' : 'delegate'}
+                  rowType={
+                    isCoreUnitExpense(budget)
+                      ? 'coreUnit'
+                      : isEcosystemActorExpense(budget)
+                      ? 'ecosystemActor'
+                      : 'delegate'
+                  }
                   key={i}
                 />
               ))}
@@ -89,6 +97,17 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
                       byBudgetExpenses[0]?.prediction
                     )}
                     rowType={'remaining'}
+                  />
+                )}
+                {remainingEcosystemActors?.prediction > 0 && (
+                  <ByBudgetTableRow
+                    expense={remainingEcosystemActors}
+                    total={total}
+                    relativePercentage={percentageRespectTo(
+                      remainingEcosystemActors?.prediction,
+                      byBudgetExpenses[0]?.prediction
+                    )}
+                    rowType={'ecosystemActor'}
                   />
                 )}
               </RemainingContainer>

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -14,6 +14,7 @@ import ByExpenseCategoryTableRow from './ByExpenseCategoryTableRow';
 import ExpenseCategoryGroup from './ExpenseCategoryGroup';
 import TableFooter from './TableFooter';
 import type { CostBreakdownFilterValue, ExtendedExpense } from '../../financesOverviewTypes';
+import type { TableFooterProps } from './TableFooter';
 import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
@@ -152,7 +153,7 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
             </>
           )}
         </TableBody>
-        <TableFooter mode={selectedFilter} total={total} />
+        <TableFooterStyled mode={selectedFilter} total={total} />
       </Table>
     </BreakdownTableContainer>
   );
@@ -226,4 +227,8 @@ const ContainerOpenModal = styled.div<WithIsLight>(({ isLight }) => ({
   [lightTheme.breakpoints.up('table_834')]: {
     display: 'none',
   },
+}));
+
+const TableFooterStyled = styled(TableFooter)<TableFooterProps>(({ mode }) => ({
+  paddingTop: mode === 'By budget' ? 10 : 8,
 }));

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/TableFooter.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/TableFooter.tsx
@@ -6,16 +6,17 @@ import React from 'react';
 import type { CostBreakdownFilterValue } from '../../financesOverviewTypes';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
-interface TableFooterProps {
+export interface TableFooterProps {
   mode: CostBreakdownFilterValue;
   total: number;
+  className?: string;
 }
 
-const TableFooter: React.FC<TableFooterProps> = ({ mode, total = 0 }) => {
+const TableFooter: React.FC<TableFooterProps> = ({ mode, total = 0, className }) => {
   const { isLight } = useThemeContext();
 
   return (
-    <TableFooterContainer isLight={isLight}>
+    <TableFooterContainer isLight={isLight} className={className}>
       <Total isLight={isLight}>Total </Total>
       <TotalNumber isLight={isLight} extraPadding={mode === 'By budget'}>
         {usLocalizedNumber(Math.round(total))} <DAISpan isLight={isLight}>DAI</DAISpan>

--- a/src/stories/containers/FinancesOverview/components/NavigationButtons/NavigationButtons.tsx
+++ b/src/stories/containers/FinancesOverview/components/NavigationButtons/NavigationButtons.tsx
@@ -27,16 +27,20 @@ const NavigationButtonsContainer = styled.div({
     flexDirection: 'row',
     justifyContent: 'center',
     gap: 24,
+    padding: 0,
     maxWidth: 738,
     margin: '46px auto 0',
   },
 
   [lightTheme.breakpoints.up('desktop_1194')]: {
     flexDirection: 'column',
-    margin: '37px auto 0',
+    margin: '32px auto 0',
     maxWidth: 320,
     padding: 0,
     gap: 16,
+  },
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    margin: '32px auto 0',
   },
 });
 
@@ -50,5 +54,8 @@ const Button = styled(LinkButton)({
     width: '100%',
     fontSize: 16,
     lineHeight: '19px',
+  },
+  [lightTheme.breakpoints.up('table_834')]: {
+    minWidth: 218,
   },
 });

--- a/src/stories/containers/FinancesOverview/components/NavigationButtons/NavigationButtons.tsx
+++ b/src/stories/containers/FinancesOverview/components/NavigationButtons/NavigationButtons.tsx
@@ -20,7 +20,7 @@ const NavigationButtonsContainer = styled.div({
   flexDirection: 'column',
   gap: 16,
   width: '100%',
-  margin: '10px auto 0',
+  margin: '12px auto 0',
   padding: '0 22px',
 
   [lightTheme.breakpoints.up('table_834')]: {

--- a/src/stories/containers/FinancesOverview/utils/costBreakdown.ts
+++ b/src/stories/containers/FinancesOverview/utils/costBreakdown.ts
@@ -1,6 +1,8 @@
 import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
 
 export const isCoreUnitExpense = (expense: ExpenseDto): boolean => expense.budget.includes('makerdao/core-unit');
+export const isEcosystemActorExpense = (expense: ExpenseDto): boolean =>
+  expense.budget.includes('makerdao/ecosystem-actor');
 
 export const mutableCombinationExpenseByAdding = (expenseA: ExpenseDto, expenseB: ExpenseDto): void => {
   expenseA.actuals += expenseB.actuals;


### PR DESCRIPTION
# Ticket

https://trello.com/c/JHKHOrzX/294-feature-budget-summary-navigation

# What solved
- [X] Finances view. By Budget section.  **Expected Output: ** The DEWIZ ecosystem actor should be displayed instead of "DEL - Recognized Delegates".

- [X] Finances view. Total Reported Expenses sections, the chart section.  **Expected Output: ** The values should include new ecosystem actor. 

- [X] Finances view. By Budget section.  **Expected Output: ** The DEWIZ ecosystem actor should have the View option that directs to its expense reports view. **Current Output:** The View option redirects to the recognized delegates. 

- [X] Finances view. By Budget section.  **Expected Output: ** The EA - Remaining Ecosystem Actors should be added.  

- [X]  The query should be updated. * On dev, we deployed a new version of the API that correctly categorizes the new ecosystem actors now. (They used to be reported as core units.)


# Description
Add ecosystem actors to query in finances