### PR TITLE
[SES-313] Adapt by categories table and the category modal to the new breakpoints

### DIFF
--- a/src/stories/components/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
+++ b/src/stories/components/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
@@ -2,13 +2,11 @@ import styled from '@emotion/styled';
 import MuiAccordion from '@mui/material/Accordion';
 import MuiAccordionDetails from '@mui/material/AccordionDetails';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';
-
 import { SelectChevronDown } from '@ses/components/svg/select-chevron-down';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { pascalCaseToNormalString } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
-
 import type { AccordionProps } from '@mui/material/Accordion';
 import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
 import type { ParsedExpenseCategoryWithExpanded } from '@ses/core/models/dto/expenseCategoriesDTO';
@@ -51,7 +49,8 @@ const TransactionHistoryContainer = styled.div({
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',
-  [lightTheme.breakpoints.down(834)]: {
+
+  [lightTheme.breakpoints.down('tablet_768')]: {
     width: '100%',
   },
 });
@@ -59,10 +58,12 @@ const TransactionHistoryContainer = styled.div({
 const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters elevation={0} square {...props} />)({
   backgroundColor: 'transparent',
   width: '100%',
-  [lightTheme.breakpoints.up('table_834')]: {
-    width: 335,
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    width: 310,
   },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     width: 416,
   },
 });
@@ -92,16 +93,20 @@ const AccordionSummary = styled((props: AccordionSummaryProps) => (
     lineHeight: '22px',
     fontFamily: 'Inter, sans-serif',
     fontStyle: 'normal',
-
     color: isLight ? '#231536' : '#D2D4EF',
     padding: 0,
     marginTop: 0,
     marginBottom: 0,
-    [lightTheme.breakpoints.up('table_834')]: {
+
+    [lightTheme.breakpoints.up('tablet_768')]: {
       fontWeight: 500,
-      fontSize: 18,
-      lineHeight: '22px',
+      fontSize: 16,
+      lineHeight: 'normal',
       letterSpacing: '0.4px',
+    },
+
+    [lightTheme.breakpoints.up('desktop_1024')]: {
+      fontSize: 18,
     },
   },
 
@@ -114,7 +119,8 @@ const AccordionDetails = styled(MuiAccordionDetails)({
   padding: 0,
   paddingLeft: 24,
   marginTop: 8,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     marginTop: 24,
     paddingLeft: 32,
   },
@@ -127,14 +133,19 @@ const ItemsStyle = styled.div<WithIsLight>(({ isLight }) => ({
   fontStyle: 'normal',
   textTransform: 'capitalize',
   color: isLight ? '#231536' : '#D2D4EF',
-
   gap: 16,
   fontWeight: 300,
   fontSize: 14,
   lineHeight: '17px',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     gap: 24,
     fontWeight: 400,
+    fontSize: 14,
+    lineHeight: 'normal',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
     lineHeight: '22px',
   },

--- a/src/stories/components/BasicModal/CategoryModalComponent.tsx
+++ b/src/stories/components/BasicModal/CategoryModalComponent.tsx
@@ -17,6 +17,7 @@ const CategoryModalComponent: React.FC = () => {
     openModal,
   } = useCategoriesModalContext();
   const { isLight } = useThemeContext();
+
   return (
     <BasicModalExtended
       handleClose={handleCloseModal}
@@ -53,16 +54,19 @@ const BasicModalExtended = styled(BasicModal)({
   outline: 'none',
   transform: 'translateX(-50%)',
   width: 'max(100%, 375px)',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     width: 'max(90%, 770px)',
     height: 'calc(100% - 128px)',
     marginBottom: 64,
     maxHeight: 813,
   },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    width: 1114,
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    maxWidth: 1114,
     maxHeight: 847,
   },
+
   [lightTheme.breakpoints.up('desktop_1280')]: {
     width: 1184,
   },

--- a/src/stories/components/BasicModal/ChekBoxDescription/ChekBoxDescription.tsx
+++ b/src/stories/components/BasicModal/ChekBoxDescription/ChekBoxDescription.tsx
@@ -30,21 +30,23 @@ export default CheckBoxDescription;
 const Container = styled.div<{ isChecked: boolean }>(({ isChecked }) => ({
   gap: 8,
   display: 'flex',
-
   marginBottom: isChecked ? 4 : undefined,
   alignItems: 'center',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     display: 'flex',
     gap: 12,
     marginBottom: isChecked ? 3 : undefined,
   },
 }));
+
 const Text = styled.div<WithIsLight & { isChecked: boolean }>(({ isLight, isChecked = false }) => ({
   fontWeight: 500,
   fontSize: 14,
   lineHeight: '18px',
   color: isLight ? '#231536' : '#D2D4EF',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontFamily: 'Inter, sans-serif',
     fontStyle: 'normal',
     fontWeight: isChecked ? 700 : 400,
@@ -65,6 +67,7 @@ const ContainerCheckBox = styled.div({
 const Checkbox = styled(CheckboxMui)<WithIsLight>(({ isLight }) => ({
   width: 15,
   height: 15,
+
   svg: {
     fill: isLight ? '#231536' : '#ADAFD4',
   },

--- a/src/stories/components/BasicModal/ContainerModal.stories.tsx
+++ b/src/stories/components/BasicModal/ContainerModal.stories.tsx
@@ -1,7 +1,6 @@
 import { ParsedExpenseCategoryBuilder } from '@ses/core/businessLogic/builders/categoriesBuilders';
 import { withFixedPositionRelative } from '@ses/core/utils/storybook/decorators';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
-
 import ContainerModal from './ContainerModal';
 import type { ComponentMeta } from '@storybook/react';
 import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
@@ -13,11 +12,12 @@ export default {
   parameters: {
     layout: 'fullscreen',
     chromatic: {
-      viewports: [375, 834, 1194, 1280, 1440],
+      viewports: [375, 734, 1024, 1280, 1440],
       pauseAnimationAtEnd: true,
     },
   },
 } as ComponentMeta<typeof ContainerModal>;
+
 const variantsArgs = [
   {
     headCountCategories: [
@@ -116,12 +116,11 @@ UnExpanded.parameters = {
           },
         },
       },
-      834: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19645:247601&t=3rWAHk8rUGngJTx7-4',
+      768: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24815:147193',
         options: {
           componentStyle: {
-            width: 770,
+            width: 704,
           },
           style: {
             top: -36,
@@ -129,12 +128,11 @@ UnExpanded.parameters = {
           },
         },
       },
-      1194: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19614:238996&t=QN0Rot6AvH91wak3-4',
+      1024: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24815:151467',
         options: {
           componentStyle: {
-            width: 1114,
+            width: 944,
           },
           style: {
             top: -36,

--- a/src/stories/components/BasicModal/ContainerModal.tsx
+++ b/src/stories/components/BasicModal/ContainerModal.tsx
@@ -63,8 +63,8 @@ const ContainerModal: React.FC<Props> = ({
             </HeadCountList>
             <NoHeadCount isLight={isLight}>Non-Headcount Expense Categories</NoHeadCount>
             <Line isLight={isLight} />
-            <ContainerTowColumns>
-              <ContainerPar>
+            <ContainerTwoColumns>
+              <ContainerEven>
                 {noHeadCountCategories
                   ?.slice(0, noHeadCountCategories.length / 2)
 
@@ -76,7 +76,7 @@ const ContainerModal: React.FC<Props> = ({
                       handleChangeItemAccordion={handleChangeItemAccordion}
                     />
                   ))}
-              </ContainerPar>
+              </ContainerEven>
               <ContainerOdd>
                 {noHeadCountCategories
                   ?.slice(noHeadCountCategories.length / 2, noHeadCountCategories.length)
@@ -90,7 +90,7 @@ const ContainerModal: React.FC<Props> = ({
                     />
                   ))}
               </ContainerOdd>
-            </ContainerTowColumns>
+            </ContainerTwoColumns>
           </InsideModal>
         </SimpleBarStyled>
       </ContainerScroll>
@@ -105,11 +105,6 @@ const Container = styled.div<WithIsLight & { isSomeOpen?: boolean }>(({ isLight,
   flexDirection: 'column',
   paddingBottom: 27,
   overflowY: 'auto',
-
-  '::-webkit-scrollbar': {
-    width: '1px',
-  },
-
   height: '100%',
   background: isLight ? '#FFFFFF' : '#10191F',
   boxShadow: isLight
@@ -117,19 +112,26 @@ const Container = styled.div<WithIsLight & { isSomeOpen?: boolean }>(({ isLight,
     : '10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
   borderTopLeftRadius: '6px',
   borderTopRightRadius: '6px',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  '::-webkit-scrollbar': {
+    width: '1px',
+  },
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     paddingBottom: 40,
     borderRadius: '16px',
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    width: 1114,
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    maxWidth: 1114,
     paddingBottom: 64,
   },
+
   [lightTheme.breakpoints.up('desktop_1280')]: {
     width: 1184,
     paddingBottom: !isSomeOpen ? 50 : 64,
   },
+
   [lightTheme.breakpoints.up('desktop_1440')]: {
     width: 1184,
     paddingBottom: 64,
@@ -150,14 +152,16 @@ const Header = styled.div<WithIsLight>(({ isLight }) => ({
   boxShadow: isLight
     ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
     : ' 10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     paddingLeft: 24,
     paddingRight: 24,
     paddingTop: 24,
     paddingBottom: 16,
     gap: 24,
   },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     paddingLeft: 40,
     paddingRight: 40,
   },
@@ -166,11 +170,13 @@ const Header = styled.div<WithIsLight>(({ isLight }) => ({
 const InsideModal = styled.div({
   paddingLeft: 16,
   paddingRight: 16,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     paddingLeft: 24,
     paddingRight: 24,
   },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     paddingLeft: 40,
     paddingRight: 40,
   },
@@ -182,7 +188,8 @@ const ContainerTitle = styled.div({
   justifyContent: 'space-between',
   alignItems: 'center',
   height: 19,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     height: 29,
   },
 });
@@ -194,7 +201,8 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
   fontStyle: 'normal',
   fontWeight: 700,
   color: isLight ? '#231536' : '#D2D4EF',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     fontWeight: 600,
     fontSize: 24,
     lineHeight: '29px',
@@ -210,15 +218,17 @@ const Description = styled.div<WithIsLight>(({ isLight }) => ({
   fontStyle: 'normal',
   color: isLight ? '#231536' : '#D2D4EF',
   width: '100%',
-  [lightTheme.breakpoints.up('table_834')]: {
-    width: 466,
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    width: 435,
     fontWeight: 400,
     fontSize: 16,
     lineHeight: '22px',
     alignItems: 'baseline',
   },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    width: 725,
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    width: 640,
   },
 }));
 
@@ -227,7 +237,8 @@ const ContainerDescription = styled.div({
   flexDirection: 'column',
   gap: 19,
   alignItems: 'flex-end',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -244,14 +255,16 @@ const HeadCount = styled.div<WithIsLight>(({ isLight }) => ({
   lineHeight: '19px',
   marginTop: 16,
   color: isLight ? '#231536' : '#D2D4EF',
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     marginTop: 24,
     fontSize: 20,
     fontWeight: 600,
     lineHeight: '24px',
     letterSpacing: '0.4px',
   },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     marginTop: 32,
   },
 }));
@@ -260,7 +273,8 @@ const Line = styled.div<WithIsLight>(({ isLight }) => ({
   borderBottom: isLight ? '1px solid #D4D9E1' : '1px solid #405361',
   marginTop: 8,
   marginBottom: 16,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     marginTop: 15,
     marginBottom: 24,
   },
@@ -270,39 +284,44 @@ const HeadCountList = styled.div({
   display: 'flex',
   flexDirection: 'column',
   gap: 16,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     gap: 32,
   },
 });
 
 const NoHeadCount = styled(HeadCount)<WithIsLight>({
   marginTop: 32,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     marginTop: 40,
   },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     marginTop: 64,
   },
 });
 
-const ContainerTowColumns = styled.div({
+const ContainerTwoColumns = styled.div({
   display: 'flex',
   flexDirection: 'column',
   flex: 1,
   gap: 16,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     display: 'flex',
     flex: 1,
     flexDirection: 'row',
   },
 });
 
-const ContainerPar = styled.div({
+const ContainerEven = styled.div({
   display: 'flex',
   flexDirection: 'column',
   flex: 1,
   gap: 16,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     gap: 32,
   },
 });
@@ -313,19 +332,22 @@ const ContainerOdd = styled.div({
   alignItems: 'flex-end',
   flex: 1,
   gap: 16,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     gap: 32,
   },
 });
 const ContainerClose = styled.div({
   paddingRight: 3,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     paddingRight: 6,
   },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
@@ -336,7 +358,8 @@ const ContainerClose = styled.div({
 const StyledClose = styled(Close)({
   width: 14,
   height: 14,
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     width: 20,
     height: 20,
   },
@@ -344,19 +367,23 @@ const StyledClose = styled(Close)({
 
 const SimpleBarStyled = styled(SimpleBar)({
   height: '100%',
+
   '.simplebar-scrollbar::before': {
     width: 4,
     marginLeft: 4,
     background: '#1aab9b',
     borderRadius: 20,
   },
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     maxHeight: 813,
+
     '.simplebar-scrollbar::before': {
       width: 6,
     },
   },
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+
+  [lightTheme.breakpoints.up('desktop_1024')]: {
     maxHeight: 847,
   },
 });
@@ -364,6 +391,7 @@ const SimpleBarStyled = styled(SimpleBar)({
 const ContainerScroll = styled.div({
   height: '100%',
   overflowY: 'auto',
+
   '::-webkit-scrollbar': {
     width: '1px',
   },

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableRow.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableRow.tsx
@@ -74,6 +74,7 @@ const Row = styled.div<WithIsLight>(({ isLight }) => ({
 const MobileColumn = styled.div({
   display: 'flex',
   flexDirection: 'column',
+  flex: 1,
 
   [lightTheme.breakpoints.up('tablet_768')]: {
     flexDirection: 'row',
@@ -130,6 +131,7 @@ const NameColumn = styled.div({
 const TotalPercentageColumn = styled.div({
   width: 145,
   minWidth: 145,
+  flex: 1,
 
   [lightTheme.breakpoints.up('tablet_768')]: {
     width: 240,
@@ -144,6 +146,7 @@ const TotalPercentageColumn = styled.div({
   [lightTheme.breakpoints.up('desktop_1440')]: {
     width: 240,
     minWidth: 240,
+    maxWidth: 240,
   },
 });
 


### PR DESCRIPTION
# Ticket
https://trello.com/c/NU2xBFF9/313-finances-homepage-breakpoints-changes

# Description
Adapt the "By expense categories" table and the categories modal to the new breakpoints

# What solved
- [X] Should adapt the "By expense category" section to the new breakpoints
- [X]  Should adapt the categories modal to the new breakpoints [image.png](https://trello.com/1/cards/650c1e1e53205096c5cede37/attachments/65158c262a38f62c3fb4af7d/download/image.png)