### PR TITLE
[SES-313] Adapt finances table to new breakpoints

### DIFF
--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
@@ -5,7 +5,6 @@ import AppLayout from '../AppLayout/AppLayout';
 import FinancesOverviewContainer from './FinancesOverviewContainer';
 import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
 import type { ComponentMeta } from '@storybook/react';
-import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
 
 export default {
   title: 'Pages/Finances Overview',
@@ -252,76 +251,3 @@ export const [[LightMode, DarkMode]] = createThemeModeVariants(
   ),
   variantsArgs
 );
-
-const optionStyles = {
-  style: {
-    top: -16,
-    left: -16,
-  },
-};
-LightMode.parameters = {
-  figma: {
-    component: {
-      0: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=15491:165746&mode=dev',
-        options: {
-          componentStyle: {
-            width: 343,
-          },
-          ...optionStyles,
-        },
-      },
-      834: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20804:267229&mode=dev',
-        options: {
-          componentStyle: {
-            width: 802,
-          },
-          ...optionStyles,
-        },
-      },
-      1194: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399:144041&mode=design&t=iwdjYJMPNwmgoBQ3-4',
-        options: {
-          componentStyle: {
-            width: 1162,
-          },
-          ...optionStyles,
-        },
-      },
-      1280: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399:143348&mode=dev',
-        options: {
-          componentStyle: {
-            width: 1248,
-          },
-          ...optionStyles,
-        },
-      },
-      1440: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=15343:199079&mode=dev',
-        options: {
-          componentStyle: {
-            width: 1408,
-          },
-          ...optionStyles,
-        },
-      },
-      1920: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=13399:142663&mode=dev',
-        options: {
-          componentStyle: {
-            width: 1888,
-          },
-          ...optionStyles,
-        },
-      },
-    },
-  } as FigmaParams,
-};

--- a/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
+++ b/src/stories/containers/FinancesOverview/FinancesOverviewContainer.stories.tsx
@@ -154,7 +154,6 @@ const variantsArgs = [
         .withAnnualPeriod(2023)
         .withBudget('/makerdao/ecosystem-actors')
         .extend('DEWIZ', 'DEWIZ')
-
         .build(),
       new TotalExpenseReportsBuilder()
         .withPrediction(425631)

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableHeader.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableHeader.tsx
@@ -25,11 +25,11 @@ const TableHeader = styled.div<WithIsLight>(({ isLight }) => ({
   borderBottom: `1px solid ${isLight ? '#D4D9E1' : '#405361'}`,
   padding: '16px 0 14px 0',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     display: 'flex',
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     padding: '16px 0',
   },
 }));
