### PR TITLE
[SES-307] Start migrating snapshots to dspot library

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
         "Blockies",
         "clawback",
         "deepmerge",
+        "dspot",
         "Formik",
         "ftes",
         "gtag",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "classnames": "^2.3.2",
     "countup.js": "2.5.0",
     "deepmerge": "^4.3.1",
+    "dspot-powerhouse-components": "^1.0.0",
     "echarts": "^5.4.1",
     "echarts-for-react": "^3.0.2",
     "ethereum-blockies-base64": "^1.0.2",

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
@@ -1,8 +1,7 @@
 import { Box } from '@mui/material';
+import { AccountsSnapshot, AccountsSnapshotSkeleton, ThemeProvider } from 'dspot-powerhouse-components';
 import React from 'react';
 import { TransparencyEmptyTable } from '../Placeholders/TransparencyEmptyTable';
-import AccountsSnapshot from './AccountsSnapshot';
-import AccountsSnapshotSkeleton from './AccountsSnapshotSkeleton';
 import useAccountsSnapshotTab from './useAccountsSnapshotTab';
 import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { DateTime } from 'luxon';
@@ -24,16 +23,25 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
   shortCode,
   resource,
 }) => {
-  const { isLoading, snapshot, sinceDate } = useAccountsSnapshotTab(ownerId, currentMonth, resource);
+  const { isLoading, snapshot, sinceDate, isEmpty, isLight } = useAccountsSnapshotTab(ownerId, currentMonth, resource);
 
-  return isLoading ? (
-    <AccountsSnapshotSkeleton />
-  ) : snapshot ? (
-    <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} sinceDate={sinceDate} resourceType={resource} />
-  ) : (
+  return isEmpty ? (
     <Box sx={{ mb: '64px' }}>
       <TransparencyEmptyTable longCode={longCode} shortCode={shortCode} resource={resource} />
     </Box>
+  ) : (
+    <ThemeProvider isLight={isLight}>
+      {isLoading || !snapshot ? (
+        <AccountsSnapshotSkeleton />
+      ) : (
+        <AccountsSnapshot
+          snapshot={snapshot}
+          snapshotOwner={snapshotOwner}
+          sinceDate={sinceDate}
+          resourceType={resource}
+        />
+      )}
+    </ThemeProvider>
   );
 };
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/TemporaryContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/TemporaryContainer.tsx
@@ -3,8 +3,8 @@ import Container from '@ses/components/Container/Container';
 import PageContainer from '@ses/components/Container/PageContainer';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
+import { AccountsSnapshot, ThemeProvider } from 'dspot-powerhouse-components';
 import React from 'react';
-import AccountsSnapshot from './AccountsSnapshot';
 import type { Snapshots } from '@ses/core/models/dto/snapshotAccountDTO';
 import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -23,7 +23,9 @@ const TemporaryContainer: React.FC<TemporaryContainerProps> = ({ snapshot, snaps
       <Container>
         <Title isLight={isLight}>Account Snapshot</Title>
 
-        <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} resourceType={resourceType} />
+        <ThemeProvider isLight={isLight}>
+          <AccountsSnapshot snapshot={snapshot} snapshotOwner={snapshotOwner} resourceType={resourceType} />
+        </ThemeProvider>
       </Container>
     </PageContainer>
   );

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshotTab.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshotTab.ts
@@ -1,3 +1,4 @@
+import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { fetcher } from '@ses/core/utils/fetcher';
 import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
@@ -54,10 +55,17 @@ const useAccountsSnapshotTab = (ownerId: string, currentMonth: DateTime, resourc
     return new Date(Math.min(...validDates.map((date) => date.getTime())));
   }, [dateResponse?.snapshots]);
 
+  const isLoading = (!response && !errorFetchingSnapshots) || (!dateResponse && !errorFetchingDateSnapshots);
+  const snapshot = response?.snapshots?.[0];
+  const { isLight } = useThemeContext();
+  const isEmpty = isLoading || !snapshot;
+
   return {
-    isLoading: (!response && !errorFetchingSnapshots) || (!dateResponse && !errorFetchingDateSnapshots),
-    snapshot: response?.snapshots?.[0],
+    isLoading,
+    snapshot,
     sinceDate,
+    isLight,
+    isEmpty,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6756,6 +6756,11 @@ dotenv@^8.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
+dspot-powerhouse-components@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dspot-powerhouse-components/-/dspot-powerhouse-components-1.0.0.tgz#bf6043a81d240fb214fbc8ef32c9802f2062306f"
+  integrity sha512-O0xOT73W5K3Z9YTbn8EItZJrJh0T0LIg1dkQiprZ+PqQmQqtFH9GOxjzDMfu2cavBwzmRSolctqz2P4IxI8Gzw==
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"


### PR DESCRIPTION
# Ticket
https://trello.com/c/NsXo335v/307-account-snapshot-portability-research

# Description
Replace the current Account Snapshot implementation for the new Dspot-Powerhouse components library

# What solved
- [X] Should migrate the current project to use the new library