### PR TITLE
fix: hover on mobile devices in the social icons

### DIFF
--- a/src/stories/components/CuTableColumnLinks/CuTableColumnLinks.tsx
+++ b/src/stories/components/CuTableColumnLinks/CuTableColumnLinks.tsx
@@ -154,8 +154,11 @@ const LinkImage = styled.a(
   ({ width = 32, height = 32, isLight = true }: StickyLinkProps) => ({
     width,
     height,
-    '&:hover svg path': {
-      fill: isLight ? '#231536' : '#48495F',
+
+    '@media (hover: hover)': {
+      '&:hover svg path': {
+        fill: isLight ? '#231536' : '#48495F',
+      },
     },
   })
 );

--- a/src/stories/components/SocialMediaComponent/SocialMediaComponent.tsx
+++ b/src/stories/components/SocialMediaComponent/SocialMediaComponent.tsx
@@ -127,9 +127,12 @@ const BoxContainer = styled.div<{ boxLinkWidth: number; boxLinkHeight: number }>
 );
 const LinkImage = styled.a<WithIsLight & { marginBottom?: boolean }>(({ isLight, marginBottom = false }) => ({
   display: 'flex',
-  '&:hover svg path': {
-    fill: isLight ? '#231536' : '#48495F',
-    stroke: isLight ? '#231536' : '#48495F',
-  },
   ...(marginBottom && { marginBottom: 8 }),
+
+  '@media (hover: hover)': {
+    '&:hover svg path': {
+      fill: isLight ? '#231536' : '#48495F',
+      stroke: isLight ? '#231536' : '#48495F',
+    },
+  },
 }));


### PR DESCRIPTION
# Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

# Description
Fixed the issue in the CU, EA and RD summary component

# What solved
- [X] Ecosystem Actors profile and CU About views. Social media icons. Selecting an icon. **Expected Output:** The expected tab should be open and the icon should remain with the green color. **Current Output:** The icon is displayed with black color (hover state).