### PR TITLE
fix: [BC-1.1] Prepare the Breakdown Chart for all levels

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,13 @@
+/* eslint-disable spellcheck/spell-checker */
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  swcMinify: true,
   compiler: {
     emotion: true,
+  },
+  images: {
+    unoptimized: true,
   },
 };
 

--- a/src/stories/containers/EndgameBudgetContainerSecondLevel/EndgameBudgetContainerSecondLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerSecondLevel/EndgameBudgetContainerSecondLevel.tsx
@@ -5,6 +5,7 @@ import IconTitle from '@ses/components/IconTitle/IconTitle';
 import { YEARS_FINANCES_SELECTED } from '@ses/core/utils/const';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
+import BreakdownChartSection from '../Finances/components/BreakdownChartSection/BreakdownChartSection';
 import ConditionalWrapper from '../Finances/components/ConditionalWrapper/ConditionalWrapper';
 import OverviewCardMobile from '../Finances/components/OverviewCardMobile/OverviewCardMobile';
 import BreadcrumbYearNavigation from '../Finances/components/SectionPages/BreadcrumbYearNavigation';
@@ -57,6 +58,12 @@ const EndgameBudgetContainerSecondLevel: React.FC<Props> = ({ budgets }) => {
     handleLoadMoreCards,
     loadMoreCards,
     cardsToShow,
+    selectedBreakdownMetric,
+    selectedBreakdownGranularity,
+    handleBreakdownMetricChange,
+    handleBreakdownGranularityChange,
+    isDisabled,
+    handleResetFilterBreakDownChart,
   } = useEndgameBudgetContainerSecondLevel(budgets);
 
   return (
@@ -92,6 +99,15 @@ const EndgameBudgetContainerSecondLevel: React.FC<Props> = ({ budgets }) => {
             cardsNavigationInformation={cardsToShow}
             loadMoreCards={loadMoreCards}
             handleLoadMoreCards={handleLoadMoreCards}
+          />
+          <BreakdownChartSection
+            year={year}
+            selectedMetric={selectedBreakdownMetric}
+            selectedGranularity={selectedBreakdownGranularity}
+            onMetricChange={handleBreakdownMetricChange}
+            onGranularityChange={handleBreakdownGranularityChange}
+            isDisabled={isDisabled}
+            handleResetFilter={handleResetFilterBreakDownChart}
           />
           <ConditionalWrapper period={'Quarterly'}>
             <BreakdownTable

--- a/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
@@ -4,6 +4,7 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import { useRouter } from 'next/router';
 import { useCallback, useMemo, useState } from 'react';
+import useBreakdownChart from '../Finances/components/BreakdownChartSection/useBreakdownChart';
 import { useBreakdownTable } from '../Finances/components/SectionPages/BreakdownTable/useBreakdownTable';
 import { useCardChartOverview } from '../Finances/components/SectionPages/CardChartOverview/useCardChartOverview';
 import { useDelegateExpenseTrendFinances } from '../Finances/components/SectionPages/DelegateExpenseTrendFinances/useDelegateExpenseTrendFinances';
@@ -24,6 +25,9 @@ export const useEndgameBudgetContainerSecondLevel = (budgets: Budget[]) => {
 
   // Hooks for Doughnut Series
   const { filters, filterSelected, handleSelectFilter } = useCardChartOverview(budgets);
+
+  // all the logic required by the breakdown chart section
+  const breakdownChartSectionData = useBreakdownChart();
 
   // Hooks Logic of Table Second Level
   const {
@@ -157,6 +161,7 @@ export const useEndgameBudgetContainerSecondLevel = (budgets: Budget[]) => {
     filters,
     filterSelected,
     doughnutSeriesData,
+    ...breakdownChartSectionData,
     actuals,
     budgetCap,
     prediction,

--- a/src/stories/containers/EndgameBudgetContainerThirdLevel/EndgameBudgetContainerThirdLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerThirdLevel/EndgameBudgetContainerThirdLevel.tsx
@@ -8,6 +8,7 @@ import lightTheme from '@ses/styles/theme/light';
 import React, { useRef } from 'react';
 import { Navigation, Pagination } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import BreakdownChartSection from '../Finances/components/BreakdownChartSection/BreakdownChartSection';
 import CardCoreUnitThirdLevelBudget from '../Finances/components/CardCoreUnitThirdLevelBudget/CardCoreUnitThirdLevelBudget';
 import CardNavigationMobile from '../Finances/components/CardNavigationMobile/CardNavigationMobile';
 import ConditionalWrapper from '../Finances/components/ConditionalWrapper/ConditionalWrapper';
@@ -70,6 +71,12 @@ const EndgameBudgetContainerThirdLevel: React.FC<Props> = ({ budgets, coreUnits 
     minItems,
     calculateItemsPerPage,
     popupContainerHeight,
+    selectedBreakdownMetric,
+    selectedBreakdownGranularity,
+    handleBreakdownMetricChange,
+    handleBreakdownGranularityChange,
+    isDisabled,
+    handleResetFilterBreakDownChart,
   } = useEndgameBudgetContainerThirdLevel(budgets, coreUnits);
   const ref = useRef<SwiperRef>(null);
   const totalItems = cardsToShow.length;
@@ -176,6 +183,15 @@ const EndgameBudgetContainerThirdLevel: React.FC<Props> = ({ budgets, coreUnits 
               ))}
             </Swiper>
           </SwiperWrapper>
+          <BreakdownChartSection
+            year={year}
+            selectedMetric={selectedBreakdownMetric}
+            selectedGranularity={selectedBreakdownGranularity}
+            onMetricChange={handleBreakdownMetricChange}
+            onGranularityChange={handleBreakdownGranularityChange}
+            isDisabled={isDisabled}
+            handleResetFilter={handleResetFilterBreakDownChart}
+          />
         </ContainerSections>
         <ConditionalWrapper period={periodFilter}>
           <BreakdownTable

--- a/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
@@ -4,6 +4,7 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import useBreakdownChart from '../Finances/components/BreakdownChartSection/useBreakdownChart';
 import { useBreakdownTable } from '../Finances/components/SectionPages/BreakdownTable/useBreakdownTable';
 import { useCardChartOverview } from '../Finances/components/SectionPages/CardChartOverview/useCardChartOverview';
 import { useDelegateExpenseTrendFinances } from '../Finances/components/SectionPages/DelegateExpenseTrendFinances/useDelegateExpenseTrendFinances';
@@ -45,6 +46,9 @@ export const useEndgameBudgetContainerThirdLevel = (budgets: Budget[], coreUnits
     filterSelected: selectedThirdLevel,
     handleSelectFilter: handleSelectFilterThirdLevel,
   } = useCardChartOverview(budgets);
+
+  // all the logic required by the breakdown chart section
+  const breakdownChartSectionData = useBreakdownChart();
 
   const momentValue = (router.query && router.query.code && router.query.code[0]) || '';
 
@@ -186,6 +190,7 @@ export const useEndgameBudgetContainerThirdLevel = (budgets: Budget[], coreUnits
     prediction,
     cardsNavigationInformation,
     doughnutSeriesData,
+    ...breakdownChartSectionData,
     filtersThirdLevel,
     selectedThirdLevel,
     handleSelectFilterThirdLevel,

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -144,10 +144,10 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year }) => {
         stack: 'x',
         barWidth,
         showBackground: false,
-        visible: true,
         itemStyle: {
           color: isLight ? '#F99374' : '#F77249',
         },
+        isVisible: true,
       },
       {
         name: 'Endgame Scopes',
@@ -156,72 +156,55 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year }) => {
         stack: 'x',
         barWidth,
         showBackground: false,
-        visible: true,
         itemStyle: {
           color: isLight ? '#447AFB' : '#447AFB',
         },
+        isVisible: true,
       },
       {
         name: 'MakerDAO Legacy',
-        visible: true,
         data: newLegacyBudgetWithBorders,
         type: 'bar',
         stack: 'x',
-        showBackground: false,
         barWidth,
+        showBackground: false,
         itemStyle: {
           color: isLight ? '#2DC1B1' : '#1AAB9B',
         },
+        isVisible: true,
       },
     ],
   };
 
-  const onLegendItemHover = (legendName: string) => () => {
-    const chartInstance = chartRef?.current.getEchartsInstance();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const seriesIndex = options.series.findIndex((series: any) => series.name === legendName);
-    if (seriesIndex !== -1) {
-      chartInstance.dispatchAction({
-        type: 'highlight',
-        seriesName: options.series[seriesIndex].name,
-      });
-    }
-  };
-
-  const onLegendItemLeave = () => {
+  const onLegendItemHover = (legendName: string) => {
     const chartInstance = chartRef.current.getEchartsInstance();
     chartInstance.dispatchAction({
-      type: 'downplay',
+      type: 'highlight',
+      seriesName: legendName,
     });
   };
 
-  const handleOnclick = (legendName: string, data: ValueSeriesBreakdownChart[]) => () => {
-    const chartInstance = chartRef?.current.getEchartsInstance();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const seriesIndex = options.series.findIndex((series: any) => series.name === legendName);
+  const onLegendItemLeave = (legendName: string) => {
+    const chartInstance = chartRef.current.getEchartsInstance();
+    chartInstance.dispatchAction({
+      type: 'downplay',
+      seriesName: legendName,
+    });
+  };
+
+  const onLegendItemClick = (legendName: string, data: ValueSeriesBreakdownChart[]) => {
+    const seriesIndex = options.series.findIndex((series: { name: string }) => series.name === legendName);
     if (seriesIndex !== -1) {
       const currentSeries = options.series[seriesIndex];
+      currentSeries.isVisible = !currentSeries.isVisible;
+      currentSeries.data = currentSeries.isVisible ? data : [];
       setIsShowSeries({
         ...isShowSeries,
         [legendName]: !isShowSeries[legendName as keyof IsShowSeries],
       });
-
-      currentSeries.visible = !currentSeries.visible;
-
-      if (!currentSeries.visible) {
-        currentSeries.data = new Array<ValueSeriesBreakdownChart>(12).fill({
-          value: 0,
-          itemStyle: {
-            borderRadius: [0, 0, 0, 0],
-          },
-        });
-        chartInstance.setOption(options, true);
-      } else {
-        currentSeries.data = data;
-      }
-      chartInstance.setOption(options, true);
     }
   };
+
   return (
     <Wrapper>
       <ChartContainer>
@@ -242,9 +225,9 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year }) => {
         <LegendContainer>
           <LegendItem
             isLight={isLight}
-            onMouseEnter={onLegendItemHover('Endgame Atlas')}
-            onMouseLeave={onLegendItemLeave}
-            onClick={handleOnclick('Endgame Atlas', newAtlasBudgetWithBorders)}
+            onMouseEnter={() => onLegendItemHover('Endgame Atlas')}
+            onMouseLeave={() => onLegendItemLeave('Endgame Atlas')}
+            onClick={() => onLegendItemClick('Endgame Atlas', newAtlasBudgetWithBorders)}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -260,9 +243,9 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year }) => {
           </LegendItem>
           <LegendItem
             isLight={isLight}
-            onMouseEnter={onLegendItemHover('Endgame Scopes')}
-            onMouseLeave={onLegendItemLeave}
-            onClick={handleOnclick('Endgame Scopes', newScopeBudgetWithBorders)}
+            onMouseEnter={() => onLegendItemHover('Endgame Scopes')}
+            onMouseLeave={() => onLegendItemLeave('Endgame Scopes')}
+            onClick={() => onLegendItemClick('Endgame Scopes', newScopeBudgetWithBorders)}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -278,9 +261,9 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year }) => {
           </LegendItem>
           <LegendItem
             isLight={isLight}
-            onMouseEnter={onLegendItemHover('MakerDAO Legacy')}
-            onMouseLeave={onLegendItemLeave}
-            onClick={handleOnclick('MakerDAO Legacy', newLegacyBudgetWithBorders)}
+            onMouseEnter={() => onLegendItemHover('MakerDAO Legacy')}
+            onMouseLeave={() => onLegendItemLeave('MakerDAO Legacy')}
+            onClick={() => onLegendItemClick('MakerDAO Legacy', newLegacyBudgetWithBorders)}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Ticket
https://trello.com/c/lJtOvFKL/304-bc-11-non-configurable-breakdown-chart

## Description
Show the Breakdown Chart at levels 2 and 3

## What solved
- [X] **Environment:** Dev. **Browser:** Chrome. **Resolution:** All **Steps to Reproduce:** -. **Expected Output:** The graphic should be prepared for all levels. **Current Output:** The graphic is prepared only for the top level. **Visual Proof:** **Order Execution:** Please, prepare the graphic to be used at all levels.