### PR TITLE
[SES-310] Fix enabling comment tab on auditor view on nav

### DIFF
--- a/src/core/hooks/useTransparencyReportingTabs.tsx
+++ b/src/core/hooks/useTransparencyReportingTabs.tsx
@@ -156,7 +156,10 @@ const useTransparencyReportingTabs = ({
             undefined,
             { shallow: true }
           );
-          setTabsIndex(TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS);
+          // it's coming from default view, but comment is in both views so we can keep it activated
+          if (router.query.section !== TRANSPARENCY_IDS_ENUM.COMMENTS) {
+            setTabsIndex(TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS);
+          }
         }
       }
     };

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -68,6 +68,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
   const ref = useRef<HTMLDivElement>(null);
   const { height, showHeader } = useHeaderSummary(ref, code);
   const headline = <CuHeadlineText cuLongCode={longCode} />;
+
   return (
     <Wrapper>
       <SEOHead


### PR DESCRIPTION
# Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

# Description
Fix the comment tab on the auditor view when the user navigates to the view and the auditor view is the preferred

# What solved
- [X] From the Expense Reports page, Auditor view Comments tab. Going back to the Core Units (selecting IS) and going through the activity feed option. Selecting an activity.  **Expected Output:** Should direct to the comments tab and display the proper data. **Current Output: **It directs to the Comments tab but displays the Account Snapshot data. 