### PR TITLE
[SES-304] Add the breakdown chart filters

### DIFF
--- a/src/stories/components/ResetButton/ResetButton.tsx
+++ b/src/stories/components/ResetButton/ResetButton.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { CustomButton } from '../CustomButton/CustomButton';
 import { Close } from '../svg/close';
@@ -9,12 +10,20 @@ interface Props {
   label?: string;
   hasIcon?: boolean;
   labelMobile?: string;
+  legacyBreakpoints?: boolean;
 }
 
-const ResetButton: React.FC<Props> = ({ onClick, disabled, label = 'Reset Filters', hasIcon = true, labelMobile }) => (
+const ResetButton: React.FC<Props> = ({
+  onClick,
+  disabled,
+  label = 'Reset Filters',
+  hasIcon = true,
+  labelMobile,
+  legacyBreakpoints = true,
+}) => (
   <>
-    <Under834>
-      <ResponsiveButton onClick={onClick} hasIcon={hasIcon}>
+    <Under834 legacyBreakpoints={legacyBreakpoints}>
+      <ResponsiveButton onClick={onClick} hasIcon={hasIcon} legacyBreakpoints={legacyBreakpoints}>
         {hasIcon ? (
           <Close width={10} height={10} fill={!disabled ? '#231536' : '#D1DEE6'} />
         ) : (
@@ -31,7 +40,7 @@ const ResetButton: React.FC<Props> = ({ onClick, disabled, label = 'Reset Filter
         )}
       </ResponsiveButton>
     </Under834>
-    <Over834>
+    <Over834 legacyBreakpoints={legacyBreakpoints}>
       <CustomButton
         label={label}
         style={{
@@ -48,31 +57,36 @@ const ResetButton: React.FC<Props> = ({ onClick, disabled, label = 'Reset Filter
 
 export default ResetButton;
 
-const Under834 = styled.div({
+const Under834 = styled.div<{ legacyBreakpoints: boolean }>(({ legacyBreakpoints }) => ({
   display: 'flex',
-  '@media (min-width: 834px)': {
-    display: 'none',
-  },
-});
 
-const Over834 = styled.div({
-  display: 'none',
-  '@media (min-width: 834px)': {
-    display: 'flex',
-  },
-});
-
-const ResponsiveButton = styled.div<{ hasIcon: boolean }>(({ hasIcon = true }) => ({
-  display: 'flex',
-  gridArea: 'buttonFilter',
-  justifySelf: 'flex-end',
-  width: hasIcon ? '34px' : 'fit-content',
-  height: '34px',
-  border: hasIcon ? '1px solid #D4D9E1' : 'none',
-  borderRadius: hasIcon ? '50%' : 'none',
-  alignItems: 'center',
-  justifyContent: 'center',
-  '@media (min-width: 834px)': {
+  [lightTheme.breakpoints.up(legacyBreakpoints ? 'table_834' : 'tablet_768')]: {
     display: 'none',
   },
 }));
+
+const Over834 = styled.div<{ legacyBreakpoints: boolean }>(({ legacyBreakpoints }) => ({
+  display: 'none',
+
+  [lightTheme.breakpoints.up(legacyBreakpoints ? 'table_834' : 'tablet_768')]: {
+    display: 'flex',
+  },
+}));
+
+const ResponsiveButton = styled.div<{ hasIcon: boolean; legacyBreakpoints: boolean }>(
+  ({ hasIcon = true, legacyBreakpoints }) => ({
+    display: 'flex',
+    gridArea: 'buttonFilter',
+    justifySelf: 'flex-end',
+    width: hasIcon ? '34px' : 'fit-content',
+    height: '34px',
+    border: hasIcon ? '1px solid #D4D9E1' : 'none',
+    borderRadius: hasIcon ? '50%' : 'none',
+    alignItems: 'center',
+    justifyContent: 'center',
+
+    [lightTheme.breakpoints.up(legacyBreakpoints ? 'table_834' : 'tablet_768')]: {
+      display: 'none',
+    },
+  })
+);

--- a/src/stories/containers/Finances/FinacesContainer.tsx
+++ b/src/stories/containers/Finances/FinacesContainer.tsx
@@ -56,6 +56,11 @@ const FinancesContainer = () => {
     maxItems,
     minItems,
     allowSelectAll,
+
+    selectedBreakdownMetric,
+    selectedBreakdownGranularity,
+    handleBreakdownMetricChange,
+    handleBreakdownGranularityChange,
   } = useFinances();
 
   return (
@@ -90,7 +95,15 @@ const FinancesContainer = () => {
           <CardsNavigation cardsNavigationInformation={cardsNavigationInformation} />
         </ContainerSections>
 
-        {isEnabled('FEATURE_FINANCES_BREAKDOWN_CHART_SECTION') && <BreakdownChartSection year={year} />}
+        {isEnabled('FEATURE_FINANCES_BREAKDOWN_CHART_SECTION') && (
+          <BreakdownChartSection
+            year={year}
+            selectedMetric={selectedBreakdownMetric}
+            selectedGranularity={selectedBreakdownGranularity}
+            onMetricChange={handleBreakdownMetricChange}
+            onGranularityChange={handleBreakdownGranularityChange}
+          />
+        )}
       </Container>
 
       <ConditionalWrapper period={periodFilter}>

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -1,0 +1,122 @@
+import styled from '@emotion/styled';
+import ResetButton from '@ses/components/ResetButton/ResetButton';
+import SingleItemSelect from '@ses/components/SingleItemSelect/SingleItemSelect';
+import { Close } from '@ses/components/svg/close';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface BreakdownChartFilterProps {
+  selectedMetric: string;
+  onMetricChange: (value: string) => void;
+  selectedGranularity: string;
+  onGranularityChange: (value: string) => void;
+}
+
+const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
+  selectedMetric,
+  onMetricChange,
+  selectedGranularity,
+  onGranularityChange,
+}) => {
+  const { isLight } = useThemeContext();
+
+  const isEnable = isLight ? '#231536' : '#48495F';
+  const handleResetFilter = () => null;
+
+  return (
+    <FilterContainer>
+      <Reset>
+        <ResetButton
+          onClick={handleResetFilter}
+          disabled={true}
+          hasIcon={false}
+          label="Reset filters"
+          legacyBreakpoints={false}
+        />
+      </Reset>
+
+      <SelectContainer>
+        <MetricSelect
+          useSelectedAsLabel
+          selected={selectedMetric}
+          onChange={onMetricChange}
+          items={['Budget', 'Actual', 'Forecast', 'Net Expenses On-chain', 'Net Expenses Off-chain']}
+          PopperProps={{
+            placement: 'bottom-end',
+          }}
+        />
+        <GranularitySelect
+          useSelectedAsLabel
+          selected={selectedGranularity}
+          onChange={onGranularityChange}
+          items={['Monthly', 'Quarterly', 'Semi-annual', 'Annually']}
+          PopperProps={{
+            placement: 'bottom-end',
+          }}
+        />
+      </SelectContainer>
+
+      <ResponsiveButton onClick={handleResetFilter} isLight={isLight}>
+        <Close width={10} height={10} fill={isEnable} fillDark={isEnable} />
+      </ResponsiveButton>
+    </FilterContainer>
+  );
+};
+
+export default BreakdownChartFilter;
+
+const FilterContainer = styled.div({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: 16,
+  zIndex: 1,
+});
+
+const Reset = styled.div({
+  gridArea: 'reset',
+  display: 'none',
+  justifyContent: 'flex-end',
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+  },
+});
+
+const SelectContainer = styled.div({
+  display: 'flex',
+  gap: 16,
+});
+
+const MetricSelect = styled(SingleItemSelect)({
+  padding: '7px 15px 7px 16px',
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    padding: '14px 15px 14px 16px',
+  },
+});
+
+const GranularitySelect = styled(SingleItemSelect)({
+  padding: '7px 15px 7px 16px',
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    padding: '14px 15px 14px 16px',
+  },
+});
+
+const ResponsiveButton = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  gridArea: 'buttonFilter',
+  justifySelf: 'flex-end',
+  height: '34px',
+  width: '34px',
+  border: isLight ? '1px solid #D4D9E1' : '1px solid #10191F',
+  borderRadius: '22px',
+  alignItems: 'center',
+  justifyContent: 'center',
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.stories.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.stories.tsx
@@ -1,0 +1,90 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import BreakdownChartSection from './BreakdownChartSection';
+import type { ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/NewFinances/Section/BreakdownChartSection',
+  component: BreakdownChartSection,
+
+  parameters: {
+    chromatic: {
+      viewports: [375, 768, 1024, 1280, 1440],
+      pauseAnimationAtEnd: true,
+    },
+  },
+} as ComponentMeta<typeof BreakdownChartSection>;
+
+const args = [
+  {
+    year: 2023,
+  },
+];
+
+export const [[LightMode, DarkMode]] = createThemeModeVariants(BreakdownChartSection, args);
+
+LightMode.parameters = {
+  figma: {
+    component: {
+      375: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24365:94944',
+        options: {
+          componentStyle: {
+            width: 343,
+          },
+          style: {
+            top: 40,
+            left: 0,
+          },
+        },
+      },
+      768: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24369:99808',
+        options: {
+          componentStyle: {
+            width: 704,
+          },
+          style: {
+            top: 40,
+            left: 0,
+          },
+        },
+      },
+      1024: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24542:201606',
+        options: {
+          componentStyle: {
+            width: 960,
+          },
+          style: {
+            top: 40,
+            left: 0,
+          },
+        },
+      },
+      1280: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=22935:213735',
+        options: {
+          componentStyle: {
+            width: 1184,
+          },
+          style: {
+            top: 40,
+            left: 0,
+          },
+        },
+      },
+      1440: {
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=22935:199997',
+        options: {
+          componentStyle: {
+            width: 1312,
+          },
+          style: {
+            top: 40,
+            left: 0,
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
@@ -1,15 +1,36 @@
 import styled from '@emotion/styled';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import BreakdownChart from './BreakdownChart/BreakdownChart';
+import BreakdownChartFilter from './BreakdownChartFilter/BreakdownChartFilter';
 import SectionTitle from './SectionTitle/SectionTitle';
 
 interface BreakdownChartSectionProps {
+  selectedMetric: string;
+  onMetricChange: (value: string) => void;
+  selectedGranularity: string;
+  onGranularityChange: (value: string) => void;
   year: string;
 }
 
-const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({ year }) => (
+const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
+  year,
+  selectedMetric,
+  onMetricChange,
+  selectedGranularity,
+  onGranularityChange,
+}) => (
   <Section>
-    <SectionTitle title="Breakdown Chart" tooltip="No data" />
+    <HeaderContainer>
+      <SectionTitle title="Breakdown Chart" tooltip="No data" />
+      <BreakdownChartFilter
+        selectedMetric={selectedMetric}
+        selectedGranularity={selectedGranularity}
+        onMetricChange={onMetricChange}
+        onGranularityChange={onGranularityChange}
+      />
+    </HeaderContainer>
+
     <BreakdownChart year={year} />
   </Section>
 );
@@ -18,4 +39,16 @@ export default BreakdownChartSection;
 
 const Section = styled.section({
   marginTop: 40,
+});
+
+const HeaderContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
 });

--- a/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+const useBreakdownChart = () => {
+  const [selectedBreakdownMetric, setSelectedBreakdownMetric] = useState<string>('Budget');
+  const [selectedBreakdownGranularity, setSelectedBreakdownGranularity] = useState<string>('Monthly');
+
+  const handleBreakdownMetricChange = (value: string) => setSelectedBreakdownMetric(value);
+  const handleBreakdownGranularityChange = (value: string) => setSelectedBreakdownGranularity(value);
+
+  return {
+    selectedBreakdownMetric,
+    selectedBreakdownGranularity,
+    handleBreakdownMetricChange,
+    handleBreakdownGranularityChange,
+  };
+};
+
+export default useBreakdownChart;

--- a/src/stories/containers/Finances/components/SelectDropdown.tsx
+++ b/src/stories/containers/Finances/components/SelectDropdown.tsx
@@ -24,6 +24,9 @@ interface Props {
   menuAnchorOrigin?: MenuProps['anchorOrigin'];
 }
 
+/**
+ * @deprecated use `SingleItemSelect` instead
+ */
 const SelectDropdown: React.FC<Props> = ({
   items,
   handleChange,

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -7,6 +7,7 @@ import sortBy from 'lodash/sortBy';
 import { DateTime } from 'luxon';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import useBreakdownChart from './components/BreakdownChartSection/useBreakdownChart';
 import EndgameAtlasBudgets from './components/EndgameAtlasBudgets';
 import EndgameScopeBudgets from './components/EndgameScopeBudgets';
 import MakerDAOLegacyBudgets from './components/MakerDAOLegacyBudgets';
@@ -358,6 +359,9 @@ export const useFinances = () => {
     return metricValues;
   }, [activeMetrics, mapMetricValuesTotal, periodFilter]);
 
+  // all the logic required by the breakdown chart section
+  const breakdownChartSectionData = useBreakdownChart();
+
   return {
     years,
     year,
@@ -400,5 +404,6 @@ export const useFinances = () => {
     defaultMetricsWithAllSelected,
     maxItems,
     minItems,
+    ...breakdownChartSectionData,
   };
 };


### PR DESCRIPTION
# Ticket
https://trello.com/c/lJtOvFKL/304-feature-breakdown-chart

# Description
Add the breakdown chart filters to allow filter the chart data (integration pending)

# What solved
- [X] Should add a select allowing to toggle between the metrics: Budget-> Actuals, Forecast, Net Expense On Chain, Net Expenses Off-Chain.
- [X] Should allow users to select only one metric. 
- [X] Should allow the user to select the specific granularity of which they’d like to see the data: Monthly, Quarterly, Semi-annual, Annually. 
- [X] Should allow the users to select only one option. 