### PR TITLE
[SES-299] Fix key results component height

### DIFF
--- a/src/stories/containers/ActorProjects/components/DeliverableCard/DeliverableCard.tsx
+++ b/src/stories/containers/ActorProjects/components/DeliverableCard/DeliverableCard.tsx
@@ -34,11 +34,7 @@ const DeliverableCard: React.FC<DeliverableCardProps> = ({
   const handleToggleExpand = () => setExpanded((prev) => !prev);
 
   return (
-    <Card
-      isLight={isLight}
-      fixedHeight={!expanded && viewMode === 'compacted' && isShownBelow && !isMobile}
-      maxKeyResultsOnRow={maxKeyResultsOnRow}
-    >
+    <Card isLight={isLight} fitContent={!isMobile && viewMode === 'compacted' && !expanded}>
       <HeaderContainer>
         <TitleContainer>
           <Title isLight={isLight} viewMode={viewMode}>
@@ -81,31 +77,19 @@ const DeliverableCard: React.FC<DeliverableCardProps> = ({
 
 export default DeliverableCard;
 
-const Card = styled.div<WithIsLight & { fixedHeight: boolean; maxKeyResultsOnRow: number }>(
-  ({ isLight, fixedHeight, maxKeyResultsOnRow }) => {
-    let height: string | number;
-
-    if (fixedHeight) {
-      height = maxKeyResultsOnRow < 4 ? 'auto' : 247;
-    } else {
-      height = 'auto';
-    }
-
-    return {
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'flex-start',
-      gap: 7,
-      borderRadius: 6,
-      background: isLight ? '#fff' : '#1E2C37',
-      boxShadow: isLight
-        ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 5px 10px 0px rgba(219, 227, 237, 0.40)'
-        : '10px 15px 20px 6px rgba(20, 0, 141, 0.10)',
-      padding: 16,
-      height: fixedHeight ? height : 'auto',
-    };
-  }
-);
+const Card = styled.div<WithIsLight & { fitContent: boolean }>(({ isLight, fitContent }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  gap: 7,
+  borderRadius: 6,
+  background: isLight ? '#fff' : '#1E2C37',
+  boxShadow: isLight
+    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 5px 10px 0px rgba(219, 227, 237, 0.40)'
+    : '10px 15px 20px 6px rgba(20, 0, 141, 0.10)',
+  padding: 16,
+  height: fitContent ? 'fit-content' : 'auto',
+}));
 
 const HeaderContainer = styled.div({
   display: 'flex',

--- a/src/stories/containers/ActorProjects/components/KeyResults/MaybeScrollableList.tsx
+++ b/src/stories/containers/ActorProjects/components/KeyResults/MaybeScrollableList.tsx
@@ -28,4 +28,5 @@ const ResultList = styled.ul({
   gap: 8,
   margin: 0,
   padding: 0,
+  height: '100%',
 });

--- a/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.stories.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.stories.tsx
@@ -36,7 +36,7 @@ const variantsArgs = [
       .withProgress(0.5)
       .addDeliverable(
         new DeliverableBuilder()
-          .withId('1')
+          .withId('6')
           .withTitle('PEA-01 On-chain Data Reconciliation')
           .withDescription(
             "On-chain Data Reconciliation will help ensure that all data related to Maker Protocol's expenses are accurate and up-to-date. This component will include a thorough analysis of all on-chain data related to expenses, which will help to identify any discrepancies."
@@ -60,7 +60,7 @@ const variantsArgs = [
       )
       .addDeliverable(
         new DeliverableBuilder()
-          .withId('2')
+          .withId('5')
           .withTitle('PEA-02 Delegates Transparency')
           .withDescription('Comprehensive overview of Delegates costs and changes over time.')
           .withOwnerData(
@@ -82,7 +82,7 @@ const variantsArgs = [
       )
       .addDeliverable(
         new DeliverableBuilder()
-          .withId('3')
+          .withId('1')
           .withTitle('PEA-02 Delegates Transparency')
           .withOwnerData(
             '3',
@@ -95,7 +95,7 @@ const variantsArgs = [
       )
       .addDeliverable(
         new DeliverableBuilder()
-          .withId('3')
+          .withId('2')
           .withTitle('PEA-02 Delegates Transparency')
           .withOwnerData(
             '2',
@@ -119,6 +119,32 @@ const variantsArgs = [
       .addDeliverable(
         new DeliverableBuilder()
           .withId('3')
+          .withTitle('PEA-03 SPF Finances')
+          .withOwnerData(
+            '4',
+            'https://makerdao-ses.github.io/ecosystem-dashboard/ecosystem-actors/BA-LABS/BA_LABS_logo.png',
+            'BA Labs',
+            'BA-LABS'
+          )
+          .withStatus(DeliverableStatus.DELIVERED)
+          .build()
+      )
+      .addDeliverable(
+        new DeliverableBuilder()
+          .withId('4')
+          .withTitle('PEA-03 SPF Finances')
+          .withOwnerData(
+            '4',
+            'https://makerdao-ses.github.io/ecosystem-dashboard/ecosystem-actors/BA-LABS/BA_LABS_logo.png',
+            'BA Labs',
+            'BA-LABS'
+          )
+          .withStatus(DeliverableStatus.DELIVERED)
+          .build()
+      )
+      .addDeliverable(
+        new DeliverableBuilder()
+          .withId('5')
           .withTitle('PEA-03 SPF Finances')
           .withOwnerData(
             '4',

--- a/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
@@ -71,7 +71,9 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isSupportedProject =
     </StatusData>
   );
 
-  const deliverables = showAllDeliverables ? project.deliverables : project.deliverables.slice(0, 4);
+  const deliverables = showAllDeliverables
+    ? project.deliverables
+    : project.deliverables.slice(0, deliverableViewMode === 'detailed' && isUpDesktop1280 ? 6 : 4);
   // transforming deliverables into rows we can predict the max height needed to the cards
   const deliverablesRows = splitInRows(deliverables, isUpDesktop1280 ? 3 : 2);
 
@@ -133,7 +135,8 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isSupportedProject =
                         .map((d) => d.keyResults.length)
                         .reduce(
                           (a, b) =>
-                            isUpDesktop1280 && !showDeliverablesBelow ? Math.min(3, Math.max(a, b)) : Math.max(a, b),
+                            // isUpDesktop1280 && !showDeliverablesBelow ? Math.min(3, Math.max(a, b)) : Math.max(a, b),
+                            Math.max(a, b),
                           0
                         )}
                     />

--- a/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
@@ -131,14 +131,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isSupportedProject =
                       deliverable={deliverable}
                       viewMode={deliverableViewMode}
                       isShownBelow={showDeliverablesBelow}
-                      maxKeyResultsOnRow={row
-                        .map((d) => d.keyResults.length)
-                        .reduce(
-                          (a, b) =>
-                            // isUpDesktop1280 && !showDeliverablesBelow ? Math.min(3, Math.max(a, b)) : Math.max(a, b),
-                            Math.max(a, b),
-                          0
-                        )}
+                      maxKeyResultsOnRow={row.map((d) => d.keyResults.length).reduce((a, b) => Math.max(a, b), 0)}
                     />
                   ))
                 )}


### PR DESCRIPTION
## Ticket
https://trello.com/c/0oAK0jem/299-tpd-1-team-projects-details-tpd-11-tdp-12-tdp-13-tdp-15

## Description
Sometimes the deliverable cards had different sizes due to how many key result items each one of them had, now all the key results lists on the same row have the same height no matter how many elements each one of them has.

## What solved
- [X] Deliverables section. Detailed mode. **Expected Output:** The key result section should be aligned in all cards. **Current Output:** The section is displayed in different positions on the card depending on the elements of the card.

## Screenshots (if apply)
![Screenshot_322](https://github.com/makerdao-ses/ecosystem-dashboard/assets/29311855/4e357d42-cb73-4893-acab-2714b064a9f7)
