### PR TITLE
fix: budget statement navigation

### DIFF
--- a/pages/ecosystem-actors/[code]/finances/reports/index.tsx
+++ b/pages/ecosystem-actors/[code]/finances/reports/index.tsx
@@ -3,9 +3,11 @@ import { fetchActors } from '@ses/containers/Actors/api/queries';
 import ActorsTransparencyReportContainer from '@ses/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer';
 import { fetchEcosystemActor } from '@ses/containers/ActorsTransparencyReport/api/queries';
 import { fetchExpenseCategories } from '@ses/containers/FinancesOverview/api/queries';
+import { getLastSnapshotPeriod } from '@ses/containers/TransparencyReport/transparencyReportAPI';
 import { TeamContext } from '@ses/core/context/TeamContext';
 import { ResourceType } from '@ses/core/models/interfaces/types';
 import { featureFlags } from 'feature-flags/feature-flags';
+import { DateTime } from 'luxon';
 import React, { useEffect, useState } from 'react';
 import type { GetServerSideProps, GetServerSidePropsContext, InferGetServerSidePropsType, NextPage } from 'next';
 
@@ -13,6 +15,7 @@ const EcosystemActorsTransparencyReportingPage: NextPage = ({
   actor,
   actors,
   expenseCategories,
+  latestSnapshotPeriod,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const [currentActor, setCurrentActor] = useState(actor);
   useEffect(() => {
@@ -28,7 +31,12 @@ const EcosystemActorsTransparencyReportingPage: NextPage = ({
         setCurrentTeam: setCurrentActor,
       }}
     >
-      <ActorsTransparencyReportContainer actor={currentActor} actors={actors} expenseCategories={expenseCategories} />
+      <ActorsTransparencyReportContainer
+        actor={currentActor}
+        actors={actors}
+        expenseCategories={expenseCategories}
+        latestSnapshotPeriod={latestSnapshotPeriod ? DateTime.fromISO(latestSnapshotPeriod) : undefined}
+      />
     </TeamContext.Provider>
   );
 };
@@ -56,11 +64,14 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
     };
   }
 
+  const latestSnapshotPeriod = await getLastSnapshotPeriod(actor.id, ResourceType.EcosystemActor);
+
   return {
     props: {
       actor,
       actors,
       expenseCategories,
+      latestSnapshotPeriod: latestSnapshotPeriod?.toISODate() ?? null,
     },
   };
 };

--- a/src/core/hooks/useTransparencyReporting.ts
+++ b/src/core/hooks/useTransparencyReporting.ts
@@ -10,10 +10,12 @@ import useBudgetStatementPager from './useBudgetStatementPager';
 import type { CoreUnit } from '../models/interfaces/coreUnit';
 import type { WithActivityFeed, WithBudgetStatement } from '../models/interfaces/generics';
 import type { Team } from '../models/interfaces/team';