@@ -38,6 +38,18 @@ const BudgetColumn = styled(TableHeaderItem)({
   width: '100%',
   textAlign: 'left',
   paddingLeft: 16,
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    flex: 1.15,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    flex: 1.35,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    flex: 'auto',
+  },
 });
 
 const TotalPercentageColumn = styled(TableHeaderItem)({
@@ -46,9 +58,19 @@ const TotalPercentageColumn = styled(TableHeaderItem)({
   textAlign: 'right',
   paddingRight: 8,
 
-  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    width: 183.5,
-    minWidth: 183.5,
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    width: 'auto',
+    minWidth: 'auto',
+    flex: 1.1,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    flex: 1,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    width: 150,
+    minWidth: 150,
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
@@ -63,15 +85,25 @@ const TotalSpendColumn = styled(TableHeaderItem)({
   textAlign: 'right',
   paddingRight: 4,
 
-  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    width: 183.5,
-    minWidth: 183.5,
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    width: 'auto',
+    minWidth: 'auto',
+    flex: 0.85,
     paddingRight: 8,
   },
 
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    flex: 1,
+  },
+
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: 157,
-    minWidth: 157,
+    width: 144,
+    minWidth: 144,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: 155,
+    minWidth: 155,
   },
 });
 
@@ -79,18 +111,23 @@ const ViewColumn = styled(TableHeaderItem)({
   width: 70,
   minWidth: 70,
 
-  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    width: 93,
-    minWidth: 93,
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    width: 110,
+    minWidth: 110,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    width: 126,
+    minWidth: 126,
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: 80,
-    minWidth: 80,
+    width: 106,
+    minWidth: 106,
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: 97,
-    minWidth: 97,
+    width: 115,
+    minWidth: 115,
   },
 });

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
@@ -24,7 +24,7 @@ const ByBudgetTableRow: React.FC<ByBudgetTableRowProps> = ({
   rowType = 'coreUnit',
 }) => {
   const { isLight } = useThemeContext();
-  const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
 
   const link =
     rowType === 'coreUnit'
@@ -51,9 +51,20 @@ const ByBudgetTableRow: React.FC<ByBudgetTableRowProps> = ({
       {!isMobile && <TotalSpendColumnComponent isLight={isLight} total={expense.prediction} />}
 
       <ViewColumn>
-        <Link href={link} passHref>
-          <ViewLink>View</ViewLink>
-        </Link>
+        {isMobile ? (
+          <MobileArrow isLight={isLight}>
+            <svg width="20" height="14" viewBox="0 0 20 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M19.5582 6.89376L19.668 7.00004L19.5582 7.10623L18.8793 7.76356L18.8784 7.76446L12.7641 13.6836C12.3283 14.1055 11.6217 14.1055 11.1859 13.6836C10.75 13.2616 10.75 12.5775 11.1859 12.1556L15.3954 8.0804H1.784C1.16764 8.0804 0.667969 7.59677 0.667969 7.00004C0.667969 6.40332 1.16764 5.91959 1.784 5.91959H15.3954L11.1859 1.84441C10.75 1.42248 10.75 0.738389 11.1859 0.316452C11.6217 -0.105484 12.3283 -0.105484 12.7641 0.316452L18.8784 6.23559L18.8793 6.2365L19.5582 6.89376Z"
+                fill="#434358"
+              />
+            </svg>
+          </MobileArrow>
+        ) : (
+          <Link href={link} passHref>
+            <ViewLink isLight={isLight}>View</ViewLink>
+          </Link>
+        )}
       </ViewColumn>
     </NavigableOnMobileRow>
   );
@@ -121,17 +132,18 @@ const Row = styled.div<WithIsLight>(({ isLight }) => ({
   alignItems: 'center',
   padding: 8,
   background: isLight ? '#FFFFFF' : '#1E2C37',
-  marginBottom: 9,
+  marginBottom: 8,
   boxShadow: isLight
     ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
     : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
   borderRadius: 6,
+  gap: 16,
 
   '&:hover': {
     background: isLight ? '#ECF1F3' : '#31424E',
   },
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     padding: '15px 0',
     boxShadow: 'none',
     background: 'transparent',
@@ -139,15 +151,30 @@ const Row = styled.div<WithIsLight>(({ isLight }) => ({
     marginBottom: 0,
     borderRadius: 0,
   },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    gap: 0,
+  },
 }));
 
 const MobileColumn = styled.div({
   display: 'flex',
   flexDirection: 'column',
+  width: '37%',
+  flex: 1,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     flexDirection: 'row',
-    width: '100%',
+    width: '30%',
+    flex: 1.55,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    flex: 1.35,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    flex: 'auto',
   },
 });
 
@@ -156,35 +183,42 @@ const NameColumn = styled.div({
   marginBottom: 9.2,
   lineHeight: '14px',
   fontSize: 14,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     paddingLeft: 16,
     paddingRight: 4,
     marginBottom: 0,
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     lineHeight: '23px',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    whiteSpace: 'normal',
+    paddingRight: 0,
   },
 });
 
 const TotalPercentageColumn = styled.div({
-  width: 145,
-  minWidth: 145,
+  flex: 1.1,
+  marginLeft: 'auto',
 
-  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    width: 183.5,
-    minWidth: 183.5,
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    flex: 1,
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    width: 170,
-    minWidth: 170,
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    width: 166,
+    minWidth: 166,
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: 180,
-    minWidth: 180,
+    width: 184,
+    minWidth: 184,
   },
 });
 
