### PR TITLE
[QC-r2] Fix doughnut chart NaN numbers

### DIFF
--- a/src/stories/containers/RecognizedDelegates/useRecognizedDelegates.ts
+++ b/src/stories/containers/RecognizedDelegates/useRecognizedDelegates.ts
@@ -42,10 +42,10 @@ export const useRecognizedDelegates = (
   // TODO: Those number will be delete next release
   const shadowTotal = 178;
   const mediaAnnual = 73254.1;
-  const delegatesExpenses = totalQuarterlyExpenses.delegatesExpenses[0]?.actuals;
+  const delegatesExpenses = totalQuarterlyExpenses.delegatesExpenses[0]?.actuals ?? 0;
 
   const otherExpenses =
-    totalQuarterlyExpenses.totalExpenses[0].actuals - totalQuarterlyExpenses.delegatesExpenses[0]?.actuals;
+    totalQuarterlyExpenses.totalExpenses[0].actuals - (totalQuarterlyExpenses.delegatesExpenses[0]?.actuals ?? 0);
 
   const selectElements = useMemo(
     () =>
@@ -68,6 +68,7 @@ export const useRecognizedDelegates = (
 
   const resultFilteredChart =
     activeElements.length === 0 ? totalDelegateMonthly : filteredDelegatesChart(orderAllMonthExpense, activeElements);
+
   return {
     totalDAI,
     recognizedDelegates,


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Some numbers were NaN and the chart was not showing up, now the source of the issue is solved

## What solved
-  Recognized Delegate's view. Key Stats section. **Expected Output:**  In the Percentage of Total DAO Expense card if there are no values or the values are zero, the values reflected should be 0 and the pie chart should have a placeholder when there are no values to show. **Current Output: ** NAN and NaN are displayed and the pie chart is not visible causing a big space. 

