### PR TITLE
[EML-1] feat: Should allow to toggle on/off the data throughout the legend on Expense Metrics Line Chart

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,13 @@
+/* eslint-disable spellcheck/spell-checker */
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  swcMinify: true,
   compiler: {
     emotion: true,
   },
   images: {
-    domains: ['raw.githubusercontent.com'],
+    unoptimized: true,
   },
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,9 @@ const nextConfig = {
   compiler: {
     emotion: true,
   },
+  images: {
+    domains: ['raw.githubusercontent.com'],
+  },
 };
 
 module.exports = nextConfig;

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
@@ -8,7 +8,7 @@ export const useMakerDAOExpenseMetrics = () => {
     Forecast: true,
     Actuals: true,
     'Net Expenses On-chain': true,
-    'Net Expenses Off-chain Included': true,
+    'Net Expenses Off-chain': true,
   });
   const [periodFilterMetrics, setPeriodFilterMetrics] = useState<PeriodicSelectionFilter>('Monthly');
   const handlePeriodChangeMetrics = (value: string) => {

--- a/src/stories/containers/Finances/utils/types.ts
+++ b/src/stories/containers/Finances/utils/types.ts
@@ -72,5 +72,5 @@ export interface MakerDAOExpenseMetricsLineChart {
   Forecast: boolean;
   Actuals: boolean;
   'Net Expenses On-chain': boolean;
-  'Net Expenses Off-chain Included': boolean;
+  'Net Expenses Off-chain': boolean;
 }


### PR DESCRIPTION
## Ticket
https://trello.com/c/Dy3KazCU/305-eml-1-expense-metrics-line-chart

## Description
Allow to toggle on/off the data throughout the legend

## What solved
- [X] **FR7:** Should allow to toggle on and off the data throughout the legend