### PR TITLE
Remove borders when others is present

### DIFF
--- a/src/stories/containers/Finances/FinacesContainer.tsx
+++ b/src/stories/containers/Finances/FinacesContainer.tsx
@@ -63,6 +63,8 @@ const FinancesContainer: React.FC<Props> = ({ budgets }) => {
     handleBreakdownGranularityChange,
     loadMoreCards,
     handleLoadMoreCards,
+    isDisabled,
+    handleResetFilterBreakDownChart,
   } = useFinances(budgets);
 
   return (
@@ -118,6 +120,8 @@ const FinancesContainer: React.FC<Props> = ({ budgets }) => {
             selectedGranularity={selectedBreakdownGranularity}
             onMetricChange={handleBreakdownMetricChange}
             onGranularityChange={handleBreakdownGranularityChange}
+            isDisabled={isDisabled}
+            handleResetFilter={handleResetFilterBreakDownChart}
           />
         )}
       </Container>

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -12,6 +12,8 @@ interface BreakdownChartFilterProps {
   onMetricChange: (value: string) => void;
   selectedGranularity: string;
   onGranularityChange: (value: string) => void;
+  isDisabled?: boolean;
+  handleResetFilter: () => void;
 }
 
 const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
@@ -19,18 +21,19 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
   onMetricChange,
   selectedGranularity,
   onGranularityChange,
