### PR TITLE
[SES-299] Show "no key result" msg on mobile & fix filter chips size

### DIFF
--- a/src/stories/containers/ActorProjects/components/KeyResults/KeyResults.tsx
+++ b/src/stories/containers/ActorProjects/components/KeyResults/KeyResults.tsx
@@ -81,28 +81,28 @@ const KeyResults: React.FC<KeyResultsProps> = ({
     return height;
   }, [expanded, isShownBelow, maxKeyResultsOnRow, viewMode]);
 
-  if (isMobile && isEmpty) return null;
-
   return (
     <ResultsContainer height={componentHeight}>
-      <Title isLight={isLight}>Key results</Title>
-      <MaybeScrollableList scrollable={!isMobile && (viewMode === 'detailed' || expanded) && keyResults.length > 6}>
-        {isEmpty ? (
-          <NoKeyContainer>
-            <NoKeyResults>No Key results yet</NoKeyResults>
-          </NoKeyContainer>
-        ) : (
-          <>
-            {results.map((keyResult) => (
-              <ResultItem key={keyResult.id}>
-                <KeyLink href={keyResult.link} target="_blank">
-                  {keyResult.title}
-                </KeyLink>
-              </ResultItem>
-            ))}
-          </>
-        )}
-      </MaybeScrollableList>
+      <Title isLight={isLight}>{isMobile && isEmpty ? 'No Key Results' : 'Key results'}</Title>
+      {((isMobile && !isEmpty) || !isMobile) && (
+        <MaybeScrollableList scrollable={!isMobile && (viewMode === 'detailed' || expanded) && keyResults.length > 6}>
+          {isEmpty ? (
+            <NoKeyContainer>
+              <NoKeyResults>No Key results yet</NoKeyResults>
+            </NoKeyContainer>
+          ) : (
+            <>
+              {results.map((keyResult) => (
+                <ResultItem key={keyResult.id}>
+                  <KeyLink href={keyResult.link} target="_blank">
+                    {keyResult.title}
+                  </KeyLink>
+                </ResultItem>
+              ))}
+            </>
+          )}
+        </MaybeScrollableList>
+      )}
       {isShownBelow && viewMode === 'compacted' && keyResults.length > 4 && (
         <ExpandableButtonItem expanded={expanded} handleToggleExpand={handleToggleExpand} />
       )}
@@ -133,7 +133,6 @@ const ResultsContainer = styled.div<{
 }));
 
 const Title = styled.h4<WithIsLight>(({ isLight }) => ({
-  display: 'none',
   margin: 0,
   fontSize: 16,
   fontWeight: 500,
@@ -141,10 +140,6 @@ const Title = styled.h4<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#231536' : '#D2D4EF',
   padding: '2px 8px',
   background: isLight ? 'rgba(236, 239, 249, 0.50)' : 'rgba(35, 21, 54, 0.30)',
-
-  [lightTheme.breakpoints.up('tablet_768')]: {
-    display: 'block',
-  },
 }));
 
 const NoKeyContainer = styled.div({

--- a/src/stories/containers/ActorProjects/components/ProjectFilters/ProjectFilters.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectFilters/ProjectFilters.tsx
@@ -68,7 +68,7 @@ const ProjectFilters: React.FC<ProjectFiltersProps> = ({
         <StatusMobileContainer>
           <CustomMultiSelect
             legacyBreakpoints={false}
-            popupContainerHeight={182}
+            popupContainerHeight={166}
             positionRight={true}
             label="Status"
             customAll={{
@@ -105,7 +105,7 @@ const ProjectFilters: React.FC<ProjectFiltersProps> = ({
       <FieldsContainer>
         <CustomMultiSelect
           legacyBreakpoints={false}
-          popupContainerHeight={186}
+          popupContainerHeight={166}
           positionRight={true}
           label="Status"
           customAll={{

--- a/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
@@ -43,7 +43,7 @@ const StatusChip = styled(Chip)<{ textColor: string; background: string; isSmall
     height: 'auto',
 
     '.MuiChip-label': {
-      fontSize: 14,
+      fontSize: isSmall ? 11 : 14,
       lineHeight: 'normal',
       color: textColor,
       padding: 0,


### PR DESCRIPTION
## Ticket
https://trello.com/c/0oAK0jem/299-tpd-1-team-projects-details-tpd-11-tdp-12-tdp-13-tdp-15

## Description
On mobile when the deliverables has no key results it shows a message instead of not displaying anything at all. 

## What solved
- [X] Should the Key Results subtitle be visible even when there are no key results in the deliverable. (Mobile)
- [X] Status filter. **Expected Output:** The status options should be displayed with the size visible in the Core Units view. **Current Output:** The options are displayed bigger than the options visible in the Core Units view 

