### PR TITLE
[Not-ticket-294] Fix colors and add correct links

### DIFF
--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
@@ -582,11 +582,14 @@ const ContainerReportingMobile = styled.div({
 
 const LabelTagMobile = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'flex',
-  color: isLight ? '#9FAFB9' : '#D2D4EF',
+  color: isLight ? '#708390' : '#D2D4EF',
   fontSize: 11,
   fontStyle: 'normal',
   fontWeight: 400,
   lineHeight: 'normal',
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    color: isLight ? '#9FAFB9' : '#D2D4EF',
+  },
 }));
 
 const ExpenseReportStatusIndicatorMobile = styled(ExpenseReportStatusIndicator)({
@@ -627,6 +630,12 @@ const ReportingMobile = styled.div({
 });
 
 const ActorLastModifiedStyled = styled(ActorLastModified)({
+  '& > div:first-of-type': {
+    color: '#9FAFB9',
+  },
+  '& > div:last-of-type': {
+    color: '#708390',
+  },
   [lightTheme.breakpoints.between('tablet_768', 'desktop_1024')]: {
     padding: '2px 10px',
   },

--- a/src/stories/containers/Finances/components/SeccionPages/DelegateExpenseTrendFinances/DelegateExpenseTrendFinances.tsx
+++ b/src/stories/containers/Finances/components/SeccionPages/DelegateExpenseTrendFinances/DelegateExpenseTrendFinances.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import BigButton from '@ses/components/Button/BigButton/BigButton';
+import { getLinkLastExpenseReport } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
@@ -36,7 +37,12 @@ const DelegateExpenseTrendFinances: React.FC<Props> = ({
       </Header>
       <ItemSection>
         {expenseReport.map((expense, index) => (
-          <DelegateExpenseTrendItem key={index} expenseReport={expense} handleLinkToPage={handleLinkToPage} />
+          <DelegateExpenseTrendItem
+            key={index}
+            expenseReport={expense}
+            handleLinkToPage={handleLinkToPage}
+            link={getLinkLastExpenseReport(expense.shortCode, expenseReport)}
+          />
         ))}
       </ItemSection>
       {showSome && (

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -10,7 +10,12 @@ import { useMemo, useState } from 'react';
 import EndgameAtlasBudgets from './components/EndgameAtlasBudgets';
 import EndgameScopeBudgets from './components/EndgameScopeBudgets';
 import MakerDAOLegacyBudgets from './components/MakerDAOLegacyBudgets';
-import { getExpenseMonthWithData, getHeadersExpenseReport, mockDataApiTeam } from './utils/utils';
+import {
+  getExpenseMonthWithData,
+  getHeadersExpenseReport,
+  getLinkLastExpenseReport,
+  mockDataApiTeam,
+} from './utils/utils';
 import type { FilterDoughnut, MomentDataItem, NavigationCard, PeriodicSelectionFilter } from './utils/types';
 
 import type { SelectChangeEvent } from '@mui/material/Select';
@@ -20,6 +25,7 @@ import type { DoughnutSeries } from '@ses/core/models/interfaces/doughnutSeries'
 
 export const useFinances = () => {
   const { isLight } = useThemeContext();
+  const router = useRouter();
   const [showSome, setShowSome] = useState(true);
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const isSmallDesk = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
@@ -53,7 +59,6 @@ export const useFinances = () => {
 
   const [filterSelected, setFilterSelected] = useState<FilterDoughnut>('Budget');
   const [periodFilter, setPeriodFilter] = useState<PeriodicSelectionFilter>('Quarterly');
-  const router = useRouter();
 
   const [year, setYears] = useState(years[0]);
   const [isOpenYear, setIsOpenYear] = useState<boolean>(false);
@@ -234,9 +239,10 @@ export const useFinances = () => {
       color: isLight ? '#2DC1B1' : '#1AAB9B',
     },
   ];
+
   const handleLinkToPage = (href: string) => {
-    // Add the correct link when APi is ready
-    console.log('some links', href);
+    const link = getLinkLastExpenseReport(href, reportExpenseItems);
+    router.push(link || '');
   };
   const handleLoadMore = () => {
     setShowSome(!showSome);

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -1,3 +1,4 @@
+import { siteRoutes } from '@ses/config/routes';
 import { SortEnum } from '@ses/core/enums/sortEnum';
 import { BudgetStatus, ResourceType } from '@ses/core/models/interfaces/types';
 import lightTheme from '@ses/styles/theme/light';
@@ -578,3 +579,15 @@ export const enumForStories: SortEnum[] = [
   SortEnum.Neutral,
   SortEnum.Neutral,
 ];
+
+export const getLinkLastExpenseReport = (code: string, reportExpenseItems: MomentDataItem[]) => {
+  const reportResult = reportExpenseItems.find((report) => report.shortCode === code);
+  if (reportResult) {
+    const typeReport = isCoreUnit(reportResult);
+    if (typeReport) {
+      return siteRoutes.coreUnitAbout(code);
+    } else {
+      return siteRoutes.ecosystemActorAbout(code);
+    }
+  }
+};


### PR DESCRIPTION
# Ticket

https://trello.com/c/JHKHOrzX/294-feature-budget-summary-navigation

# What solved
- [X] The Last Modified text should have color: #9FAFB9 and the date should have color: #708390.
- [X] Reporting Month text (columns). **Expected Output:** The text should be displayed with color: #708390.
- [X] Selecting the entire row or the icon.  It should be directed to the core units/actors.   **Current Output:**  It is directed to the first section of the current view. 
- [X]  Selecting the View option.  It should be directed to the core units/actors. Nothing happens, the option is not 



# Description
Add some issues in last expense report