### PR TITLE
[SES-310] Add delegates auditor flow

### DIFF
--- a/src/core/auth/teamExtension.ts
+++ b/src/core/auth/teamExtension.ts
@@ -1,5 +1,6 @@
+import { RoleEnum } from '../enums/roleEnum';
+import { ResourceType } from '../models/interfaces/types';
 import type { Team } from '../models/interfaces/team';
-import type { ResourceType } from '../models/interfaces/types';
 import type { User } from '../models/interfaces/users';
 import type PermissionManager from './permissionManager';
 
@@ -36,6 +37,13 @@ class TeamExtension {
     if (!user) {
       // there is not authenticated user
       return false;
+    }
+
+    if (team?.type === ResourceType.Delegates) {
+      return (
+        this.permissionManager.hasRole(RoleEnum.DelegatesAuditor) ||
+        this.permissionManager.hasPermission('Delegates/Audit')
+      );
     }
 
     return !!team?.auditors?.some((auditor) => auditor.id === user?.id);

--- a/src/core/enums/roleEnum.ts
+++ b/src/core/enums/roleEnum.ts
@@ -3,5 +3,6 @@ export enum RoleEnum {
   CoreUnitFacilitator = 'CoreUnitFacilitator',
   CoreUnitAuditor = 'CoreUnitAuditor',
   DelegatesAdmin = 'DelegatesAdmin',
+  DelegatesAuditor = 'DelegatesAuditor',
   User = 'User',
 }

--- a/src/core/models/dto/delegatesDTO.ts
+++ b/src/core/models/dto/delegatesDTO.ts
@@ -1,11 +1,13 @@
 import type { ChangeTrackingEvent } from '../interfaces/activity';
 import type { BudgetStatement } from '../interfaces/budgetStatement';
+import type { ResourceType } from '../interfaces/types';
 import type { ExpenseDto } from './expensesDTO';
 
 export interface DelegatesDto {
   id: string;
   shortCode: string;
   code: string;
+  type: ResourceType;
   budgetStatements: BudgetStatement[];
   activityFeed: ChangeTrackingEvent[];
 }

--- a/src/stories/containers/RecognizedDelegatesReports/RecognizedDelegatesReportAPI.ts
+++ b/src/stories/containers/RecognizedDelegatesReports/RecognizedDelegatesReportAPI.ts
@@ -1,4 +1,5 @@
 import { GRAPHQL_ENDPOINT } from '@ses/config/endpoints';
+import { ResourceType } from '@ses/core/models/interfaces/types';
 import request, { gql } from 'graphql-request';
 import type { DelegatesDto } from '@ses/core/models/dto/delegatesDTO';
 import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatement';
@@ -76,6 +77,7 @@ export const fetchRecognizedDelegatesBudgetStatements = async (): Promise<Delega
   const delegates = {
     shortCode: 'DEL',
     code: 'Delegates',
+    type: ResourceType.Delegates,
     budgetStatements: response.budgetStatements,
     activityFeed: response.budgetStatements.reduce((acc, budgetStatement) => ({
       ...acc,


### PR DESCRIPTION
# Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

# Description
Enable the auditor flow in the delegates reports

# What solved
- [X] If the user logged is an Admin and the same time Auditor then should be allowed to add new reports and audit reports.