### PR TITLE
[SES-294] Add card for core units third level

### DIFF
--- a/src/stories/components/svg/ArrowOutline.tsx
+++ b/src/stories/components/svg/ArrowOutline.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import * as React from 'react';
+
+interface Props {
+  width?: number;
+  height?: number;
+  className?: string;
+  href: string;
+}
+
+const ArrowOutline: React.FC<Props> = ({ className, height = 28, width = 40, href, ...props }) => (
+  <Link href={href}>
+    <svg
+      cursor="pointer"
+      className={className}
+      width={width}
+      height={height}
+      viewBox="0 0 40 28"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M24.934 13.94l.058.06-.058.06-.357.376-3.218 3.383a.567.567 0 01-.831 0 .64.64 0 010-.873l2.215-2.329H15.58c-.325 0-.588-.276-.588-.617 0-.341.263-.617.588-.617h7.163l-2.215-2.329a.64.64 0 010-.873.567.567 0 01.83 0l3.219 3.382.357.376z"
+        fill="#231536"
+      />
+      <rect x={0.5} y={0.5} width={39} height={27} rx={13.5} stroke="#D4D9E1" />
+    </svg>
+  </Link>
+);
+
+export default ArrowOutline;

--- a/src/stories/containers/Finances/components/CardCoreUnitThirdLevelBudget/CardCoreUnitThirdLevelBudget.stories.tsx
+++ b/src/stories/containers/Finances/components/CardCoreUnitThirdLevelBudget/CardCoreUnitThirdLevelBudget.stories.tsx
@@ -1,0 +1,62 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import CardCoreUnitThirdLevelBudget from './CardCoreUnitThirdLevelBudget';
+import type { ComponentMeta } from '@storybook/react';
+import type { FigmaParams } from 'storybook-addon-figma-comparator/dist/ts/types';
+
+export default {
+  title: 'Components/NewFinances/CardCoreUnitThirdLevelBudget',
+  component: CardCoreUnitThirdLevelBudget,
+
+  parameters: {
+    chromatic: {
+      viewports: [375, 1440],
+      pauseAnimationAtEnd: true,
+    },
+  },
+} as ComponentMeta<typeof CardCoreUnitThirdLevelBudget>;
+
+const args = [
+  {
+    href: '#',
+    code: 'CES',
+    name: 'Collateral Engineering Services',
+    // name: 'Data Insights',
+
+    img: 'https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ces-001/ces_logo.png',
+  },
+];
+export const [[LightMode, DarkMode]] = createThemeModeVariants(CardCoreUnitThirdLevelBudget, args);
+
+LightMode.parameters = {
+  figma: {
+    component: {
+      375: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=23852:184275&mode=dev',
+        options: {
+          componentStyle: {
+            width: 100,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+      1440: {
+        component:
+          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=22063:255652&mode=dev',
+        options: {
+          componentStyle: {
+            width: 150,
+          },
+          style: {
+            top: -20,
+            left: -40,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};
+DarkMode.parameters = {};

--- a/src/stories/containers/Finances/components/CardCoreUnitThirdLevelBudget/CardCoreUnitThirdLevelBudget.tsx
+++ b/src/stories/containers/Finances/components/CardCoreUnitThirdLevelBudget/CardCoreUnitThirdLevelBudget.tsx
@@ -1,0 +1,97 @@
+import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
+import { CircleAvatar } from '@ses/components/CircleAvatar/CircleAvatar';
+import ArrowOutline from '@ses/components/svg/ArrowOutline';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import ReadMore from '../ReadMore';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface Props {
+  img: string;
+  code: string;
+  name: string;
+  href: string;
+}
+
+const CardCoreUnitThirdLevelBudget: React.FC<Props> = ({ img, href, code, name }) => {
+  const { isLight } = useThemeContext();
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+  return (
+    <Container isLight={isLight}>
+      <Avatar>
+        <CircleAvatarStyled isLight={isLight} image={img} width={'32px'} height="32px" name="Core Unit" border="none" />
+      </Avatar>
+      <Information>
+        <Code isLight={isLight}>{code}</Code>
+        <Name isLight={isLight}>{name}</Name>
+      </Information>
+      <Action>{isMobile ? <ArrowOutline href={href} /> : <ReadMore href={href} />}</Action>
+    </Container>
+  );
+};
+
+export default CardCoreUnitThirdLevelBudget;
+
+const Container = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '16px 8px 10px',
+  width: 100,
+  borderRadius: 6,
+  background: isLight ? '#FFF' : 'red',
+  boxShadow: isLight ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)' : 'red',
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    padding: 16,
+    width: 150,
+  },
+}));
+const Avatar = styled.div({
+  marginBottom: 8,
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    marginBottom: 16,
+  },
+});
+const CircleAvatarStyled = styled(CircleAvatar)<WithIsLight>(({ isLight }) => ({
+  boxShadow: isLight ? '2px 4px 7px 0px rgba(26, 171, 155, 0.25)' : 'red',
+}));
+
+const Information = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: 2,
+  marginBottom: 16,
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    marginBottom: 23,
+    gap: 4,
+  },
+});
+
+const Code = styled.div<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#9FAFB9' : 'red',
+  fontSize: 12,
+  fontStyle: 'normal',
+  fontWeight: 600,
+  lineHeight: 'normal',
+  letterSpacing: '1px',
+  textTransform: 'uppercase',
+}));
+const Name = styled.div<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#231536' : 'red',
+  fontSize: 12,
+
+  fontStyle: 'normal',
+  fontWeight: 400,
+  lineHeight: 'normal',
+  width: 56,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    width: 89,
+  },
+}));
+
+const Action = styled.div({});


### PR DESCRIPTION
## Ticket
https://trello.com/c/JHKHOrzX/294-bsn-1-budget-summary-navigation

## Description
This add the card for third level of the page

## What solved
- [X] **(4)** Should create a new cards component for the Third level Budgets(Core Units)