@@ -192,45 +226,54 @@ const TotalSpendColumn = styled.div({
   width: 153,
   minWidth: 153,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     textAlign: 'right',
+    flex: 0.85,
+    minWidth: 'auto',
+    width: 'auto',
   },
 
-  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    width: 183.5,
-    minWidth: 183.5,
+  [lightTheme.breakpoints.between('tablet_768', 'desktop_1024')]: {
     paddingRight: 4,
   },
 
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    flex: 0.95,
+  },
+
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: 157,
-    minWidth: 157,
+    width: 140,
+    minWidth: 140,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1440')]: {
+    width: 150,
+    minWidth: 150,
   },
 });
 
 const ViewColumn = styled.div({
-  width: 70,
-  minWidth: 70,
   textAlign: 'center',
-  display: 'none',
+  display: 'block',
+  borderLeft: `1px solid ${'#D4D9E1'}`,
+  padding: '5px 4px 5px 7px',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     display: 'block',
+    borderLeft: 'none',
+    padding: '0 14px 0 0',
   },
 
-  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
-    width: 93,
-    minWidth: 93,
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    padding: '0 23px 0 11px',
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: 80,
-    minWidth: 80,
+    padding: '0 14px 0 16px',
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: 97,
-    minWidth: 97,
+    padding: '0 19px',
   },
 });
 
@@ -243,7 +286,7 @@ const ShortCode = styled.span<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#9FAFB9' : '#546978',
   marginRight: 4,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
     fontWeight: 700,
     lineHeight: '22px',
