### PR TITLE
[SES-299] Show snapshot last update on transparency reporting page

### DIFF
--- a/src/core/models/dto/snapshotAccountDTO.ts
+++ b/src/core/models/dto/snapshotAccountDTO.ts
@@ -66,6 +66,7 @@ export interface Snapshots {
   end: string | null;
   ownerType: string;
   ownerId: string;
+  created: string | null;
   snapshotAccount: SnapshotAccount[];
   actualsComparison: ActualsComparison[];
 }

--- a/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
@@ -54,7 +54,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
     hasNextMonth,
     hasPreviousMonth,
     showExpenseReportStatusCTA,
-    lastUpdateForBudgetStatement,
+    lastUpdate,
     tabItems,
     compressedTabItems,
     onTabsInit,
@@ -62,6 +62,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
     onTabsExpand,
     lastVisitHandler,
     comments,
+    setSnapshotCreated,
   } = useActorsTransparencyReport(actor, latestSnapshotPeriod);
   const router = useRouter();
   const ref = useRef<HTMLDivElement>(null);
@@ -95,7 +96,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
               hasPrevious={hasPreviousMonth()}
               budgetStatus={currentBudgetStatement?.status || BudgetStatus.Draft}
               showExpenseReportStatusCTA={showExpenseReportStatusCTA}
-              lastUpdate={lastUpdateForBudgetStatement}
+              lastUpdate={lastUpdate}
               ref={pagerRef}
             />
 
@@ -172,6 +173,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
                   longCode={actor.code}
                   shortCode={actor.shortCode}
                   resource={ResourceType.EcosystemActor}