+import type { DateTime } from 'luxon';
 
 interface TransparencyReportingOptions<TabIds extends string> {
   commentTabId?: TabIds;
   initTabIndex?: () => TabIds;
+  latestSnapshotPeriod?: DateTime;
 }
 
 const useTransparencyReporting = <TabIds extends string>(
@@ -44,6 +46,7 @@ const useTransparencyReporting = <TabIds extends string>(
     useBudgetStatementPager(transparencyElement as WithBudgetStatement, {
       onNext: onPagerChanges,
       onPrevious: onPagerChanges,
+      latestSnapshotPeriod: options.latestSnapshotPeriod,
     });
 
   useEffect(() => {

--- a/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
@@ -28,17 +28,20 @@ import TeamHeadLine from './components/TeamHeadlineText/TeamHeadlineText';
 import useActorsTransparencyReport from './useActorsTransparencyReport';
 import type { ExpenseCategory } from '@ses/core/models/dto/expenseCategoriesDTO';
 import type { Team } from '@ses/core/models/interfaces/team';
+import type { DateTime } from 'luxon';
 
 interface ActorsTransparencyReportContainerProps {
   actors: Team[];
   actor: Team;
   expenseCategories: ExpenseCategory[];
+  latestSnapshotPeriod?: DateTime;
 }
 
 const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContainerProps> = ({
   actor,
   actors,
   expenseCategories,
+  latestSnapshotPeriod,
 }) => {
   const {
     isEnabled,
@@ -59,11 +62,12 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
     onTabsExpand,
     lastVisitHandler,
     comments,
-  } = useActorsTransparencyReport(actor);
+  } = useActorsTransparencyReport(actor, latestSnapshotPeriod);
   const router = useRouter();
   const ref = useRef<HTMLDivElement>(null);
   const { height, showHeader } = useHeaderSummary(ref, router.query.code as string);
   const headline = <TeamHeadLine teamLongCode={actor.code} teamShortCode={actor.shortCode} />;
+
   return (
     <Wrapper>
       <SEOHead

--- a/src/stories/containers/ActorsTransparencyReport/useActorsTransparencyReport.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/useActorsTransparencyReport.tsx
@@ -5,8 +5,9 @@ import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import { TRANSPARENCY_IDS_ENUM } from '../TransparencyReport/useTransparencyReport';
 import type { Team } from '@ses/core/models/interfaces/team';
+import type { DateTime } from 'luxon';
 
-const useActorsTransparencyReport = (actor: Team) => {
+const useActorsTransparencyReport = (actor: Team, latestSnapshotPeriod?: DateTime) => {
   const router = useRouter();
   const query = router.query;
   const [isEnabled] = useFlagsActive();
@@ -68,6 +69,7 @@ const useActorsTransparencyReport = (actor: Team) => {
   } = useTransparencyReporting<TRANSPARENCY_IDS_ENUM>(actor, {
     commentTabId: TRANSPARENCY_IDS_ENUM.COMMENTS,
     initTabIndex,
+    latestSnapshotPeriod,
   });
 
   const { tabItems, compressedTabItems, onTabChange, onTabsExpand, onTabsInit } = useTransparencyReportingTabs({

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -21,7 +21,6 @@ import AccountsSnapshotTabContainer from './components/AccountsSnapshot/Accounts
 import CuHeadlineText from './components/CuHeadlineText/CuHeadlineText';
 import ExpenseReport from './components/ExpenseReport/ExpenseReport';
 import { TransparencyActuals } from './components/TransparencyActuals/TransparencyActuals';
-
 import { TransparencyAudit } from './components/TransparencyAudit/TransparencyAudit';
 import AuditorCommentsContainer from './components/TransparencyAuditorComments/AuditorCommentsContainer/AuditorCommentsContainer';
 import { TransparencyForecast } from './components/TransparencyForecast/TransparencyForecast';
@@ -30,18 +29,25 @@ import { TransparencyTransferRequest } from './components/TransparencyTransferRe
 import { TRANSPARENCY_IDS_ENUM, useTransparencyReport } from './useTransparencyReport';
 import type { ExpenseCategory } from '@ses/core/models/dto/expenseCategoriesDTO';
 import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
+import type { DateTime } from 'luxon';
 
 interface TransparencyReportProps {
   coreUnits: CoreUnit[];
   coreUnit: CoreUnit;
   expenseCategories: ExpenseCategory[];
+  latestSnapshotPeriod?: DateTime;
 }
 export type TableItems = {
   item: string | JSX.Element;
   id: string;
 };
 
-export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: TransparencyReportProps) => {
+export const TransparencyReport = ({
+  coreUnits,
+  coreUnit,
+  expenseCategories,
+  latestSnapshotPeriod,
+}: TransparencyReportProps) => {
   const { isLight } = useThemeContext();
   const {
     tabItems,
@@ -63,7 +69,7 @@ export const TransparencyReport = ({ coreUnits, coreUnit, expenseCategories }: T
     onTabChange,
     onTabsExpand,
     compressedTabItems,
-  } = useTransparencyReport(coreUnit);
+  } = useTransparencyReport(coreUnit, latestSnapshotPeriod);
   const [isEnabled] = useFlagsActive();
   const ref = useRef<HTMLDivElement>(null);
   const { height, showHeader } = useHeaderSummary(ref, code);

--- a/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
@@ -4,6 +4,7 @@ import useTransparencyReportingTabs from '@ses/core/hooks/useTransparencyReporti
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
+import type { DateTime } from 'luxon';
 
 export enum TRANSPARENCY_IDS_ENUM {
   ACTUALS = 'actuals',
@@ -16,7 +17,7 @@ export enum TRANSPARENCY_IDS_ENUM {
   EXPENSE_REPORT = 'expense-report',
 }
 
-export const useTransparencyReport = (coreUnit: CoreUnit) => {
+export const useTransparencyReport = (coreUnit: CoreUnit, latestSnapshotPeriod?: DateTime) => {
   const router = useRouter();
   const query = router.query;
   const [isEnabled] = useFlagsActive();
@@ -78,6 +79,7 @@ export const useTransparencyReport = (coreUnit: CoreUnit) => {
   } = useTransparencyReporting<TRANSPARENCY_IDS_ENUM>(coreUnit, {
     commentTabId: TRANSPARENCY_IDS_ENUM.COMMENTS,
     initTabIndex,
+    latestSnapshotPeriod,
   });
 
   const { tabItems, compressedTabItems, onTabChange, onTabsExpand, onTabsInit } = useTransparencyReportingTabs({


### PR DESCRIPTION
# Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

# Description
Allow to navigate the budget statements having in count if there is snapshot data or not

# What solved
- [X] SES core unit. Expense Reports view. Month navigation component.  **Expected Output:** It should allow navigation to the current month.  **Current Output: ** It doesn't allow navigation to the October month even when there is data to show. 