### PR TITLE
[SES-294] Fix finances filters dropdown

### DIFF
--- a/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
+++ b/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
 import { CustomMultiSelect } from '@ses/components/CustomMultiSelect/CustomMultiSelect';
 import ResetButton from '@ses/components/ResetButton/ResetButton';
 import { Close } from '@ses/components/svg/close';
@@ -37,6 +38,7 @@ const FilterTable: React.FC<Props> = ({
   onClose,
   onOpen,
 }) => {
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const { isLight } = useThemeContext();
   const isEnable = isLight
     ? activeItems.length > 0
@@ -59,7 +61,7 @@ const FilterTable: React.FC<Props> = ({
 
       <ContainerFiltersMetric>
         <CustomMultiSelectStyled
-          positionRight={true}
+          positionRight={!isMobile}
           label="Metrics"
           activeItems={activeItems}
           items={metrics}
@@ -87,7 +89,11 @@ const FilterTable: React.FC<Props> = ({
           selectedValue={selectedValue}
           onClose={onClose}
           onOpen={onOpen}
-          widthPaper={256}
+          widthPaper={224}
+          menuAnchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left',
+          }}
         />
       </PeriodicSelectionFilter>
 
@@ -163,6 +169,7 @@ const StyledSelectDropdown = styled(SelectDropdown)({
   '& > div': {
     width: 141,
     height: 34,
+
     [lightTheme.breakpoints.up('tablet_768')]: {
       width: 120,
       height: 48,

--- a/src/stories/containers/Finances/components/SelectDropdown.tsx
+++ b/src/stories/containers/Finances/components/SelectDropdown.tsx
@@ -4,7 +4,8 @@ import Select from '@mui/material/Select';
 import { SelectChevronDown } from '@ses/components/svg/select-chevron-down';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
-import React from 'react';
+import React, { useEffect } from 'react';
+import type { MenuProps } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
@@ -20,6 +21,7 @@ interface Props {
   height?: number;
   width?: number;
   borderRadiusPopover?: string;
+  menuAnchorOrigin?: MenuProps['anchorOrigin'];
 }
 
 const SelectDropdown: React.FC<Props> = ({
@@ -34,8 +36,25 @@ const SelectDropdown: React.FC<Props> = ({
   width = 92,
   widthPaper = 120,
   borderRadiusPopover = '6px',
+  menuAnchorOrigin,
 }: Props) => {
   const { isLight } = useThemeContext();
+
+  useEffect(() => {
+    // close the menu if it is open
+    const handleScroll = () => {
+      if (isOpen) {
+        onClose?.();
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [isOpen, onClose]);
+
   return (
     <ContainerSelect className={className}>
       <SelectStyled
@@ -44,6 +63,9 @@ const SelectDropdown: React.FC<Props> = ({
         isLight={isLight}
         MenuProps={{
           disableScrollLock: true,
+          ...(menuAnchorOrigin && {
+            anchorOrigin: menuAnchorOrigin,
+          }),
           PaperProps: {
             sx: {
               bgcolor: isLight ? 'white' : '#000A13',
@@ -80,9 +102,9 @@ const SelectDropdown: React.FC<Props> = ({
           </ContainerIcon>
         )}
       >
-        {items.map((items) => (
-          <MenuItemStyled value={items} key={items} disableTouchRipple={true} isLight={isLight}>
-            {items}
+        {items.map((item) => (
+          <MenuItemStyled value={item} key={item} disableTouchRipple={true} isLight={isLight}>
+            {item}
           </MenuItemStyled>
         ))}
       </SelectStyled>
@@ -122,7 +144,8 @@ const SelectStyled = styled(Select)<WithIsLight & { width: number; height: numbe
       border: `1px solid ${isLight ? '#231536' : '#787A9B'}`,
     },
   },
-  [lightTheme.breakpoints.up('table_834')]: {
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
     height: 48,
   },
 }));


### PR DESCRIPTION
# Ticket
https://trello.com/c/JHKHOrzX/294-feature-budget-summary-navigation

# Description
Fix some issues related to the filter select components

# What solved
- [X] The area with options should stay in the same position always, even when you start scrolling the page. **Current Output:** After clicking on period filters, the area with options that appear is moving when scrolling the page.
- [X]  The area with the options for period filter should be aligned to the right side, the same as for metrics filters. **Current Output:** The area that appears after clicking on the period filters is not aligned as the metrics filters are. 
- [X] The window with options should be displayed fully on the screen. **Current Output:** The window seems to be cut. 