### PR TITLE
[TPD-1] Apply Project cards corrections

### DIFF
--- a/src/stories/containers/ActorProjects/components/DeliverableCard/DeliverableCard.tsx
+++ b/src/stories/containers/ActorProjects/components/DeliverableCard/DeliverableCard.tsx
@@ -10,6 +10,7 @@ import DeliverablePercentageBar from '../DeliverablePercentageBar/DeliverablePer
 import DeliverableStatusChip from '../DeliverableStatusChip/DeliverableStatusChip';
 import DeliverableStoryPointsBar from '../DeliverableStoryPointsBar/DeliverableStoryPointsBar';
 import KeyResults from '../KeyResults/KeyResults';
+import MilestoneLink from '../MilestoneLink/MilestoneLink';
 import OwnerTooltipContent from '../OwnerTooltipContent/OwnerTooltipContent';
 import type { DeliverableViewMode } from '../ProjectCard/ProjectCard';
 import type { Deliverable } from '@ses/core/models/interfaces/projects';
@@ -18,16 +19,10 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 interface DeliverableCardProps {
   deliverable: Deliverable;
   viewMode: DeliverableViewMode;
-  isShownBelow: boolean;
   maxKeyResultsOnRow: number;
 }
 
-const DeliverableCard: React.FC<DeliverableCardProps> = ({
-  deliverable,
-  viewMode,
-  isShownBelow,
-  maxKeyResultsOnRow,
-}) => {
+const DeliverableCard: React.FC<DeliverableCardProps> = ({ deliverable, viewMode, maxKeyResultsOnRow }) => {
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const [expanded, setExpanded] = useState<boolean>(false);
@@ -58,19 +53,21 @@ const DeliverableCard: React.FC<DeliverableCardProps> = ({
           ))}
       </ProgressContainer>
 
-      {viewMode === 'detailed' && (
+      {(viewMode === 'detailed' || expanded) && (
         <Description isLight={isLight}>
           Purely financial view of SPFs with generalized financial categories applicable across all budget categories.
         </Description>
       )}
-      <KeyResults
-        keyResults={deliverable.keyResults}
-        viewMode={viewMode}
-        isShownBelow={isShownBelow}
-        expanded={expanded}
-        handleToggleExpand={handleToggleExpand}
-        maxKeyResultsOnRow={maxKeyResultsOnRow}
-      />
+      <KeyBox>
+        <MilestoneLink />
+        <KeyResults
+          keyResults={deliverable.keyResults}
+          viewMode={viewMode}
+          expanded={expanded}
+          handleToggleExpand={handleToggleExpand}
+          maxKeyResultsOnRow={maxKeyResultsOnRow}
+        />
+      </KeyBox>
     </Card>
   );
 };
@@ -153,3 +150,11 @@ const Description = styled.p<WithIsLight>(({ isLight }) => ({
     lineHeight: '22px',
   },
 }));
+
+const KeyBox = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  paddingTop: 9,
+  marginTop: 'auto',
+});