+                  setSnapshotCreated={setSnapshotCreated}
                 />
               )}
               {tabsIndex === TRANSPARENCY_IDS_ENUM.COMMENTS && (

--- a/src/stories/containers/ActorsTransparencyReport/useActorsTransparencyReport.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/useActorsTransparencyReport.tsx
@@ -2,7 +2,7 @@ import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
 import useTransparencyReporting from '@ses/core/hooks/useTransparencyReporting';
 import useTransparencyReportingTabs from '@ses/core/hooks/useTransparencyReportingTabs';
 import { useRouter } from 'next/router';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { TRANSPARENCY_IDS_ENUM } from '../TransparencyReport/useTransparencyReport';
 import type { Team } from '@ses/core/models/interfaces/team';
 import type { DateTime } from 'luxon';
@@ -80,6 +80,18 @@ const useActorsTransparencyReport = (actor: Team, latestSnapshotPeriod?: DateTim
     setTabsIndex,
   });
 
+  const [snapshotCreated, setSnapshotCreated] = useState<DateTime | undefined>();
+  const [lastUpdate, setLastUpdate] = useState<DateTime | undefined>();
+
+  useEffect(() => {
+    // update the last update if the account snapshot tab is selected or if it is a budget statement tab selected
+    if (tabsIndex === TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS) {
+      setLastUpdate(snapshotCreated);
+    } else {
+      setLastUpdate(lastUpdateForBudgetStatement);
+    }
+  }, [lastUpdateForBudgetStatement, snapshotCreated, tabsIndex]);
+
   return {
     isEnabled,
     pagerRef,
@@ -90,7 +102,7 @@ const useActorsTransparencyReport = (actor: Team, latestSnapshotPeriod?: DateTim
     handlePreviousMonth,
     hasNextMonth,
     hasPreviousMonth,
-    lastUpdateForBudgetStatement,
+    lastUpdate,
     showExpenseReportStatusCTA,
     tabItems,
     compressedTabItems,
@@ -99,6 +111,7 @@ const useActorsTransparencyReport = (actor: Team, latestSnapshotPeriod?: DateTim
     onTabChange,
     lastVisitHandler,
     comments,
+    setSnapshotCreated,
   };
 };
 

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -61,7 +61,7 @@ export const TransparencyReport = ({
     hasPreviousMonth,
     currentBudgetStatement,
     tabsIndex,
-    lastUpdateForBudgetStatement,
+    lastUpdate,
     comments,
     showExpenseReportStatusCTA,
     lastVisitHandler,
@@ -69,6 +69,7 @@ export const TransparencyReport = ({
     onTabChange,
     onTabsExpand,
     compressedTabItems,
+    setSnapshotCreated,
   } = useTransparencyReport(coreUnit, latestSnapshotPeriod);
   const [isEnabled] = useFlagsActive();
   const ref = useRef<HTMLDivElement>(null);
@@ -102,7 +103,7 @@ export const TransparencyReport = ({
               hasPrevious={hasPreviousMonth()}
               budgetStatus={currentBudgetStatement?.status || BudgetStatus.Draft}
               showExpenseReportStatusCTA={showExpenseReportStatusCTA}
-              lastUpdate={lastUpdateForBudgetStatement}
+              lastUpdate={lastUpdate}
               ref={pagerRef}
             />
 
@@ -179,6 +180,7 @@ export const TransparencyReport = ({
                   longCode={coreUnit.code}
                   shortCode={coreUnit.shortCode}
                   resource={ResourceType.CoreUnit}
+                  setSnapshotCreated={setSnapshotCreated}
                 />
               )}
 

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshotTabContainer.tsx
@@ -14,6 +14,7 @@ interface AccountsSnapshotTabContainerProps {
   longCode: string;
   shortCode: string;
   resource: ResourceType;
+  setSnapshotCreated: (value: DateTime | undefined) => void;
 }
 
 const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> = ({
@@ -23,8 +24,14 @@ const AccountsSnapshotTabContainer: React.FC<AccountsSnapshotTabContainerProps> 
   longCode,
   shortCode,
   resource,
+  setSnapshotCreated,
 }) => {
-  const { isLoading, snapshot, sinceDate } = useAccountsSnapshotTab(ownerId, currentMonth, resource);
+  const { isLoading, snapshot, sinceDate } = useAccountsSnapshotTab(
+    ownerId,
+    currentMonth,
+    resource,
+    setSnapshotCreated
+  );
 
   return isLoading ? (
     <AccountsSnapshotSkeleton />

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/api/queries.ts
@@ -12,6 +12,7 @@ export const accountsSnapshotQuery = (filter: SnapshotFilter) => ({
         period
         start
         end
+        created
         ownerType
         ownerId
         snapshotAccount {

--- a/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
@@ -2,7 +2,7 @@ import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
 import useTransparencyReporting from '@ses/core/hooks/useTransparencyReporting';
 import useTransparencyReportingTabs from '@ses/core/hooks/useTransparencyReportingTabs';
 import { useRouter } from 'next/router';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
 import type { DateTime } from 'luxon';
 
@@ -90,6 +90,18 @@ export const useTransparencyReport = (coreUnit: CoreUnit, latestSnapshotPeriod?:
     setTabsIndex,
   });
 
+  const [snapshotCreated, setSnapshotCreated] = useState<DateTime | undefined>();
+  const [lastUpdate, setLastUpdate] = useState<DateTime | undefined>();
+
+  useEffect(() => {
+    // update the last update if the account snapshot tab is selected or if it is a budget statement tab selected
+    if (tabsIndex === TRANSPARENCY_IDS_ENUM.ACCOUNTS_SNAPSHOTS) {
+      setLastUpdate(snapshotCreated);
+    } else {
+      setLastUpdate(lastUpdateForBudgetStatement);
+    }
+  }, [lastUpdateForBudgetStatement, snapshotCreated, tabsIndex]);
+
   return {
     isEnabled,
     pagerRef,
@@ -100,7 +112,7 @@ export const useTransparencyReport = (coreUnit: CoreUnit, latestSnapshotPeriod?:
     handlePreviousMonth,
     hasNextMonth,
     hasPreviousMonth,
-    lastUpdateForBudgetStatement,
+    lastUpdate,
     showExpenseReportStatusCTA,
     tabItems,
     compressedTabItems,
@@ -111,5 +123,6 @@ export const useTransparencyReport = (coreUnit: CoreUnit, latestSnapshotPeriod?:
     comments,
     code: coreUnit.shortCode,
     longCode: coreUnit.code,
+    setSnapshotCreated,
   };
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/0oAK0jem/299-user-story-tpd-11-projects-overview-v1

## Description
Display the snapshot last update instead of budget statement last update when the account snapshot tab is active and keep the previous behavior when the other tabs are active

## What solved
- [X] Should change the source of the value shown for LAST UPDATE when the user selects the Accounts Snapshot tab. The value should now come from the new ‘created’ field in the ‘Snapshot’ table.
- [X] Should the Last Updated = created datetime when tab with Snapshot Report is selected.
- [X] Should use existing datetime behaviour if Expense Report or Comments are selected.

