### PR TITLE
[SES-310] Fix activity feed items on comments in ecosystem actors

### DIFF
--- a/src/core/hooks/useBudgetStatementComments.ts
+++ b/src/core/hooks/useBudgetStatementComments.ts
@@ -29,7 +29,7 @@ const useBudgetStatementComments = (
   const comments = useMemo(() => {
     const comments = getAllCommentsBudgetStatementLine(budgetStatement) as (BudgetStatementComment & WithDate)[];
     let activities = budgetStatement?.activityFeed?.filter(
-      (activity) => activity.event === 'CU_BUDGET_STATEMENT_CREATED'
+      (activity) => activity.event.endsWith('_STATEMENT_CREATED') || activity.event.endsWith('_STATEMENT_UPDATED')
     ) as (ChangeTrackingEvent & WithDate)[];
     activities =
       activities?.map((activity) => {


### PR DESCRIPTION
# Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

# Description
Fix the comments items in the Ecosystem Actors finance's page

# What solved
- [X] DEWIZ ecosystem actor (last activity in Comments tab).  **Expected Output:** The data from the API should be displayed. **Current Output: ** Activity related to DEWIZ comes from the API but the frontend doesn't show it.