### PR TITLE
[SES-QC-310] Fix finances navigation

### DIFF
--- a/pages/ecosystem-actors/[code]/finances/reports/index.tsx
+++ b/pages/ecosystem-actors/[code]/finances/reports/index.tsx
@@ -15,7 +15,7 @@ const EcosystemActorsTransparencyReportingPage: NextPage = ({
   actor,
   actors,
   expenseCategories,
-  latestSnapshotPeriod,
+  snapshotLimitPeriods,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const [currentActor, setCurrentActor] = useState(actor);
   useEffect(() => {
@@ -35,7 +35,15 @@ const EcosystemActorsTransparencyReportingPage: NextPage = ({
         actor={currentActor}
         actors={actors}
         expenseCategories={expenseCategories}
-        latestSnapshotPeriod={latestSnapshotPeriod ? DateTime.fromISO(latestSnapshotPeriod) : undefined}
+        snapshotLimitPeriods={
+          snapshotLimitPeriods
+            ? {
+                // deserialize the ISO strings to date objects
+                earliest: DateTime.fromISO(snapshotLimitPeriods.earliest),
+                latest: DateTime.fromISO(snapshotLimitPeriods.latest),
+              }
+            : undefined
+        }
       />
     </TeamContext.Provider>
   );
@@ -64,14 +72,20 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
     };
   }
 
-  const latestSnapshotPeriod = await getLastSnapshotPeriod(actor.id, ResourceType.EcosystemActor);
+  const snapshotLimitPeriods = await getLastSnapshotPeriod(actor.id, ResourceType.EcosystemActor);
 
   return {
     props: {
       actor,
       actors,
       expenseCategories,
-      latestSnapshotPeriod: latestSnapshotPeriod?.toISODate() ?? null,
+      snapshotLimitPeriods: snapshotLimitPeriods
+        ? {
+            // serialize the date objects to ISO strings
+            earliest: snapshotLimitPeriods.earliest.toISO(),
+            latest: snapshotLimitPeriods.latest.toISO(),
+          }
+        : null,
     },
   };
 };

--- a/src/core/hooks/useTransparencyReporting.ts
+++ b/src/core/hooks/useTransparencyReporting.ts
@@ -10,12 +10,12 @@ import useBudgetStatementPager from './useBudgetStatementPager';
 import type { CoreUnit } from '../models/interfaces/coreUnit';
 import type { WithActivityFeed, WithBudgetStatement } from '../models/interfaces/generics';
 import type { Team } from '../models/interfaces/team';
-import type { DateTime } from 'luxon';
+import type { SnapshotLimitPeriods } from './useBudgetStatementPager';
 
 interface TransparencyReportingOptions<TabIds extends string> {
   commentTabId?: TabIds;
   initTabIndex?: () => TabIds;
-  latestSnapshotPeriod?: DateTime;
+  snapshotLimitPeriods?: SnapshotLimitPeriods;
 }
 
 const useTransparencyReporting = <TabIds extends string>(
@@ -46,7 +46,7 @@ const useTransparencyReporting = <TabIds extends string>(
     useBudgetStatementPager(transparencyElement as WithBudgetStatement, {
       onNext: onPagerChanges,
       onPrevious: onPagerChanges,
-      latestSnapshotPeriod: options.latestSnapshotPeriod,
+      latestSnapshotPeriod: options.snapshotLimitPeriods,
     });
 
   useEffect(() => {

--- a/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
@@ -26,22 +26,22 @@ import { TransparencyTransferRequest } from '../TransparencyReport/components/Tr
 import { TRANSPARENCY_IDS_ENUM } from '../TransparencyReport/useTransparencyReport';
 import TeamHeadLine from './components/TeamHeadlineText/TeamHeadlineText';
 import useActorsTransparencyReport from './useActorsTransparencyReport';
+import type { SnapshotLimitPeriods } from '@ses/core/hooks/useBudgetStatementPager';
 import type { ExpenseCategory } from '@ses/core/models/dto/expenseCategoriesDTO';
 import type { Team } from '@ses/core/models/interfaces/team';
-import type { DateTime } from 'luxon';
 
 interface ActorsTransparencyReportContainerProps {
   actors: Team[];
   actor: Team;
   expenseCategories: ExpenseCategory[];
-  latestSnapshotPeriod?: DateTime;
+  snapshotLimitPeriods?: SnapshotLimitPeriods;
 }
 
 const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContainerProps> = ({
   actor,
   actors,
   expenseCategories,
-  latestSnapshotPeriod,
+  snapshotLimitPeriods,
 }) => {
   const {
     isEnabled,
@@ -63,7 +63,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
     lastVisitHandler,
     comments,
     setSnapshotCreated,
-  } = useActorsTransparencyReport(actor, latestSnapshotPeriod);
+  } = useActorsTransparencyReport(actor, snapshotLimitPeriods);
   const router = useRouter();
   const ref = useRef<HTMLDivElement>(null);
   const { height, showHeader } = useHeaderSummary(ref, router.query.code as string);

--- a/src/stories/containers/ActorsTransparencyReport/useActorsTransparencyReport.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/useActorsTransparencyReport.tsx
@@ -4,10 +4,11 @@ import useTransparencyReportingTabs from '@ses/core/hooks/useTransparencyReporti
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useState } from 'react';
 import { TRANSPARENCY_IDS_ENUM } from '../TransparencyReport/useTransparencyReport';
+import type { SnapshotLimitPeriods } from '@ses/core/hooks/useBudgetStatementPager';
 import type { Team } from '@ses/core/models/interfaces/team';
 import type { DateTime } from 'luxon';
 
-const useActorsTransparencyReport = (actor: Team, latestSnapshotPeriod?: DateTime) => {
+const useActorsTransparencyReport = (actor: Team, snapshotLimitPeriods?: SnapshotLimitPeriods) => {
   const router = useRouter();
   const query = router.query;
   const [isEnabled] = useFlagsActive();
@@ -69,7 +70,7 @@ const useActorsTransparencyReport = (actor: Team, latestSnapshotPeriod?: DateTim
   } = useTransparencyReporting<TRANSPARENCY_IDS_ENUM>(actor, {
     commentTabId: TRANSPARENCY_IDS_ENUM.COMMENTS,
     initTabIndex,
-    latestSnapshotPeriod,
+    snapshotLimitPeriods,
   });
 
   const { tabItems, compressedTabItems, onTabChange, onTabsExpand, onTabsInit } = useTransparencyReportingTabs({

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -27,15 +27,15 @@ import { TransparencyForecast } from './components/TransparencyForecast/Transpar
 import { TransparencyMkrVesting } from './components/TransparencyMkrVesting/TransparencyMkrVesting';
 import { TransparencyTransferRequest } from './components/TransparencyTransferRequest/TransparencyTransferRequest';
 import { TRANSPARENCY_IDS_ENUM, useTransparencyReport } from './useTransparencyReport';
+import type { SnapshotLimitPeriods } from '@ses/core/hooks/useBudgetStatementPager';
 import type { ExpenseCategory } from '@ses/core/models/dto/expenseCategoriesDTO';
 import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
-import type { DateTime } from 'luxon';
 
 interface TransparencyReportProps {
   coreUnits: CoreUnit[];
   coreUnit: CoreUnit;
   expenseCategories: ExpenseCategory[];
-  latestSnapshotPeriod?: DateTime;
+  snapshotLimitPeriods?: SnapshotLimitPeriods;
 }
 export type TableItems = {
   item: string | JSX.Element;
@@ -46,7 +46,7 @@ export const TransparencyReport = ({
   coreUnits,
   coreUnit,
   expenseCategories,
-  latestSnapshotPeriod,
+  snapshotLimitPeriods,
 }: TransparencyReportProps) => {
   const { isLight } = useThemeContext();
   const {
@@ -70,7 +70,7 @@ export const TransparencyReport = ({
     onTabsExpand,
     compressedTabItems,
     setSnapshotCreated,
-  } = useTransparencyReport(coreUnit, latestSnapshotPeriod);
+  } = useTransparencyReport(coreUnit, snapshotLimitPeriods);
   const [isEnabled] = useFlagsActive();
   const ref = useRef<HTMLDivElement>(null);
   const { height, showHeader } = useHeaderSummary(ref, code);

--- a/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
+++ b/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
@@ -1,6 +1,7 @@
 import { GRAPHQL_ENDPOINT } from '@ses/config/endpoints';
 import request, { gql } from 'graphql-request';
 import { DateTime } from 'luxon';
+import type { SnapshotLimitPeriods } from '@ses/core/hooks/useBudgetStatementPager';
 import type { ResourceType } from '@ses/core/models/interfaces/types';
 
 export const CORE_UNIT_REQUEST = (shortCode: string) => ({
@@ -133,7 +134,7 @@ export const snapshotPeriodQuery = (ownerId: string, resourceType: ResourceType)
 export const getLastSnapshotPeriod = async (
   ownerId: string,
   resourceType: ResourceType
-): Promise<DateTime | undefined> => {
+): Promise<SnapshotLimitPeriods | undefined> => {
   const { query, filter } = snapshotPeriodQuery(ownerId, resourceType);
   const data = await request<{ snapshots: [{ period: string }] }>(GRAPHQL_ENDPOINT, query, filter);
 
@@ -142,5 +143,8 @@ export const getLastSnapshotPeriod = async (
   }
 
   const periods = data.snapshots.map((snapshot) => DateTime.fromFormat(snapshot.period, 'yyyy/MM'));
-  return DateTime.max(...periods);
+  return {
+    earliest: DateTime.min(...periods),
+    latest: DateTime.max(...periods),
+  };
 };

--- a/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/useTransparencyReport.tsx
@@ -3,6 +3,7 @@ import useTransparencyReporting from '@ses/core/hooks/useTransparencyReporting';
 import useTransparencyReportingTabs from '@ses/core/hooks/useTransparencyReportingTabs';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useState } from 'react';
+import type { SnapshotLimitPeriods } from '@ses/core/hooks/useBudgetStatementPager';
 import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
 import type { DateTime } from 'luxon';
 
@@ -17,7 +18,7 @@ export enum TRANSPARENCY_IDS_ENUM {
   EXPENSE_REPORT = 'expense-report',
 }
 
-export const useTransparencyReport = (coreUnit: CoreUnit, latestSnapshotPeriod?: DateTime) => {
+export const useTransparencyReport = (coreUnit: CoreUnit, snapshotLimitPeriods?: SnapshotLimitPeriods) => {
   const router = useRouter();
   const query = router.query;
   const [isEnabled] = useFlagsActive();
@@ -79,7 +80,7 @@ export const useTransparencyReport = (coreUnit: CoreUnit, latestSnapshotPeriod?:
   } = useTransparencyReporting<TRANSPARENCY_IDS_ENUM>(coreUnit, {
     commentTabId: TRANSPARENCY_IDS_ENUM.COMMENTS,
     initTabIndex,
-    latestSnapshotPeriod,
+    snapshotLimitPeriods,
   });
 
   const { tabItems, compressedTabItems, onTabChange, onTabsExpand, onTabsInit } = useTransparencyReportingTabs({


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
The account snapshot data wasn't considered when navigating the finances page. Now it is fixed

## What solved
- [X] Try to navigate to previous months on the Ecosystem Actors or Core Unit Expense reports **Expected Output:** Should be able to navigate back in the history till the earliest month with snapshot or budget statement data. **Current Output: ** The users can navigate back to the earliest months of the budget statements with data. 