+  isDisabled = true,
+  handleResetFilter,
 }) => {
   const { isLight } = useThemeContext();
 
-  const isEnable = isLight ? '#231536' : '#48495F';
-  const handleResetFilter = () => null;
+  const colorButton = isLight ? (isDisabled ? '#ECEFF9' : '#231536') : isDisabled ? 'red' : '#48495F';
 
   return (
     <FilterContainer>
       <Reset>
         <ResetButton
           onClick={handleResetFilter}
-          disabled={true}
+          disabled={isDisabled}
           hasIcon={false}
           label="Reset filters"
           legacyBreakpoints={false}
@@ -58,8 +61,8 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
         />
       </SelectContainer>
 
-      <ResponsiveButton onClick={handleResetFilter} isLight={isLight}>
-        <Close width={10} height={10} fill={isEnable} fillDark={isEnable} />
+      <ResponsiveButton onClick={!isDisabled ? handleResetFilter : undefined} isLight={isLight} isDisabled={isDisabled}>
+        <Close width={10} height={10} fill={colorButton} fillDark={colorButton} />
       </ResponsiveButton>
     </FilterContainer>
   );
@@ -98,20 +101,20 @@ const MetricSelect = styled(SingleItemSelect)({
 });
 
 const GranularitySelect = styled(SingleItemSelect)({
-  padding: '7px 15px 7px 16px',
+  padding: '7px 12px 7px 16px',
 
   [lightTheme.breakpoints.up('tablet_768')]: {
     padding: '14px 15px 14px 16px',
   },
 });
 
-const ResponsiveButton = styled.div<WithIsLight>(({ isLight }) => ({
+const ResponsiveButton = styled.div<WithIsLight & { isDisabled: boolean }>(({ isLight, isDisabled }) => ({
   display: 'flex',
   gridArea: 'buttonFilter',
   justifySelf: 'flex-end',
   height: '34px',
   width: '34px',
-  border: isLight ? '1px solid #D4D9E1' : '1px solid #10191F',
+  border: isLight ? `1px solid ${isDisabled ? '#ECEFF9' : '#D4D9E1'}` : `1px solid ${isDisabled ? 'red' : '#10191F'}`,
   borderRadius: '22px',
   alignItems: 'center',
   justifyContent: 'center',

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
@@ -11,6 +11,8 @@ interface BreakdownChartSectionProps {
   selectedGranularity: string;
   onGranularityChange: (value: string) => void;
   year: string;
+  isDisabled?: boolean;
+  handleResetFilter: () => void;
 }
 
 const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
@@ -19,6 +21,8 @@ const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
   onMetricChange,
   selectedGranularity,
   onGranularityChange,
+  isDisabled,
+  handleResetFilter,
 }) => (
   <Section>
     <HeaderContainer>
@@ -28,6 +32,8 @@ const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
         selectedGranularity={selectedGranularity}
         onMetricChange={onMetricChange}
         onGranularityChange={onGranularityChange}
+        isDisabled={isDisabled}
+        handleResetFilter={handleResetFilter}
       />
     </HeaderContainer>
 

--- a/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -58,6 +58,11 @@ const useBreakdownChart = () => {
     itemStyle:
       valuesAtlasBudget[index].value === 0 && valuesScopeBudget[index].value === 0 ? itemStyleFull : itemStyleTop,
   })) as ValueSeriesBreakdownChart[];
+  const isDisabled = selectedBreakdownMetric === 'Budget' && selectedBreakdownGranularity === 'Monthly';
+  const handleResetFilterBreakDownChart = () => {
+    setSelectedBreakdownMetric('Budget');
+    setSelectedBreakdownGranularity('Monthly');
+  };
 
   return {
     selectedBreakdownMetric,
@@ -69,6 +74,8 @@ const useBreakdownChart = () => {
     newLegacyBudgetWithBorders,
     isShowSeries,
     setIsShowSeries,
+    isDisabled,
+    handleResetFilterBreakDownChart,
   };
 };
 

--- a/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
+++ b/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
@@ -188,7 +188,7 @@ const CustomMultiSelectStyled = styled(CustomMultiSelect)({
 });
 
 const PeriodSelect = styled(SingleItemSelect)({
-  padding: '7px 15px 7px 16px',
+  padding: '7px 12px 7px 16px',
 
   [lightTheme.breakpoints.up('tablet_768')]: {
     padding: '14px 15px 14px 16px',

--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -39,7 +39,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
     <>
       {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}
       {showFooterAndCorrectNumber.map((table, index) => (
-        <TableContainer isLight={isLight} className={className} key={index}>
+        <TableContainer isLight={isLight} className={className} key={index} hasOthers={table.others || false}>
           <TableBody isLight={isLight}>
             {table.rows.map((row: RowsItems) => (
               <TableRow isLight={isLight} isMain={row.isMain}>
@@ -102,7 +102,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
 
 export default FinancesTable;
 
-const TableContainer = styled.table<WithIsLight>(({ isLight }) => ({
+const TableContainer = styled.table<WithIsLight & { hasOthers: boolean }>(({ isLight, hasOthers }) => ({
   borderCollapse: 'collapse',
   boxShadow: isLight ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)' : 'red',
   fontFamily: 'Inter, sans-serif',
@@ -112,13 +112,14 @@ const TableContainer = styled.table<WithIsLight>(({ isLight }) => ({
   backgroundColor: isLight ? 'white' : '#1E2C37',
   borderRadius: '6px',
   '& tr:last-of-type td:last-of-type': {
-    borderBottomRightRadius: 6,
+    borderBottomRightRadius: hasOthers ? 0 : 6,
   },
 
   '& tr:last-of-type th:last-of-type': {
-    borderBottomLeftRadius: 6,
+    borderBottomLeftRadius: hasOthers ? 0 : 6,
   },
-  '& tfoot': {
+
+  '& tfoot td:last-of-type': {
     borderBottomLeftRadius: 6,
     borderBottomRightRadius: 6,
   },
@@ -235,6 +236,7 @@ const Footer = styled.tfoot<WithIsLight & { isEven: boolean; period: PeriodicSel
     backgroundColor: isLight ? (!isEven ? '#ffffff' : '#F5F5F5') : isEven ? '#18252E' : '#1f2d37',
 
     '& td:last-of-type': {
+      borderBottomRightRadius: 6,
       borderRight: 'none',
 
       backgroundColor: isLight
@@ -244,6 +246,9 @@ const Footer = styled.tfoot<WithIsLight & { isEven: boolean; period: PeriodicSel
         : !isEven
         ? '#17232C'
         : '#111C23',
+    },
+    '& tr:last-of-type td:last-of-type': {
+      borderBottomRightRadius: 6,
     },
   })
 );

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/CellAnnually.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/CellAnnually.tsx
@@ -42,19 +42,20 @@ const ContainerCell = styled.div<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const Metrics = styled.div<WithIsLight>({
+const Metrics = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'flex',
   flexDirection: 'column',
   width: 78,
   flex: 1,
-
+  position: 'relative',
   ':after': {
     content: '""',
     position: 'absolute',
     height: 48,
     bottom: 4,
+    borderRight: `1px solid ${isLight ? '#D1DEE6' : 'none'}`,
   },
-  padding: '16px 8px',
+  padding: 0,
   [lightTheme.breakpoints.up('tablet_768')]: {
     ':after': {
       display: 'none',
@@ -66,7 +67,7 @@ const Metrics = styled.div<WithIsLight>({
   [lightTheme.breakpoints.up('desktop_1440')]: {
     width: 78,
   },
-});
+}));
 const Name = styled.div<WithIsLight>({
   marginBottom: 4,
   fontSize: 11,


### PR DESCRIPTION
## Ticket
https://trello.com/c/JHKHOrzX/294-bsn-1-budget-summary-navigation

## Description
This remove the borders in the last row when the others rows (footer) appears

## What solved
- [X] FR  MakerDAO Legacy Budgets category. The rows should have straight edges. **Current Output:**  A redounded corner is displayed. 
- [X] FR  The columns should be separated by a line.  The lines between the columns aren't visible.
- [X] FR  The option should be disabled by default due to the filters have the default values. The option is active by default. 
- [X] FR The option should be active allowing resetting the filter values.  Changing the filter values, the Reset option is still disabled not allowing to reset to the default values.

