### PR TITLE
[SES-302] Supported projects section

### DIFF
--- a/src/stories/containers/ActorProjects/ActorProjectsContainer.tsx
+++ b/src/stories/containers/ActorProjects/ActorProjectsContainer.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 import Container from '@ses/components/Container/Container';
 import PageContainer from '@ses/components/Container/PageContainer';
 import { SEOHead } from '@ses/components/SEOHead/SEOHead';
+import SESTooltip from '@ses/components/SESTooltip/SESTooltip';
+import Information from '@ses/components/svg/information';
 import { siteRoutes } from '@ses/config/routes';
 import { toAbsoluteURL } from '@ses/core/utils/urls';
 import lightTheme from '@ses/styles/theme/light';
@@ -12,6 +14,7 @@ import ProjectList from './components/ProjectList/ProjectList';
 import useActorProjectsContainer from './useActorProjectsContainer';
 import type { Project } from '@ses/core/models/interfaces/projects';
 import type { Team } from '@ses/core/models/interfaces/team';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface ActorProjectsContainerProps {
   actors: Team[];
@@ -21,6 +24,7 @@ interface ActorProjectsContainerProps {
 
 const ActorProjectsContainer: React.FC<ActorProjectsContainerProps> = ({ actor, actors, projects }) => {
   const {
+    isLight,
     height,
     ref,
     showHeader,
@@ -68,6 +72,27 @@ const ActorProjectsContainer: React.FC<ActorProjectsContainerProps> = ({ actor, 
             />
 
             <ProjectList projects={filteredProjects} />
+
+            {projects.length > 0 && (
+              <>
+                <SupportedProjects isLight={isLight}>
+                  <span>Projects supported by {actor.name}</span>
+                  <SESTooltip
+                    content="Contributory Projects: This highlights the ecosystem actor's role as a contributor rather than the primary owner."
+                    enterTouchDelay={0}
+                    leaveTouchDelay={15000}
+                    placement="bottom-start"
+                    fallbackPlacements={['bottom-end']}
+                  >
+                    <IconContainer>
+                      <Information />
+                    </IconContainer>
+                  </SESTooltip>
+                </SupportedProjects>
+
+                <ProjectList projects={[projects[0]]} isSupportedProjects />
+              </>
+            )}
           </ContainerResponsive>
         </ContainerAllData>
       </Container>
@@ -99,4 +124,38 @@ const ContainerResponsive = styled.div({
     width: '100%',
     marginTop: 100,
   },
+});
+
+const SupportedProjects = styled.h2<WithIsLight>(({ isLight }) => ({
+  margin: '32px 0 16px',
+  fontSize: 20,
+  fontWeight: 600,
+  lineHeight: 'normal',
+  letterSpacing: 0.4,
+  color: isLight ? '#231536' : '#D2D4EF',
+  display: 'flex',
+  justifyContent: 'space-between',
+
+  '& .MuiTooltip-tooltip': {
+    marginLeft: 0,
+    marginRight: 0,
+  },
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    justifyContent: 'normal',
+    alignItems: 'flex-end',
+    gap: 8,
+    fontSize: 24,
+    margin: '56px 0 32px',
+  },
+}));
+
+const IconContainer = styled.span({
+  cursor: 'pointer',
+  padding: 4.5,
+  width: 24,
+  height: 24,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
 });

--- a/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
+import { LinkButton } from '@ses/components/LinkButton/LinkButton';
+import { siteRoutes } from '@ses/config/routes';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { ButtonType } from '@ses/core/enums/buttonTypeEnum';
 import lightTheme from '@ses/styles/theme/light';
 import Image from 'next/image';
 import React, { useCallback, useState } from 'react';
@@ -17,6 +20,7 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface ProjectCardProps {
   project: Project;
+  isSupportedProject?: boolean;
 }
 
 export type DeliverableViewMode = 'compacted' | 'detailed';
@@ -32,7 +36,7 @@ function splitInRows<T = unknown>(arr: T[], rowLength: number): T[][] {
   return result;
 }
 
-const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
+const ProjectCard: React.FC<ProjectCardProps> = ({ project, isSupportedProject = false }) => {
   const { isLight } = useThemeContext();
   const isUpDesktop1280 = useMediaQuery(lightTheme.breakpoints.up('desktop_1280'));
 
@@ -85,6 +89,14 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
             <DataContainer showDeliverablesBelow={showDeliverablesBelow}>
               {(!isUpDesktop1280 || showDeliverablesBelow) && statusSection}
               <Description isLight={isLight}>{project.abstract}</Description>
+              {isSupportedProject && (
+                <ViewEcosystem
+                  isLight={isLight}
+                  href={siteRoutes.ecosystemActorAbout(project.owner.code ?? '')}
+                  buttonType={ButtonType.Default}
+                  label="View Ecosystem Actor"
+                />
+              )}
             </DataContainer>
           </LeftColumn>
           <RightColumn>
@@ -456,5 +468,28 @@ const DeliverablesContainer = styled.div<{ showDeliverablesBelow: boolean }>(({ 
             maxWidth: 'calc(50% - 12px)',
           }),
     },
+  },
+}));
+
+const ViewEcosystem = styled(LinkButton)<WithIsLight>(({ isLight }) => ({
+  borderColor: isLight ? '#D4D9E1' : '#708390',
+  borderRadius: '22px',
+  fontFamily: 'Inter, sans serif',
+  fontStyle: 'normal',
+  padding: '7px 23px',
+
+  '& > div': {
+    color: isLight ? '#31424E' : '#ADAFD4',
+    fontWeight: 500,
+    fontSize: 14,
+    lineHeight: '18px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  '&:hover': {
+    background: isLight ? '#F6F8F9' : '#10191F',
+    border: `1px solid ${isLight ? '#ECF1F3' : '#1E2C37'}}`,
   },
 }));

--- a/src/stories/containers/ActorProjects/components/ProjectList/ProjectList.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectList/ProjectList.tsx
@@ -6,15 +6,16 @@ import type { Project } from '@ses/core/models/interfaces/projects';
 
 interface ProjectListProps {
   projects: Project[];
+  isSupportedProjects?: boolean;
 }
 
-const ProjectList: React.FC<ProjectListProps> = ({ projects }) => (
+const ProjectList: React.FC<ProjectListProps> = ({ projects, isSupportedProjects = false }) => (
   <List>
     {projects.map((project) => (
-      <ProjectCard key={project.id} project={project} />
+      <ProjectCard key={project.id} project={project} isSupportedProject={isSupportedProjects} />
     ))}
 
-    {projects.length === 0 && (
+    {projects.length === 0 && !isSupportedProjects && (
       <TablePlaceholder description="There are no Projects available with this combination of filters." />
     )}
   </List>


### PR DESCRIPTION
## Ticket
https://trello.com/c/wAk6GR11/302-tpd-14-non-project-owner-view

## Description
Add the supported projects section where all the project supported by the active ecosystem actor are listed

## What solved
- [X] Should add a new section titled: "Projects supported by {*Ecosystem Actor name*}", if there is a team that doesn't own the project but owns a deliverable
- [X] Should add an info icon where hovering over it a tooltip is displayed.
- [X] Should each supported project be listed in card displaying: The deliverable name, 'Deliverable Owner' tag, brief description
- [X] Should display CTA that links to the full project details on the owning team's project page

## Screenshots (if apply)
![Screenshot_287](https://github.com/makerdao-ses/ecosystem-dashboard/assets/29311855/4ee9f878-b498-43dc-be9f-67c61a600839)
