### PR TITLE
Adjust data when there is more one metric

### DIFF
--- a/src/stories/containers/Finances/components/FinacesTable/CellTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/CellTable.tsx
@@ -15,7 +15,9 @@ const CellTable: React.FC<Props> = ({ metrics }) => {
     <Cell isLight={isLight}>
       <SpacedValues>
         {metrics.map((_, index) => (
-          <span key={index}>{usLocalizedNumber(2208889)}</span>
+          <Span key={index} isLight={isLight}>
+            {usLocalizedNumber(2208889)}
+          </Span>
         ))}
       </SpacedValues>
     </Cell>
@@ -25,7 +27,7 @@ const CellTable: React.FC<Props> = ({ metrics }) => {
 export default CellTable;
 
 const Cell = styled.td<WithIsLight>(({ isLight }) => ({
-  borderRight: `1px solid ${isLight ? '#D8E0E3' : 'red'}`,
+  borderRight: `1px solid ${isLight ? '#D8E0E3' : '#405361'}`,
   padding: '16px 8px',
   textAlign: 'center',
   fontSize: 12,
@@ -45,3 +47,7 @@ const SpacedValues = styled.div({
     gap: 32,
   },
 });
+
+const Span = styled.span<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#231536' : '#D2D4EF',
+}));

--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -32,7 +32,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
       {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}
       {tables.map((table, index) => (
         <TableContainer isLight={isLight} className={className} key={index}>
-          <TableBody>
+          <TableBody isLight={isLight}>
             {breakdownTable[table].map((row) => (
               <TableRow isMain={row.isMain} isLight={isLight}>
                 <Headed isLight={isLight} period={period}>
@@ -72,17 +72,24 @@ export default FinancesTable;
 const TableContainer = styled.table<WithIsLight>(({ isLight }) => ({
   borderCollapse: 'collapse',
   boxShadow: isLight ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)' : 'red',
-  borderRadius: 6,
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
   tableLayout: 'fixed',
   width: '100%',
+  backgroundColor: isLight ? 'white' : '#1E2C37',
+  borderRadius: '6px',
+  '& tr:last-of-type td:last-of-type': {
+    borderBottomRightRadius: 6,
+  },
+  '& tr:last-of-type th:last-of-type': {
+    borderBottomLeftRadius: 6,
+  },
 }));
 
 const Headed = styled.th<WithIsLight & { period?: PeriodicSelectionFilter }>(({ isLight, period }) => ({
-  borderRight: `1px solid ${isLight ? '#D8E0E3' : 'red'}`,
+  borderRight: `1px solid ${isLight ? '#D8E0E3' : '#405361'}`,
   fontSize: 11,
-  color: '#231536',
+  color: isLight ? '#231536' : '#D2D4EF',
   width: 87,
   textAlign: 'center',
   verticalAlign: 'center',
@@ -131,7 +138,7 @@ const TableRow = styled.tr<WithIsLight & { isMain?: boolean }>(({ isMain = false
     textAlign: 'left',
   },
   '& td:last-of-type': {
-    backgroundColor: isLight ? (isMain ? 'rgba(159, 175, 185, 0.17)' : 'inherit') : 'red',
+    backgroundColor: isLight ? (isMain ? 'rgba(159, 175, 185, 0.17)' : 'inherit') : isMain ? '#2D3C48;' : 'inherit',
     fontWeight: isMain ? 600 : 400,
     borderRight: 'none',
     borderTopRightRadius: isMain ? 6 : 'none',
@@ -142,20 +149,24 @@ const TableRow = styled.tr<WithIsLight & { isMain?: boolean }>(({ isMain = false
   },
 }));
 
-const TableBody = styled.tbody({
+const TableBody = styled.tbody<WithIsLight>(({ isLight }) => ({
   '& tr:nth-of-type(odd):not(:first-child)': {
-    backgroundColor: '#F5F5F5',
+    backgroundColor: isLight ? '#F5F5F5' : '#18252E',
+  },
+  '& tr:nth-of-type(even):not(:first-child)': {
+    backgroundColor: isLight ? '#ffffff' : '#1f2d37',
   },
   '& tr:first-of-type': {
-    backgroundColor: '#ECF1F3',
+    backgroundColor: isLight ? '#ECF1F3' : '#30434e',
   },
-});
+}));
 
 const Cell = styled.td<WithIsLight>(({ isLight }) => ({
-  borderRight: `1px solid ${isLight ? '#D8E0E3' : 'red'}`,
+  borderRight: `1px solid ${isLight ? '#D8E0E3' : '#405361'}`,
   padding: '16px 8px',
   textAlign: 'center',
   fontSize: 12,
+  color: isLight ? '#231536' : '#D2D4EF',
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
     padding: '16px 20px',

--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -3,6 +3,7 @@ import { useMediaQuery } from '@mui/material';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
+import { sortDataByElementCount } from '../../utils/utils';
 import CellTable from './CellTable';
 import type { MockData } from '../../utils/mockData';
 import type { PeriodicSelectionFilter } from '../../utils/types';
@@ -18,7 +19,8 @@ interface Props {
 
 const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, period }) => {
   const { isLight } = useThemeContext();
-  const tables = Object.keys(breakdownTable);
+  const orderData = sortDataByElementCount(breakdownTable);
+  const tables = Object.keys(orderData);
   const iteration = period === 'Quarterly' ? 5 : period === 'Monthly' ? 13 : 3;
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const desk1440 = useMediaQuery(lightTheme.breakpoints.up('desktop_1024'));

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/CellAnnually.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/CellAnnually.tsx
@@ -33,7 +33,7 @@ const ContainerCell = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
-  color: isLight ? '#231536' : 'red',
+  color: isLight ? '#231536' : '#D2D4EF',
   width: '100%',
   fontWeight: 500,
 }));
@@ -66,23 +66,23 @@ const Metrics = styled.div<WithIsLight>(({ isLight }) => ({
     minWidth: 80,
   },
 }));
-const Name = styled.div<WithIsLight>(({ isLight }) => ({
+const Name = styled.div<WithIsLight>({
   marginBottom: 4,
   fontSize: 11,
   fontWeight: 500,
   textAlign: 'center',
   fontStyle: 'normal',
   lineHeight: 'normal',
-  color: isLight ? '#708390' : 'red',
+  color: '#708390',
   [lightTheme.breakpoints.up('desktop_1024')]: {
     textAlign: 'center',
   },
   [lightTheme.breakpoints.up('desktop_1920')]: {
     marginBottom: 2,
   },
-}));
+});
 const Amount = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : 'red',
+  color: isLight ? '#231536' : '#D2D4EF',
   fontSize: 11,
   fontWeight: 600,
   textAlign: 'center',

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
@@ -18,10 +18,10 @@ export const HeaderAnnually: React.FC<Props> = ({ year, metrics, title }) => {
     <Container isLight={isLight}>
       <ContainerAnnually>
         <ContainerTitle isLight={isLight}>
-          <Title>{title}</Title>
+          <Title isLight={isLight}>{title}</Title>
         </ContainerTitle>
         <ContainerYear>
-          <Year>{year}</Year>
+          <Year isLight={isLight}>{year}</Year>
           <ContainerAnnuallyCell>
             <CellAnnually metrics={metrics} />
           </ContainerAnnuallyCell>
@@ -51,18 +51,19 @@ const ContainerAnnually = styled.div({
   },
 });
 
-const Year = styled.div({
+const Year = styled.div<WithIsLight>(({ isLight }) => ({
   textAlign: 'center',
   fontSize: 14,
   fontWeight: 500,
   fontStyle: 'normal',
   lineHeight: 'normal',
   marginBottom: 8,
+  color: isLight ? '#231536' : '#D2D4EF',
   [lightTheme.breakpoints.up('tablet_768')]: {
     marginBottom: 24,
     fontSize: 18,
   },
-});
+}));
 
 const ContainerAnnuallyCell = styled.div({
   display: 'flex',
@@ -79,8 +80,8 @@ const ContainerAnnuallyCell = styled.div({
   },
 });
 
-const Title = styled.div({
-  color: '#231536',
+const Title = styled.div<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#231536' : '#D2D4EF',
   fontFamily: 'Inter, sans-serif',
   fontSize: 11,
   fontStyle: 'normal',
@@ -90,13 +91,13 @@ const Title = styled.div({
   [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
   },
-});
+}));
 
 const ContainerTitle = styled.div<WithIsLight>(({ isLight }) => ({
   width: 76,
   display: 'flex',
   alignItems: 'center',
-  borderRight: `1px solid ${isLight ? '#D1DEE6' : 'red'}`,
+  borderRight: `1px solid ${isLight ? '#D1DEE6' : 'none'}`,
   whiteSpace: 'break-spaces',
   [lightTheme.breakpoints.up('tablet_768')]: {
     width: 140,
@@ -132,8 +133,11 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
   flex: 1,
   justifyContent: 'flex-start',
   borderRadius: 6,
-  backgroundColor: isLight ? '#E5E9EC' : 'red',
-  boxShadow: isLight ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)' : 'red',
+  backgroundColor: isLight ? '#E5E9EC' : '#405361',
+  boxShadow: isLight
+    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
+    : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px -40px rgba(7, 22, 40, 0.40)',
+
   alignItems: 'center',
   whiteSpace: 'pre',
   overflow: 'auto',

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
@@ -18,7 +18,7 @@ export const CellMonthly: React.FC<Props> = ({ metrics, title, isTotal = false, 
   const { isLight } = useThemeContext();
   return (
     <ContainerCell isLight={isLight} isTotal={isTotal} className={className}>
-      <Month>{title}</Month>
+      <Month isLight={isLight}>{title}</Month>
       {metrics?.map((metric, index) => (
         <Metrics key={index}>
           <Name isLight={isLight}>{returnShortNameForMetric(metric).name}</Name>
@@ -36,17 +36,17 @@ const ContainerCell = styled.div<WithIsLight & { isTotal: boolean }>(({ isLight,
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
-  color: isLight ? '#231536' : 'red',
+  color: isLight ? '#231536' : '#D2D4EF',
 
   fontWeight: 500,
-  backgroundColor: isLight ? (isTotal ? 'rgba(209, 222, 230, 0.50)' : 'transparent') : isTotal ? 'red' : 'red',
+  backgroundColor: isLight ? (isTotal ? 'rgba(209, 222, 230, 0.50)' : 'transparent') : isTotal ? '#374752' : '#405361',
   ...(isTotal && {
     padding: '16px 0px 16px 0px',
   }),
 }));
 
-const Month = styled.div({
-  color: '#231536',
+const Month = styled.div<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#231536' : '#D2D4EF',
   textAlign: 'center',
   fontFamily: 'Inter, sans-serif',
   fontSize: 18,
@@ -54,30 +54,30 @@ const Month = styled.div({
   fontWeight: 500,
   lineHeight: 'normal',
   marginBottom: 8,
-});
+}));
 
 const Metrics = styled.div({
   display: 'flex',
   flexDirection: 'column',
   width: 70.5,
 });
-const Name = styled.div<WithIsLight>(({ isLight }) => ({
+const Name = styled.div<WithIsLight>({
   marginBottom: 4,
   fontSize: 11,
   fontWeight: 500,
   textAlign: 'center',
   fontStyle: 'normal',
   lineHeight: 'normal',
-  color: isLight ? '#708390' : 'red',
+  color: '#708390',
   [lightTheme.breakpoints.up('desktop_1024')]: {
     textAlign: 'center',
   },
   [lightTheme.breakpoints.up('desktop_1920')]: {
     marginBottom: 2,
   },
-}));
+});
 const Amount = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : 'red',
+  color: isLight ? '#231536' : '#D2D4EF',
   fontSize: 12,
   fontWeight: 600,
   textAlign: 'center',

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/HeaderMonthly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/HeaderMonthly.tsx
@@ -18,7 +18,7 @@ export const HeaderMonthly: React.FC<Props> = ({ metrics, title, months }) => {
     <Container isLight={isLight}>
       <ContainerAnnually>
         <ContainerTitle>
-          <Title>{title}</Title>
+          <Title isLight={isLight}>{title}</Title>
         </ContainerTitle>
         <ContainerYear>
           <ContainerAnnuallyCell>
@@ -41,7 +41,7 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
   flex: 1,
   justifyContent: 'flex-start',
   borderRadius: 6,
-  backgroundColor: isLight ? '#E5E9EC' : 'red',
+  backgroundColor: isLight ? '#E5E9EC' : '#405361',
   boxShadow: isLight ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)' : 'red',
   alignItems: 'center',
   whiteSpace: 'pre',
@@ -71,14 +71,14 @@ const ContainerAnnuallyCell = styled.div({
   width: '100%',
 });
 
-const Title = styled.div({
-  color: '#231536',
+const Title = styled.div<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#231536' : '#D2D4EF',
   fontFamily: 'Inter, sans-serif',
   fontSize: 16,
   fontStyle: 'normal',
   fontWeight: 700,
   lineHeight: 'normal',
-});
+}));
 
 const ContainerTitle = styled.div({
   display: 'flex',
@@ -100,5 +100,4 @@ const ContainerYear = styled.div({
 
 const CellMonthlyTotally = styled(CellMonthly)({
   width: 85,
-  border: '2px silid red',
 });

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/CellQuarterly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/CellQuarterly.tsx
@@ -45,7 +45,7 @@ const MainContainer = styled.div<WithIsLight & { isTotal: boolean }>(({ isLight,
   position: 'relative',
   alignItems: 'center',
   padding: isTotal ? '16px 0px 16px 8px' : '16px 4px',
-  backgroundColor: isLight ? (isTotal ? 'rgba(209, 222, 230, 0.50)' : 'transparent') : isTotal ? 'red' : 'red',
+  backgroundColor: isLight ? (isTotal ? 'rgba(209, 222, 230, 0.50)' : 'transparent') : isTotal ? '#374752' : '#405361)',
   ...(!isTotal && {
     ':after': {
       content: '""',
@@ -53,7 +53,7 @@ const MainContainer = styled.div<WithIsLight & { isTotal: boolean }>(({ isLight,
       height: 48,
       left: 10,
 
-      borderLeft: `1px solid ${isLight ? '#D1DEE6' : 'red'}`,
+      borderLeft: `1px solid ${isLight ? '#D1DEE6' : 'none'}`,
       [lightTheme.breakpoints.up('tablet_768')]: {
         left: 6,
       },
@@ -103,7 +103,7 @@ const Quarterly = styled.div<WithIsLight>(({ isLight }) => ({
   marginBottom: 6,
   fontWeight: 700,
   fontSize: 16,
-  color: isLight ? '#231536' : 'red',
+  color: isLight ? '#231536' : '#D2D4EF',
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
     fontSize: 20,
@@ -141,7 +141,7 @@ const Name = styled.div<WithIsLight>(({ isLight }) => ({
   textAlign: 'center',
   fontStyle: 'normal',
   lineHeight: 'normal',
-  color: isLight ? '#708390' : 'red',
+  color: isLight ? '#708390' : '#708390',
   [lightTheme.breakpoints.up('desktop_1024')]: {
     textAlign: 'center',
   },
@@ -150,7 +150,7 @@ const Name = styled.div<WithIsLight>(({ isLight }) => ({
   },
 }));
 const Amount = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : 'red',
+  color: isLight ? '#231536' : '#D2D4EF',
   fontSize: 12,
   fontWeight: 600,
   textAlign: 'center',

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
@@ -40,8 +40,10 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
   flex: 1,
   justifyContent: 'flex-start',
   borderRadius: 6,
-  backgroundColor: isLight ? '#E5E9EC' : 'red',
-  boxShadow: isLight ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)' : 'red',
+  backgroundColor: isLight ? '#E5E9EC' : '#405361',
+  boxShadow: isLight
+    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
+    : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px -40px rgba(7, 22, 40, 0.40)',
   alignItems: 'center',
   whiteSpace: 'pre',
   overflow: 'auto',
@@ -53,7 +55,7 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
 }));
 
 const Title = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : 'red',
+  color: isLight ? '#231536' : '#D2D4EF',
   fontFamily: 'Inter, sans-serif',
   fontSize: 16,
   fontStyle: 'normal',
@@ -71,7 +73,7 @@ const TitleContainer = styled.div<WithIsLight>(({ isLight }) => ({
   justifyContent: 'flex-start',
   alignItems: 'center',
   height: 48,
-  borderRight: `1px solid ${isLight ? '#D1DEE6' : 'red'}`,
+  borderRight: `1px solid ${isLight ? '#D1DEE6' : 'none'}`,
 
   width: 145,
 

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
@@ -42,8 +42,10 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
   flex: 1,
   justifyContent: 'flex-start',
   borderRadius: 6,
-  backgroundColor: isLight ? '#E5E9EC' : 'red',
-  boxShadow: isLight ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)' : 'red',
+  backgroundColor: isLight ? '#E5E9EC' : '#405361',
+  boxShadow: isLight
+    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
+    : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px -40px rgba(7, 22, 40, 0.40)',
   alignItems: 'center',
   whiteSpace: 'pre',
   overflow: 'auto',
@@ -55,7 +57,7 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
 }));
 
 const Title = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : 'red',
+  color: isLight ? '#231536' : '#D2D4EF',
   fontFamily: 'Inter, sans-serif',
   fontSize: 12,
   fontStyle: 'normal',

--- a/src/stories/containers/Finances/utils/mockData.ts
+++ b/src/stories/containers/Finances/utils/mockData.ts
@@ -561,43 +561,5 @@ export const mockDataTableQuarterly: MockData = {
         total: 34354,
       },
     },
-    {
-      name: 'Special Purpose Funds',
-      forecast: {
-        q1: 1234567,
-        q2: 123,
-        q3: 3455,
-        q4: 345436,
-        total: 34354,
-      },
-      budget: {
-        q1: 2208889,
-        q2: 2208889,
-        q3: 2208889,
-        q4: 2208889,
-        total: 34354,
-      },
-      actual: {
-        q1: 2208889,
-        q2: 2208889,
-        q3: 2208889,
-        q4: 2208889,
-        total: 34354,
-      },
-      'Net Expenses On-chain': {
-        q1: 2208889,
-        q2: 2208889,
-        q3: 2208889,
-        q4: 2208889,
-        total: 34354,
-      },
-      'Net Expenses Off-chain': {
-        q1: 2208889,
-        q2: 2208889,
-        q3: 2208889,
-        q4: 2208889,
-        total: 34354,
-      },
-    },
   ],
 };

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -3,7 +3,7 @@ import { SortEnum } from '@ses/core/enums/sortEnum';
 import { BudgetStatus, ResourceType } from '@ses/core/models/interfaces/types';
 import lightTheme from '@ses/styles/theme/light';
 import { DateTime } from 'luxon';
-import type { QuarterlyBudget } from './mockData';
+import type { MockData, QuarterlyBudget } from './mockData';
 import type { DelegateExpenseTableHeader, MetricsWithAmount, MomentDataItem, PeriodicSelectionFilter } from './types';
 import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatement';
 
@@ -701,4 +701,18 @@ export const getMetricByPeriod = (
   }
 
   return metricsCount;
+};
+
+export const sortDataByElementCount = (data: MockData) => {
+  const groupSizes = Object.keys(data).map((key) => ({
+    name: key,
+    size: data[key].length,
+  }));
+  groupSizes.sort((a, b) => b.size - a.size);
+  const sortedData: MockData = {};
+  groupSizes.forEach((group) => {
+    sortedData[group.name as keyof typeof sortedData] = data[group.name];
+  });
+
+  return sortedData;
 };


### PR DESCRIPTION
# Ticket

https://trello.com/c/JHKHOrzX/294-feature-budget-summary-navigation

# What solved
- [X] Should adjust the data on the row, depending on the metric selected in the Quarterly period.
- [X] Should present the tables ordered by the one with the most sub-categories.    

# Description
Adjust the row when there is more than one metric
Order the table in function number of category