--- a/src/stories/containers/ActorProjects/components/KeyResults/KeyResults.tsx
+++ b/src/stories/containers/ActorProjects/components/KeyResults/KeyResults.tsx
@@ -13,7 +13,6 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 interface KeyResultsProps {
   keyResults: KeyResult[];
   viewMode: DeliverableViewMode;
-  isShownBelow: boolean;
   expanded: boolean;
   handleToggleExpand: () => void;
   maxKeyResultsOnRow: number;
@@ -22,7 +21,6 @@ interface KeyResultsProps {
 const KeyResults: React.FC<KeyResultsProps> = ({
   keyResults,
   viewMode,
-  isShownBelow,
   expanded,
   handleToggleExpand,
   maxKeyResultsOnRow,
@@ -33,15 +31,11 @@ const KeyResults: React.FC<KeyResultsProps> = ({
 
   const results = useMemo(() => {
     if (viewMode === 'compacted') {
-      if (isShownBelow) {
-        return expanded ? keyResults : keyResults.slice(0, keyResults.length > 4 ? 3 : 4);
-      }
-      // it is shown in the right side and it is > 1280px width
-      return keyResults.slice(0, 3);
+      return expanded ? keyResults : keyResults.slice(0, keyResults.length > 4 ? 3 : 4);
     }
 
     return keyResults;
-  }, [expanded, isShownBelow, keyResults, viewMode]);
+  }, [expanded, keyResults, viewMode]);
 
   const componentHeight = useMemo(() => {
     let height: number | 'auto' = 'auto';
@@ -50,45 +44,39 @@ const KeyResults: React.FC<KeyResultsProps> = ({
 
     // calculate the height of the key results based on which card
     // on the row has more items
-    if (isShownBelow) {
-      if (viewMode === 'detailed') {
-        if (maxKeyResultsOnRow > 0) {
-          const items = Math.min(6, maxKeyResultsOnRow);
-          // items * its height + gap between items
+    if (viewMode === 'detailed') {
+      if (maxKeyResultsOnRow > 0) {
+        const items = Math.min(6, maxKeyResultsOnRow);
+        // items * its height + gap between items
+        height = NON_VARIABLE_HEIGHTS + items * 18 + (items - 1) * 8;
+      }
+    } else {
+      // compacted:
+      if (!expanded) {
+        if (maxKeyResultsOnRow === 0) {
+          // all on the row are empty
+          height = 'auto';
+        } else if (maxKeyResultsOnRow <= 4) {
+          const items = Math.min(4, maxKeyResultsOnRow);
           height = NON_VARIABLE_HEIGHTS + items * 18 + (items - 1) * 8;
-        }
-      } else {
-        // compacted:
-        if (!expanded) {
-          if (maxKeyResultsOnRow === 0) {
-            // all on the row are empty
-            height = 'auto';
-          } else if (maxKeyResultsOnRow <= 4) {
-            const items = Math.min(4, maxKeyResultsOnRow);
-            height = NON_VARIABLE_HEIGHTS + items * 18 + (items - 1) * 8;
-          } else {
-            // more than 4 so we have at least one card with the expand button
-            height = NON_VARIABLE_HEIGHTS + 70 + 26;
-          }
+        } else {
+          // more than 4 so we have at least one card with the expand button
+          height = NON_VARIABLE_HEIGHTS + 70 + 26;
         }
       }
-    } else if (maxKeyResultsOnRow > 0) {
-      // is up 1280, they are at the right and at least one card has some items
-      const items = Math.min(3, maxKeyResultsOnRow);
-      height = NON_VARIABLE_HEIGHTS - 8 + items * 18 + (items - 1) * 8;
     }
 
     return height;
-  }, [expanded, isShownBelow, maxKeyResultsOnRow, viewMode]);
+  }, [expanded, maxKeyResultsOnRow, viewMode]);
 
   return (
     <ResultsContainer height={componentHeight}>
-      <Title isLight={isLight}>{isMobile && isEmpty ? 'No Key Results' : 'Key results'}</Title>
+      <Title isLight={isLight}>{isMobile && isEmpty ? 'No Key Results' : 'Key Results'}</Title>
       {((isMobile && !isEmpty) || !isMobile) && (
         <MaybeScrollableList scrollable={!isMobile && (viewMode === 'detailed' || expanded) && keyResults.length > 6}>
           {isEmpty ? (
             <NoKeyContainer>
-              <NoKeyResults>No Key results yet</NoKeyResults>
+              <NoKeyResults>No Key Results</NoKeyResults>
             </NoKeyContainer>
           ) : (
             <>
@@ -103,7 +91,7 @@ const KeyResults: React.FC<KeyResultsProps> = ({
           )}
         </MaybeScrollableList>
       )}
-      {isShownBelow && viewMode === 'compacted' && keyResults.length > 4 && (
+      {viewMode === 'compacted' && keyResults.length > 4 && (
         <ExpandableButtonItem expanded={expanded} handleToggleExpand={handleToggleExpand} />
       )}
     </ResultsContainer>
@@ -118,8 +106,7 @@ const ResultsContainer = styled.div<{
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
-  paddingTop: 17,
-  marginTop: 'auto',
+  paddingTop: 16,
   gap: 8,
 
   [lightTheme.breakpoints.up('tablet_768')]: {

--- a/src/stories/containers/ActorProjects/components/MilestoneLink/MilestoneLink.tsx
+++ b/src/stories/containers/ActorProjects/components/MilestoneLink/MilestoneLink.tsx
@@ -1,0 +1,81 @@
+import styled from '@emotion/styled';
+import ArrowNavigationForCards from '@ses/components/svg/ArrowNavigationForCards';
+import { siteRoutes } from '@ses/config/routes';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import Link from 'next/link';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+const MilestoneLink: React.FC = () => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <LinkCard isLight={isLight} href={siteRoutes.endgamePhaseOneProgress}>
+      <TextBox>
+        <Milestone isLight={isLight}>Milestone</Milestone>
+        <Code isLight={isLight}>Base</Code>
+      </TextBox>
+      <ArrowContainer isLight={isLight}>
+        <ArrowNavigationForCards width={24} height={24} fill={isLight ? '#434358' : '#B7A6CD'} />
+      </ArrowContainer>
+    </LinkCard>
+  );
+};
+
+export default MilestoneLink;
+
+const LinkCard = styled(Link)<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  width: '100%',
+  overflow: 'hidden',
+  borderRadius: 6,
+  background: isLight ? '#fff' : '#31424E',
+  boxShadow: isLight
+    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 5px 10px 0px rgba(219, 227, 237, 0.40)'
+    : '10px 0px 20px 6px rgba(20, 0, 141, 0.10)',
+}));
+
+const TextBox = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: 8,
+});
+
+const Milestone = styled.div<WithIsLight>(({ isLight }) => ({
+  position: 'relative',
+  color: isLight ? '#708390' : '#787A9B',
+  fontSize: 12,
+  fontWeight: 600,
+  lineHeight: 'normal',
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  paddingRight: 9,
+
+  '&:after': {
+    content: '""',
+    background: isLight ? '#D4D9E1' : '#787A9B',
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    height: '100%',
+    width: 1,
+  },
+}));
+
+const Code = styled.div<WithIsLight>(({ isLight }) => ({
+  color: isLight ? '#434358' : '#787A9B',
+  fontSize: 14,
+  fontWeight: 600,
+  lineHeight: 'normal',
+}));
+
+const ArrowContainer = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'flex',
+  backgroundColor: isLight ? 'rgba(236, 239, 249, 0.50)' : 'rgba(124, 107, 149, 0.30)',
+  alignItems: 'center',
+  overflow: 'hidden',
+  justifyContent: 'center',
+  width: 32,
+  height: 34,
+}));

--- a/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectCard/ProjectCard.tsx
@@ -115,7 +115,9 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isSupportedProject =
           </LeftColumn>
           <RightColumn>
             <DeliverableTitleContainer>
-              <DeliverablesTitle isLight={isLight}>Highlighted Deliverables</DeliverablesTitle>
+              <DeliverablesTitle isLight={isLight}>
+                {showAllDeliverables ? 'All' : 'Highlighted'} Deliverables
+              </DeliverablesTitle>
               <DeliverableViewModeToggle
                 deliverableViewMode={deliverableViewMode}
                 onChangeDeliverableViewMode={handleChangeDeliverableViewMode}
@@ -130,7 +132,6 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isSupportedProject =
                       key={deliverable.id}
                       deliverable={deliverable}
                       viewMode={deliverableViewMode}
-                      isShownBelow={showDeliverablesBelow}
                       maxKeyResultsOnRow={row.map((d) => d.keyResults.length).reduce((a, b) => Math.max(a, b), 0)}
                     />
                   ))


### PR DESCRIPTION
## Ticket
https://trello.com/c/0oAK0jem/299-tpd-1-team-projects-details-tpd-11-tdp-12-tdp-13-tdp-15

## Description
Change the logic for the deliverables section on the different modes, added the milestones link and change the behavior of the deliverables title

## What solved
- [X] Should have in all resolutions the title Key Results, and the text inside the area updated to No Key Results. No Key Results title only in Mobile resolution.
- [X] Should be displayed as title of the section "All Deliverables"  when clicking "view all deliverables", otherwise should be "Highlighted Deliverables".
- [X] Should display the description of the deliverable when the user selects the Expand option for a specific deliverable, being the section in the Collapse Mode.
- [X] Should add the links to the Milestones in the Deliverable cards.

