### PR TITLE
feat: BSN-1 Budget Summary + Navigation

### DIFF
--- a/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
@@ -43,7 +43,7 @@ export const useEndgameBudgetContainerSecondLevel = (budgets: Budget[], initialY
     handlePeriodChange,
     periodicSelectionFilter,
     handleSelectChangeMetrics,
-  } = useBreakdownTable(initialYear);
+  } = useBreakdownTable();
 
   const { headersExpenseReport, reportExpenseItems, handleLoadMore, showSome, onSortClick } =
     useDelegateExpenseTrendFinances();

--- a/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
@@ -185,7 +185,7 @@ export const useEndgameBudgetContainerThirdLevel = (
     allowSelectAll,
     periodicSelectionFilter,
     popupContainerHeight,
-  } = useBreakdownTable(initialYear);
+  } = useBreakdownTable();
 
   return {
     router,

--- a/src/stories/containers/Finances/FinacesContainer.tsx
+++ b/src/stories/containers/Finances/FinacesContainer.tsx
@@ -17,7 +17,6 @@ import DelegateExpenseTrendFinances from './components/SectionPages/DelegateExpe
 import MakerDAOExpenseMetricsFinances from './components/SectionPages/MakerDAOExpenseMetrics/MakerDAOExpenseMetrics';
 import { useFinances } from './useFinances';
 import { mockDataTableQuarterlyArray } from './utils/mockData';
-import type { BudgetAnalytic } from '@ses/core/models/interfaces/analytic';
 import type { Budget } from '@ses/core/models/interfaces/budget';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
@@ -25,10 +24,9 @@ interface Props {
   budgets: Budget[];
   yearsRange: string[];
   initialYear: string;
-  budgetsAnalytics: BudgetAnalytic[];
 }
 
-const FinancesContainer: React.FC<Props> = ({ budgets, yearsRange, initialYear, budgetsAnalytics }) => {
+const FinancesContainer: React.FC<Props> = ({ budgets, yearsRange, initialYear }) => {
   const [isEnabled] = useFlagsActive();
   const {
     trailingAddress,
@@ -76,7 +74,7 @@ const FinancesContainer: React.FC<Props> = ({ budgets, yearsRange, initialYear, 
     newNetExpensesOnChain,
     isDisabled,
     handleResetFilterBreakDownChart,
-  } = useFinances(budgets, initialYear, budgetsAnalytics);
+  } = useFinances(budgets, initialYear);
 
   return (
     <PageContainer>

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -1,5 +1,4 @@
 import { useMediaQuery } from '@mui/material';
-import { siteRoutes } from '@ses/config/routes';
 import { getMetricByPeriod } from '@ses/containers/Finances/utils/utils';
 import lightTheme from '@ses/styles/theme/light';
 import sortBy from 'lodash/sortBy';
@@ -8,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { MultiSelectItem } from '@ses/components/CustomMultiSelect/CustomMultiSelect';
 import type { Metric, MetricsWithAmount, PeriodicSelectionFilter } from '@ses/containers/Finances/utils/types';
 
-export const useBreakdownTable = (initialYear: string) => {
+export const useBreakdownTable = () => {
   const router = useRouter();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const isTable = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
@@ -83,8 +82,6 @@ export const useBreakdownTable = (initialYear: string) => {
     };
   }, [isDesk1024, isDesk1280, isDesk1440, isMobile, periodFilter]);
 
-  const [year, setYear] = useState(initialYear);
-
   const routes = ['Finances'];
 
   const totalCardsNavigation = 34223;
@@ -101,10 +98,6 @@ export const useBreakdownTable = (initialYear: string) => {
     ? ['Annually', 'Quarterly']
     : ['Annually', 'Quarterly', 'Monthly'];
 
-  const handleChangeYears = (value: string) => {
-    setYear(value);
-    router.push(`${siteRoutes.newFinancesOverview}?year=${value}` /* undefined, { shallow: true } */);
-  };
   const handlePeriodChange = (value: string) => {
     setPeriodFilter(value as PeriodicSelectionFilter);
   };
@@ -168,14 +161,12 @@ export const useBreakdownTable = (initialYear: string) => {
     minItems,
     allowSelectAll,
     popupContainerHeight,
-    year,
     totalCardsNavigation,
     routes,
     handleSelectChangeMetrics,
     handleResetMetrics,
     defaultMetricsWithAllSelected,
     periodicSelectionFilter,
-    handleChangeYears,
     handlePeriodChange,
     selectMetrics,
     trailingAddress,

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -23,18 +23,19 @@ export const useCardChartOverview = (budgets: Budget[], budgetsAnalytics?: Budge
 
   const metric = {
     actuals: 0,
+    forecast: 0,
     budget: 0,
   };
 
-  // temporary if
+  // remove the if when budgetsAnalytics exists in all pages/levels
   if (budgetsAnalytics !== undefined) {
     for (const ba of budgetsAnalytics) {
       metric.actuals += ba.metric.actuals.value;
+      metric.forecast += ba.metric.forecast.value;
       metric.budget += ba.metric.budget.value;
     }
   }
 
-  const prediction = 0; // temporary
   const filters: FilterDoughnut[] = ['Actual', 'Forecast', 'Net Expenses On-chain', 'Net Expenses Off-chain', 'Budget'];
   const [filterSelected, setFilterSelected] = useState<FilterDoughnut>('Budget');
 
@@ -53,8 +54,8 @@ export const useCardChartOverview = (budgets: Budget[], budgetsAnalytics?: Budge
 
   return {
     actuals: metric.actuals,
+    prediction: metric.forecast,
     budgetCap: metric.budget,
-    prediction,
     filterSelected,
     setFilterSelected,
     handleSelectFilter,

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -1,25 +1,36 @@
 import { siteRoutes } from '@ses/config/routes';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSWRConfig } from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import useBreakdownChart from './components/BreakdownChartSection/useBreakdownChart';
 import { useBreakdownTable } from './components/SectionPages/BreakdownTable/useBreakdownTable';
 import { useCardChartOverview } from './components/SectionPages/CardChartOverview/useCardChartOverview';
 import { useDelegateExpenseTrendFinances } from './components/SectionPages/DelegateExpenseTrendFinances/useDelegateExpenseTrendFinances';
 import { useMakerDAOExpenseMetrics } from './components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics';
-import { prefixToRemove, removePrefix } from './utils/utils';
-import type { BudgetAnalytic } from '@ses/core/models/interfaces/analytic';
+import { getBudgetsAnalytics, prefixToRemove, removePrefix } from './utils/utils';
 import type { Budget } from '@ses/core/models/interfaces/budget';
 
-export const useFinances = (budgets: Budget[], initialYear: string, budgetsAnalytics: BudgetAnalytic[]) => {
-  console.log(budgetsAnalytics); // temporary
+export const useFinances = (budgets: Budget[], initialYear: string) => {
+  const [year, setYear] = useState(initialYear);
+  const handleChangeYears = (value: string) => {
+    setYear(value);
+    router.push(`${siteRoutes.newFinancesOverview}?year=${value}`, undefined, { shallow: true });
+  };
+
+  const { data: budgetsAnalytics } = useSWRImmutable('analytics/annual', () =>
+    getBudgetsAnalytics('annual', year, 'atlas', 2)
+  );
+  const { mutate } = useSWRConfig();
+
   const { isLight } = useThemeContext();
   const colors: string[] = ['#F99374', '#447AFB', '#2DC1B1'];
   const colorsDark: string[] = ['#F77249', '#447AFB', '#1AAB9B'];
   const router = useRouter();
 
   const cardsNavigationInformation = budgets.map((item, index) => {
-    const budgetMetric = budgetsAnalytics.find((ba) => ba.codePath === item.codePath);
+    const budgetMetric = budgetsAnalytics?.find((ba) => ba.codePath === item.codePath);
 
     return {
       image: item.image || '',
@@ -48,12 +59,18 @@ export const useFinances = (budgets: Budget[], initialYear: string, budgetsAnaly
   const cardOverViewSectionData = useCardChartOverview(budgets, budgetsAnalytics);
 
   // All the logic required by the BreakdownTable section
-  const breakdownTable = useBreakdownTable(initialYear);
+  const breakdownTable = useBreakdownTable();
 
   // All the logic required by the MakerDAOExpenseMetrics
   const makerDAOExpensesMetrics = useMakerDAOExpenseMetrics();
 
+  useEffect(() => {
+    mutate('analytics/annual');
+  }, [mutate, year]);
+
   return {
+    year,
+    handleChangeYears,
     ...cardOverViewSectionData,
     router,
     isLight,

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -1,4 +1,5 @@
 import { siteRoutes } from '@ses/config/routes';
+import { fetchAnalytics } from '@ses/containers/Finances/api/queries';
 import { SortEnum } from '@ses/core/enums/sortEnum';
 import { BudgetStatus, ResourceType } from '@ses/core/models/interfaces/types';
 import { NUMBER_ROWS_FINANCES_TABLE } from '@ses/core/utils/const';
@@ -7,7 +8,13 @@ import { DateTime } from 'luxon';
 
 import type { QuarterlyBudget, RowsItems } from './mockData';
 import type { DelegateExpenseTableHeader, MetricsWithAmount, MomentDataItem, PeriodicSelectionFilter } from './types';
-import type { ValueAndUnit, BudgetMetric, Analytic, BudgetAnalytic } from '@ses/core/models/interfaces/analytic';
+import type {
+  ValueAndUnit,
+  BudgetMetric,
+  Analytic,
+  BudgetAnalytic,
+  AnalyticGranularity,
+} from '@ses/core/models/interfaces/analytic';
 import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatement';
 
 export const calculateValuesByBreakpoint = (
@@ -972,7 +979,7 @@ const newBudgetMetric = () =>
     paymentsOffChainIncluded: setMetric(0, ''),
   } as BudgetMetric);
 
-export const getBudgetsAnalytics = (analytics: Analytic) => {
+const getAnalytics = (analytics: Analytic) => {
   const analyticsMap: Map<string, BudgetMetric> = new Map();
 
   for (const row of analytics.series[0]?.rows) {
@@ -1004,4 +1011,14 @@ export const getBudgetsAnalytics = (analytics: Analytic) => {
     codePath,
     metric,
   })) as BudgetAnalytic[];
+};
+
+export const getBudgetsAnalytics = async (
+  granularity: AnalyticGranularity,
+  year: string,
+  select: string,
+  lod: number
+) => {
+  const analytics = await fetchAnalytics(granularity, year, select, lod);
+  return getAnalytics(analytics);
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/JHKHOrzX/294-bsn-1-budget-summary-navigation

## What solved
- [X] Show analytics (forecast) on overview card (first level)
- [X] Use SWR library (from Vercel) to get the analytics from the client side after the page is rendered for the year specified in the url or the current year