### PR TITLE
Add fix header in CoreUnitSummary

### DIFF
--- a/src/stories/containers/CUAbout/CuAboutContainer.tsx
+++ b/src/stories/containers/CUAbout/CuAboutContainer.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { Divider, useMediaQuery } from '@mui/material';
 import { siteRoutes } from '@ses/config/routes';
+import { useHeaderSummary } from '@ses/core/hooks/useHeaderSummary';
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import lightTheme from '../../../../styles/theme/light';
@@ -31,6 +32,7 @@ interface Props {
 
 const CuAboutContainer = ({ code, coreUnits, cuAbout }: Props) => {
   const router = useRouter();
+
   const { isLight } = useThemeContext();
   const [showThreeMIPs, setShowThreeMIPs] = useState<boolean>(true);
   const [isEnabled] = useFlagsActive();
@@ -40,13 +42,14 @@ const CuAboutContainer = ({ code, coreUnits, cuAbout }: Props) => {
   const LessPhone = useMediaQuery(lightTheme.breakpoints.down('mobile_375'));
   const lessDesktop1194 = useMediaQuery(lightTheme.breakpoints.down('desktop_1194'));
 
-  const { onClickLessMips, relateMipsOrder, hasMipsNotAccepted, queryStrings } = useCuAbout({
+  const { onClickLessMips, relateMipsOrder, hasMipsNotAccepted, queryStrings, ref } = useCuAbout({
     cuAbout,
     code,
     router,
     showThreeMIPs,
     setShowThreeMIPs,
   });
+  const { height, showHeader } = useHeaderSummary(ref, router.query.code as string);
 
   return (
     <ContainerAbout isLight={isLight}>
@@ -58,9 +61,9 @@ const CuAboutContainer = ({ code, coreUnits, cuAbout }: Props) => {
         canonicalURL={siteRoutes.coreUnitAbout(code)}
       />
 
-      <CoreUnitSummary coreUnits={coreUnits} showDescription={true} />
+      <CoreUnitSummary coreUnits={coreUnits} showDescription={true} ref={ref} showHeader={showHeader} />
       <Wrapper>
-        <ContainerAllData>
+        <ContainerAllData marginTop={height}>
           <ContainerResponsive>
             <MarkdownContainer>
               <MdViewerContainer
@@ -350,13 +353,14 @@ const ContainerNoRelateMIps = styled.div({
   justifyContent: 'center',
 });
 
-const ContainerAllData = styled.div({
+const ContainerAllData = styled.div<{ marginTop: number }>(({ marginTop }) => ({
   maxWidth: '100%',
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
   marginRight: '64px',
   marginLeft: '64px',
+  marginTop,
   [lightTheme.breakpoints.up('desktop_1920')]: {
     marginRight: '0px',
     marginLeft: '0px',
@@ -373,7 +377,7 @@ const ContainerAllData = styled.div({
     marginRight: '16px',
     marginLeft: '16px',
   },
-});
+}));
 
 export const DividerStyle = styled(Divider)({
   width: '100%',

--- a/src/stories/containers/CUAbout/useCuAbout.ts
+++ b/src/stories/containers/CUAbout/useCuAbout.ts
@@ -1,6 +1,6 @@
 import { CuMipStatus } from '@ses/core/models/interfaces/types';
 import sortBy from 'lodash/sortBy';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useRef } from 'react';
 import { getRelateMipObjectFromCoreUnit } from '../../../core/businessLogic/coreUnitAbout';
 import { getArrayParam, getStringParam } from '../../../core/utils/filters';
 import { buildQueryString } from '../../../core/utils/urls';
@@ -17,6 +17,7 @@ interface Props {
 }
 
 export const useCuAbout = ({ cuAbout, code, router, setShowThreeMIPs, showThreeMIPs }: Props) => {
+  const ref = useRef<HTMLDivElement>(null);
   const filteredStatuses = useMemo(() => getArrayParam('filteredStatuses', router.query), [router.query]);
   const filteredCategories = useMemo(() => getArrayParam('filteredCategories', router.query), [router.query]);
   const searchText = useMemo(() => getStringParam('searchText', router.query), [router.query]);
@@ -66,5 +67,6 @@ export const useCuAbout = ({ cuAbout, code, router, setShowThreeMIPs, showThreeM
     setShowThreeMIPs,
     onClickActivity,
     queryStrings,
+    ref,
   };
 };

--- a/src/stories/containers/CUActivity/CUActivityFeedContainer.tsx
+++ b/src/stories/containers/CUActivity/CUActivityFeedContainer.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { siteRoutes } from '@ses/config/routes';
+import { useHeaderSummary } from '@ses/core/hooks/useHeaderSummary';
 import React from 'react';
 import lightTheme from '../../../../styles/theme/light';
 import { toAbsoluteURL } from '../../../core/utils/urls';
@@ -17,7 +18,9 @@ interface CUActivityContainerProps {
 }
 
 const CUActivityFeedContainer: React.FC<CUActivityContainerProps> = ({ coreUnit, coreUnits, activities }) => {
-  const { isLight, columns, onSortClick } = useCuActivity();
+  const { isLight, columns, onSortClick, code, ref } = useCuActivity();
+
+  const { height, showHeader } = useHeaderSummary(ref, code);
   return (
     <Wrapper>
       <SEOHead
@@ -27,9 +30,15 @@ const CUActivityFeedContainer: React.FC<CUActivityContainerProps> = ({ coreUnit,
         twitterCard={coreUnit.image ? 'summary' : 'summary_large_image'}
         canonicalURL={siteRoutes.coreUnitActivityFeed(coreUnit.shortCode)}
       />
-      <CoreUnitSummary coreUnits={coreUnits} trailingAddress={['Activity Feed']} breadcrumbTitle="Activity Feed" />
+      <CoreUnitSummary
+        coreUnits={coreUnits}
+        trailingAddress={['Activity Feed']}
+        breadcrumbTitle="Activity Feed"
+        ref={ref}
+        showHeader={showHeader}
+      />
       <Container isLight={isLight}>
-        <InnerPage>
+        <InnerPage marginTop={height}>
           <TableWrapper>
             <ActivityTable
               columns={columns}
@@ -75,12 +84,13 @@ const Container = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   },
 }));
 
-const InnerPage = styled.div({
+const InnerPage = styled.div<{ marginTop: number }>(({ marginTop }) => ({
   display: 'block',
   textAlign: 'left',
   width: '100%',
   maxWidth: '1440px',
   margin: '0 auto',
+  marginTop,
   paddingTop: 24,
   paddingRight: '64px',
   paddingLeft: '64px',
@@ -105,7 +115,7 @@ const InnerPage = styled.div({
     paddingRight: '16px',
     paddingLeft: '16px',
   },
-});
+}));
 
 export const Title = styled.div<{
   marginBottom?: number;

--- a/src/stories/containers/CUActivity/useCuActivity.ts
+++ b/src/stories/containers/CUActivity/useCuActivity.ts
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useRef, useState } from 'react';
 import lightTheme from '../../../../styles/theme/light';
 import { useThemeContext } from '../../../core/context/ThemeContext';
 import { SortEnum } from '../../../core/enums/sortEnum';
@@ -6,7 +7,9 @@ import type { ActivityTableHeader } from '../../components/CUActivityTable/Activ
 
 export const useCuActivity = () => {
   const { isLight } = useThemeContext();
-
+  const router = useRouter();
+  const code = router.query.code as string;
+  const ref = useRef<HTMLDivElement>(null);
   const [columns, setColumns] = useState<ActivityTableHeader[]>([
     {
       header: 'Timestamp',
@@ -40,5 +43,7 @@ export const useCuActivity = () => {
     isLight,
     columns,
     onSortClick,
+    code,
+    ref,
   };
 };

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -5,8 +5,9 @@ import Tabs from '@ses/components/Tabs/Tabs';
 import BudgetStatementPager from '@ses/components/TransparencyReporting/BudgetStatementPager/BudgetStatementPager';
 import { siteRoutes } from '@ses/config/routes';
 import { ModalCategoriesProvider } from '@ses/core/context/CategoryModalContext';
+import { useHeaderSummary } from '@ses/core/hooks/useHeaderSummary';
 import { ResourceType } from '@ses/core/models/interfaces/types';
-import React from 'react';
+import React, { useRef } from 'react';
 import lightTheme from '../../../../styles/theme/light';
 import { CommentActivityContext } from '../../../core/context/CommentActivityContext';
 import { useThemeContext } from '../../../core/context/ThemeContext';
@@ -64,7 +65,8 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
     compressedTabItems,
   } = useTransparencyReport(coreUnit);
   const [isEnabled] = useFlagsActive();
-
+  const ref = useRef<HTMLDivElement>(null);
+  const { height, showHeader } = useHeaderSummary(ref, code);
   const headline = <CuHeadlineText cuLongCode={longCode} />;
   return (
     <Wrapper>
@@ -75,9 +77,15 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
         twitterCard={coreUnit.image ? 'summary' : 'summary_large_image'}
         canonicalURL={siteRoutes.coreUnitReports(coreUnit.shortCode)}
       />
-      <CoreUnitSummary coreUnits={coreUnits} trailingAddress={['Expense Reports']} breadcrumbTitle="Expense Reports" />
+      <CoreUnitSummary
+        coreUnits={coreUnits}
+        trailingAddress={['Expense Reports']}
+        breadcrumbTitle="Expense Reports"
+        showHeader={showHeader}
+        ref={ref}
+      />
       <PageContainer hasImageBackground={true}>
-        <PageSeparator>
+        <PageSeparator marginTop={height}>
           <Container>
             <BudgetStatementPager
               currentMonth={currentMonth}
@@ -254,14 +262,13 @@ const Wrapper = styled.div({
   width: '100%',
 });
 
-const PageSeparator = styled.div({
-  marginTop: 32,
-
+const PageSeparator = styled.div<{ marginTop: number }>(({ marginTop }) => ({
+  marginTop: `${32 + marginTop}px`,
   [lightTheme.breakpoints.up('table_834')]: {
     paddingTop: 32,
-    marginTop: 0,
+    marginTop,
   },
-});
+}));
 
 export const Title = styled.div<{
   marginBottom?: number;


### PR DESCRIPTION
# Ticket

https://trello.com/c/udGDe7fW/278-qc-round-1-r

# What solved
- [X]  Core Units view. Scroll down slightly on the information until the header just closes and it will bounce up and down given a specific mouse position. **Current Output:** There is a point on the Core Unit info page where the header section will bounce between hidden and showing. (Transparency Report and About Page of Core Units)

# Description
Add fix in the header summary for the page of about page of core unit and transparency report for core unit