### PR TITLE
[SES-310] Fix total forecast with N/A values

### DIFF
--- a/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
+++ b/src/stories/containers/TransparencyReport/components/TransparencyForecast/useTransparencyForecast.tsx
@@ -318,9 +318,9 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
           column: mainTableColumns[1],
           value: (
             <ContainerProgressiveIndicator>
-              {typeof totalFirstMonthBudGetCap === 'number' ? (
+              {typeof totalFirstMonthBudGetCap === 'number' || totalFirstMonth !== 0 ? (
                 <ProgressiveIndicator
-                  budgetCap={totalFirstMonthBudGetCap}
+                  budgetCap={totalFirstMonthBudGetCap === 'N/A' ? 0 : totalFirstMonthBudGetCap}
                   forecast={totalFirstMonth}
                   isTotal
                   month={firstMonth}
@@ -335,9 +335,9 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
           column: mainTableColumns[2],
           value: (
             <ContainerProgressiveIndicator>
-              {typeof totalSecondMonthBudGetCap === 'number' ? (
+              {typeof totalSecondMonthBudGetCap === 'number' || totalSecondMonth !== 0 ? (
                 <ProgressiveIndicator
-                  budgetCap={totalSecondMonthBudGetCap}
+                  budgetCap={totalSecondMonthBudGetCap === 'N/A' ? 0 : totalSecondMonthBudGetCap}
                   forecast={totalSecondMonth}
                   isTotal
                   month={secondMonth}
@@ -352,9 +352,9 @@ export const useTransparencyForecast = (currentMonth: DateTime, budgetStatements
           column: mainTableColumns[3],
           value: (
             <ContainerProgressiveIndicator>
-              {typeof totalThirdMonthBudGetCap === 'number' ? (
+              {typeof totalThirdMonthBudGetCap === 'number' || totalThirdMonth !== 0 ? (
                 <ProgressiveIndicator
-                  budgetCap={totalThirdMonthBudGetCap}
+                  budgetCap={totalThirdMonthBudGetCap === 'N/A' ? 0 : totalThirdMonthBudGetCap}
                   forecast={totalThirdMonth}
                   isTotal
                   month={thirdMonth}


### PR DESCRIPTION
# Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

# Description
Fix N/A values in total in the forecast tab of the finances pages

# What solved
- [X] Expense Reports view, Forecast tab. IS core unit (Jun 2023 month), SNE core unit. [Link](https://expenses-dev.makerdao.network/core-unit/IS/finances/reports?viewMonth=Jun2023&section=forecast) **Current Output:** The total (row) value related to the August month is displayed with N/A.