### PR TITLE
[SES-299] Apply filters to supported projects

### DIFF
--- a/src/stories/containers/ActorProjects/ActorProjectsContainer.tsx
+++ b/src/stories/containers/ActorProjects/ActorProjectsContainer.tsx
@@ -38,6 +38,7 @@ const ActorProjectsContainer: React.FC<ActorProjectsContainerProps> = ({ actor, 
     handleSearchChange,
     handleResetFilters,
     filteredProjects,
+    filteredSupporterProjects,
   } = useActorProjectsContainer(projects);
 
   return (
@@ -90,7 +91,7 @@ const ActorProjectsContainer: React.FC<ActorProjectsContainerProps> = ({ actor, 
                   </SESTooltip>
                 </SupportedProjects>
 
-                <ProjectList projects={[projects[0]]} isSupportedProjects />
+                <ProjectList projects={filteredSupporterProjects} isSupportedProjects />
               </>
             )}
           </ContainerResponsive>

--- a/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
@@ -90,7 +90,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isSupportedProject =
 
           <ParticipantsContainer>
             <ProjectOwnerChip owner={project.owner} />
-            <SupportedTeamsAvatarGroup supporters={supporters} />
+            {supporters.length > 0 && <SupportedTeamsAvatarGroup supporters={supporters} />}
           </ParticipantsContainer>
         </ProjectHeader>
 

--- a/src/stories/containers/ActorProjects/components/ProjectList/ProjectList.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectList/ProjectList.tsx
@@ -1,25 +1,35 @@
 import styled from '@emotion/styled';
 import { TablePlaceholder } from '@ses/components/CustomTable/TablePlaceholder';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import ProjectCard from '../ProjectCard/ProjectCard';
 import type { Project } from '@ses/core/models/interfaces/projects';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface ProjectListProps {
   projects: Project[];
   isSupportedProjects?: boolean;
 }
 
-const ProjectList: React.FC<ProjectListProps> = ({ projects, isSupportedProjects = false }) => (
-  <List>
-    {projects.map((project) => (
-      <ProjectCard key={project.id} project={project} isSupportedProject={isSupportedProjects} />
-    ))}
+const ProjectList: React.FC<ProjectListProps> = ({ projects, isSupportedProjects = false }) => {
+  const { isLight } = useThemeContext();
 
-    {projects.length === 0 && !isSupportedProjects && (
-      <TablePlaceholder description="There are no Projects available with this combination of filters." />
-    )}
-  </List>
-);
+  return (
+    <List>
+      {projects.map((project) => (
+        <ProjectCard key={project.id} project={project} isSupportedProject={isSupportedProjects} />
+      ))}
+
+      {projects.length === 0 &&
+        (isSupportedProjects ? (
+          <NoResults isLight={isLight}>No results found</NoResults>
+        ) : (
+          <TablePlaceholder description="There are no Projects available with this combination of filters." />
+        ))}
+    </List>
+  );
+};
 
 export default ProjectList;
 
@@ -28,3 +38,16 @@ const List = styled.div({
   flexDirection: 'column',
   gap: 32,
 });
+
+const NoResults = styled.div<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#231536' : '#D2D4EF',
+  fontSize: 20,
+  fontWeight: 500,
+  textAlign: 'center',
+  fontStyle: 'italic',
+  margin: '32px 0',
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    fontSize: 24,
+  },
+}));

--- a/src/stories/containers/ActorProjects/useActorProjectsContainer.tsx
+++ b/src/stories/containers/ActorProjects/useActorProjectsContainer.tsx
@@ -62,6 +62,16 @@ const useActorProjectsContainer = (projects: Project[]) => {
     [activeStatuses, projects, searchQuery]
   );
 
+  const filteredSupporterProjects = useMemo(
+    () =>
+      projects.filter(
+        (project) =>
+          project.title.toLocaleLowerCase().includes(searchQuery) &&
+          (activeStatuses.length === 0 || activeStatuses.includes(project.status))
+      ),
+    [activeStatuses, projects, searchQuery]
+  );
+
   return {
     ref,
     height,
@@ -77,6 +87,7 @@ const useActorProjectsContainer = (projects: Project[]) => {
     handleSearchChange,
     handleResetFilters,
     filteredProjects,
+    filteredSupporterProjects,
   };
 };
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/0oAK0jem/299-tpd-1-team-projects-details-tpd-11-tdp-12-tdp-13-tdp-15

## Description
Apply filter to the supported projects and show "No result founds" if there are no results

## What solved
- [X]  Should apply the filter to the supported projects. If there are no supported projects matching the filters then should show an italic "No results found" text on the supported projects section
- [X] Phoenix Labs ecosystem actor.  Supporter avatar. **Expected Output:** If the project doesn't have any supporters, the avatar and tooltip should not be visible. If there are supporters then the avatar should be displayed properly and the tooltip should list the names. **Current Output:** A little circle is displayed and the tooltip is not displaying any name.