@@ -256,7 +299,7 @@ const Name = styled.span<WithIsLight>(({ isLight }) => ({
   lineHeight: '14px',
   color: isLight ? '#231536' : '#D2D4EF ',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
     lineHeight: '22px',
   },
@@ -266,7 +309,7 @@ const TotalBarContainer = styled.div({
   display: 'flex',
   alignItems: 'center',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     padding: '0 8px',
   },
 });
@@ -280,6 +323,11 @@ const TotalPercentage = styled.span<WithIsLight>(({ isLight }) => ({
   width: 34,
   minWidth: 34,
   marginLeft: 4,
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    width: 44,
+    minWidth: 44,
+  },
 }));
 
 const TotalNumber = styled.div<WithIsLight>(({ isLight }) => ({
@@ -290,7 +338,7 @@ const TotalNumber = styled.div<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#231536' : '#D2D4EF',
   paddingRight: 4,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
     fontWeight: 400,
     lineHeight: '19px',
@@ -306,7 +354,7 @@ const DAISpan = styled.span({
   fontFeatureSettings: "'tnum' on, 'lnum' on",
   color: '#9FAFB9',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 'inherit',
     fontWeight: 'inherit',
     lineHeight: 'inherit',
@@ -314,9 +362,23 @@ const DAISpan = styled.span({
   },
 });
 
-const ViewLink = styled.a({
+const MobileArrow = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: 32,
+  height: 32,
+  borderRadius: 6,
+  background: isLight ? '#F9FAFF' : 'red',
+  boxShadow: isLight ? '0px 2px 3px 0px #DEE1F4' : 'red',
+}));
+
+const ViewLink = styled.a<WithIsLight>(({ isLight }) => ({
   fontSize: 14,
   fontWeight: 500,
   lineHeight: '18px',
-  color: '#1AAB9B',
-});
+  color: isLight ? '#31424E' : 'red',
+  padding: '7px 23px',
+  borderRadius: 22,
+  border: `1px solid ${isLight ? '#D4D9E1' : 'red'}`,
+}));

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableHeader.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableHeader.tsx
@@ -27,7 +27,7 @@ export default ByExpenseCategoryTableHeader;
 const TableHeader = styled.div({
   display: 'none',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     display: 'flex',
     padding: 16,
   },
@@ -47,7 +47,7 @@ const TotalPercentageColumn = styled(TableHeaderItem)({
   width: 240,
   minWidth: 240,
   textAlign: 'right',
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     width: 164,
     minWidth: 164,
   },
@@ -64,7 +64,7 @@ const TotalSpendColumn = styled(TableHeaderItem)({
   minWidth: 200,
   textAlign: 'right',
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     width: 154,
     minWidth: 154,
   },

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableRow.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableRow.tsx
@@ -22,7 +22,7 @@ const ByExpenseCategoryTableRow: React.FC<ByExpenseCategoryTableRowProps> = ({
   total,
 }) => {
   const { isLight } = useThemeContext();
-  const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
 
   return (
     <Row isLight={isLight}>
@@ -61,7 +61,7 @@ const Row = styled.div<WithIsLight>(({ isLight }) => ({
     background: isLight ? '#ECF1F3' : '#31424E',
   },
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     padding: '15px 0',
     boxShadow: 'none',
     background: 'transparent',
@@ -75,7 +75,7 @@ const MobileColumn = styled.div({
   display: 'flex',
   flexDirection: 'column',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     flexDirection: 'row',
     width: '100%',
   },
@@ -118,7 +118,7 @@ const NameColumn = styled.div({
   lineHeight: '15px',
   fontSize: 12,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     width: '100%',
     minWidth: '100%',
     paddingLeft: 16,
@@ -131,12 +131,12 @@ const TotalPercentageColumn = styled.div({
   width: 145,
   minWidth: 145,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     width: 240,
     minWidth: 240,
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     width: 180,
     minWidth: 180,
   },
@@ -152,14 +152,14 @@ const TotalSpendColumn = styled.div({
   minWidth: 153,
   lineHeight: '17px',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     textAlign: 'right',
     width: 216,
     minWidth: 216,
     paddingRight: 16,
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     width: 170,
     minWidth: 170,
   },
@@ -176,7 +176,7 @@ const Name = styled.span<WithIsLight>(({ isLight }) => ({
   lineHeight: '15px',
   color: isLight ? '#231536' : '#D2D4EF',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
     fontWeight: 400,
     lineHeight: '22px',
@@ -206,7 +206,7 @@ const TotalNumber = styled.span<WithIsLight>(({ isLight }) => ({
   fontFeatureSettings: "'tnum' on, 'lnum' on",
   color: isLight ? '#231536' : '#D2D4EF',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
     fontWeight: 400,
     lineHeight: '19px',
@@ -222,7 +222,7 @@ const DAISpan = styled.span({
   fontFeatureSettings: "'tnum' on, 'lnum' on",
   color: '#9FAFB9',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 'inherit',
     fontWeight: 'inherit',
     lineHeight: 'inherit',

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.stories.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.stories.tsx
@@ -1,0 +1,273 @@
+import { TotalExpenseReportsBuilder } from '@ses/core/businessLogic/builders/totalExpenseReportsBuilder';
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import useFinancesOverview from '../../useFinancesOverview';
+import CostBreakdownTable from './CostBreakdownTable';
+import type { CostBreakdownFilterValue, ExtendedExpense } from '../../financesOverviewTypes';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/Finances/Cost Breakdown Table',
+  component: CostBreakdownTable,
+  parameters: {
+    chromatic: {
+      viewports: [375, 768],
+    },
+  },
+} as ComponentMeta<typeof CostBreakdownTable>;
+
+const byBudgetBreakdownExpenses = [
+  new TotalExpenseReportsBuilder()
+    .withPrediction(5827878)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('PE', 'Protocol Engineering')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(3433400)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('GRO', 'Growth')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(3112752)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('CES', 'Collateral Engineering Services')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(2633200)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('RISK', 'Risk')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(2539612)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('ORA', 'Oracles')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(2364780)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('DECO', 'Deco Protocol')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(2364780)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('TECH', 'TechOps')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(1739908)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('SF', 'Strategic Happiness')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(1573652)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('DEL', 'Feedback Loops LLC')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(1240280)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('DUX', 'Development & UX')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(779481)
+    .withActuals(329481)
+    .withAnnualPeriod(2023)
+    .withBudget('/makerdao/ecosystem-actors')
+    .extend('DEWIZ', 'DEWIZ')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(425631)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('TEST', 'Testing')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withPrediction(425631)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('TEST', 'Testing')
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withBudget('delegates')
+    .withPrediction(415631)
+    .withActuals(1082362)
+    .withAnnualPeriod(2023)
+    .extend('DEL', 'Recognized Delegates')
+    .build(),
+];
+const byCategoryBreakdownExpenses = [
+  new TotalExpenseReportsBuilder()
+    .withCategory('headcount/CompensationAndBenefits')
+    .withPrediction(3021102)
+    .withActuals(2082362)
+    .withAnnualPeriod(2023)
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withCategory('headcount/TravelAndEntertainment')
+    .withPrediction(2802112)
+    .withActuals(2602124)
+    .withAnnualPeriod(2023)
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withCategory('non-headcount/GasExpense')
+    .withPrediction(2725452)
+    .withActuals(2700000)
+    .withAnnualPeriod(2023)
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withCategory('non-headcount/HardwareExpense')
+    .withPrediction(2500045)
+    .withActuals(2302145)
+    .withAnnualPeriod(2023)
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withCategory('non-headcount/ProfessionalServices')
+    .withPrediction(1825452)
+    .withActuals(1800125)
+    .withAnnualPeriod(2023)
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withCategory('non-headcount/SoftwareExpense')
+    .withPrediction(1421456)
+    .withActuals(1400456)
+    .withAnnualPeriod(2023)
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withCategory('non-headcount/ContingencyBuffer')
+    .withPrediction(1000000)
+    .withActuals(1000000)
+    .withAnnualPeriod(2023)
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withCategory('non-headcount/TrainingExpense')
+    .withPrediction(980452)
+    .withActuals(752865)
+    .withAnnualPeriod(2023)
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withCategory('non-headcount/AdminExpense')
+    .withPrediction(456325)
+    .withActuals(444256)
+    .withAnnualPeriod(2023)
+    .build(),
+  new TotalExpenseReportsBuilder()
+    .withCategory('non-headcount/SoftwareDevelopmentExpense')
+    .withPrediction(256256)
+    .withActuals(202456)
+    .withAnnualPeriod(2023)
+    .build(),
+];
+
+const BuilderComponent: React.FC<{ filter: CostBreakdownFilterValue }> = ({ filter }) => {
+  const {
+    setSelectedFilter,
+    byBudgetExpenses,
+    remainingBudgetCU,
+    remainingBudgetDelegates,
+    maxValueByBudget,
+    byCategoryExpenses,
+    remainingCategories,
+    maxValueByCategory,
+    costBreakdownTotal,
+    remainingEcosystemActors,
+  } = useFinancesOverview([], [], byBudgetBreakdownExpenses as ExtendedExpense[], byCategoryBreakdownExpenses);
+
+  return (
+    <CostBreakdownTable
+      remainingEcosystemActors={remainingEcosystemActors}
+      selectedFilter={filter}
+      setSelectedFilter={setSelectedFilter}
+      byBudgetExpenses={byBudgetExpenses}
+      remainingBudgetCU={remainingBudgetCU}
+      remainingBudgetDelegates={remainingBudgetDelegates}
+      maxValueByBudget={maxValueByBudget}
+      byCategoryExpenses={byCategoryExpenses}
+      remainingCategories={remainingCategories}
+      maxValueByCategory={maxValueByCategory}
+      total={costBreakdownTotal}
+    />
+  );
+};
+export const [[ByBudgetLightMode, ByBudgetDarkMode]] = createThemeModeVariants(BuilderComponent, [
+  { filter: 'By budget' },
+]);
+
+export const [[ByCategoryLightMode, ByCategoryDarkMode]] = createThemeModeVariants(BuilderComponent, [
+  { filter: 'By Category' },
+]);
+
+ByBudgetLightMode.parameters = {
+  figma: {
+    component: {
+      0: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=25230:206973',
+        options: {
+          componentStyle: {
+            width: 343,
+          },
+          style: {
+            top: 0,
+            left: -40,
+          },
+        },
+      },
+      768: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24815:141273',
+        options: {
+          componentStyle: {
+            width: 704,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1024: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24815:145653',
+        options: {
+          componentStyle: {
+            width: 960,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1280: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=15343:204060',
+        options: {
+          componentStyle: {
+            width: 640,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24631:228180',
+        options: {
+          componentStyle: {
+            width: 744,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -51,6 +51,7 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
   total,
 }) => {
   const { isLight } = useThemeContext();
+
   return (
     <BreakdownTableContainer>
       <CostBreakdownFilter selectedFilter={selectedFilter} onFilterChange={setSelectedFilter} />
@@ -167,7 +168,7 @@ const Table = styled.div<WithIsLight>(({ isLight }) => ({
   width: '100%',
   marginTop: 24,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     background: isLight ? '#FFFFFF' : '#1E2C37',
     borderRadius: 6,
     marginTop: 25,
@@ -176,7 +177,11 @@ const Table = styled.div<WithIsLight>(({ isLight }) => ({
       : '10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    marginTop: 24,
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
     marginTop: 15,
   },
 }));
@@ -196,7 +201,7 @@ const RemainingContainer = styled.div<WithIsLight>(({ isLight }) => ({
     marginBottom: 0,
   },
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     margin: '32px 0 0',
     padding: 0,
     gap: 0,
@@ -224,7 +229,8 @@ const ContainerOpenModal = styled.div<WithIsLight>(({ isLight }) => ({
   borderRadius: '6px',
   padding: '8px 16px 8px 16px',
   marginTop: -2,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     display: 'none',
   },
 }));

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ExpenseCategoryGroup.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ExpenseCategoryGroup.tsx
@@ -34,13 +34,13 @@ const NameContainer = styled.div({
   overflow: 'hidden',
   margin: '24px 0',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     margin: '16px 0',
   },
 });
 
 const GroupContainer = styled.div({
-  [lightTheme.breakpoints.down('table_834')]: {
+  [lightTheme.breakpoints.down('tablet_768')]: {
     '&:first-child > div:first-child': {
       marginTop: 40,
     },
@@ -57,7 +57,7 @@ const Name = styled.div<WithIsLight>(({ isLight }) => ({
   padding: '0 16px',
   minWidth: 'fit-content',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 12,
     lineHeight: '15px',
   },

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/TableFooter.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/TableFooter.tsx
@@ -37,7 +37,7 @@ const TableFooterContainer = styled.div<WithIsLight>(({ isLight }) => ({
     ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
     : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     boxShadow: 'none',
     background: isLight ? '#ECF1F3' : '#25273D',
     padding: '14px 16px',
@@ -55,7 +55,7 @@ const Total = styled.div<WithIsLight>(({ isLight }) => ({
   textAlign: 'center',
   marginBottom: 10,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     textAlign: 'left',
     marginBottom: 0,
   },
@@ -70,24 +70,24 @@ const TotalNumber = styled.div<WithIsLight & { extraPadding: boolean }>(({ isLig
   letterSpacing: '0.4px',
   fontFeatureSettings: "'tnum' on, 'lnum' on",
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     textAlign: 'right',
-    paddingRight: extraPadding ? 85 : 0,
+    paddingRight: extraPadding ? 102 : 0,
     fontSize: 16,
     fontWeight: 700,
     lineHeight: '19px',
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    paddingRight: extraPadding ? 57 : 0,
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    paddingRight: extraPadding ? 118 : 0,
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    paddingRight: extraPadding ? 68 : 0,
+    paddingRight: extraPadding ? 98 : 0,
   },
 
   [lightTheme.breakpoints.up('desktop_1440')]: {
-    paddingRight: extraPadding ? 85 : 0,
+    paddingRight: extraPadding ? 107 : 0,
   },
 }));
 
@@ -99,7 +99,7 @@ const DAISpan = styled.span<WithIsLight>(({ isLight }) => ({
   fontFeatureSettings: "'tnum' on, 'lnum' on",
   color: isLight ? '#9FAFB9' : '#546978',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontWeight: 'inherit',
     fontSize: 'inherit',
     lineHeight: 'inherit',

--- a/src/stories/containers/FinancesOverview/components/RelativeBudgetBar/RelativeBudgetBar.tsx
+++ b/src/stories/containers/FinancesOverview/components/RelativeBudgetBar/RelativeBudgetBar.tsx
@@ -58,7 +58,7 @@ const BudgetBar = styled.div<WithIsLight>(({ isLight }) => ({
   background: isLight ? '#ECF1F3' : '#10191F',
   boxShadow: isLight ? '2px 4px 7px rgba(26, 171, 155, 0.25)' : '2px 3px 10px rgba(23, 35, 44, 0.7)',
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [lightTheme.breakpoints.up('tablet_768')]: {
     height: 12,
   },
 }));


### PR DESCRIPTION
# Ticket
https://trello.com/c/NU2xBFF9/313-finances-homepage-breakpoints-changes

# Description
Adapt the "By Budget" table of the Finances page to the new breakpoints and replace the "view" text with a button and an arrow on mobile

# What solved
- [X] Should add the navigation arrow in mobile. [image.png](https://trello.com/1/cards/650c1e1e53205096c5cede37/attachments/65158a911b2c035720233e78/download/image.png)
- [X] Should adapt the "by budget" section to the new breakpoints
- [X] Should add the navigation button from > 768