### PR TITLE
[QC-r2] accomodate EA scopes

### DIFF
--- a/src/stories/components/SESTooltip/SESTooltip.tsx
+++ b/src/stories/components/SESTooltip/SESTooltip.tsx
@@ -155,12 +155,5 @@ const tooltipProps = (borderColor: React.CSSProperties['color'], isLight = true)
       margin: '-0.95em 0',
       scale: '1 1.81',
     },
-
-    [lightTheme.breakpoints.down('table_834')]: {
-      // prevent the tooltip to be too close to the windows edge
-      maxWidth: 343,
-      marginRight: '16px',
-      marginLeft: '16px',
-    },
   },
 });

--- a/src/stories/containers/Actors/components/ActorItem/ActorItem.tsx
+++ b/src/stories/containers/Actors/components/ActorItem/ActorItem.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
 import { CircleAvatar } from '@ses/components/CircleAvatar/CircleAvatar';
 import SocialMediaComponent from '@ses/components/SocialMediaComponent/SocialMediaComponent';
 import { siteRoutes } from '@ses/config/routes';
@@ -11,6 +12,7 @@ import React from 'react';
 import { ActorsLinkType, getActorLastMonthWithData, getLinksFromRecognizedActors } from '../../utils/utils';
 import ActorLastModified from '../ActorLastModified/ActorLastModified';
 import ScopeChip from '../ScopeChip/ScopeChip';
+import GroupedScopes from './GroupedScopes';
 import type { ActorScopeEnum } from '@ses/core/enums/actorScopeEnum';
 import type { Team } from '@ses/core/models/interfaces/team';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -23,6 +25,8 @@ interface Props {
 
 const ActorItem: React.FC<Props> = ({ actor, queryStrings }) => {
   const { isLight } = useThemeContext();
+  const isUp1194 = useMediaQuery(lightTheme.breakpoints.up('desktop_1194'));
+
   const ActorAboutLink: React.FC<PropsWithChildren> = ({ children }) => (
     <ContainerLinkColum>
       <Link href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}/${queryStrings}`} legacyBehavior passHref>
@@ -59,13 +63,18 @@ const ActorItem: React.FC<Props> = ({ actor, queryStrings }) => {
             <WrapperCategoryScopeMobileInside>
               <ActorTitle isLight={isLight}>{pascalCaseToNormalString(actor.category?.[0] ?? '')}</ActorTitle>
             </WrapperCategoryScopeMobileInside>
-            {actor.scopes?.length > 0 && (
-              <ContainerScopeMobile>
-                {actor.scopes?.map((item, index) => (
-                  <ScopeChip status={item.name as ActorScopeEnum} code={item.code} key={index} />
-                ))}
-              </ContainerScopeMobile>
-            )}
+            {actor.scopes?.length > 0 &&
+              (actor.scopes?.length > 2 ? (
+                <MobileGroupedScopesBox>
+                  <GroupedScopes scopes={actor.scopes} />
+                </MobileGroupedScopesBox>
+              ) : (
+                <ContainerScopeMobile>
+                  {actor.scopes?.map((item, index) => (
+                    <ScopeChip status={item.name as ActorScopeEnum} code={item.code} key={index} />
+                  ))}
+                </ContainerScopeMobile>
+              ))}
           </WrapperCategoryScopeMobile>
         </ContainerActorType>
       </ActorAboutLink>
@@ -79,9 +88,13 @@ const ActorItem: React.FC<Props> = ({ actor, queryStrings }) => {
           <ContainerScopeLastModified>
             <ActorAboutLink>
               <ScopeSection>
-                {actor?.scopes?.map((item, index) => (
-                  <ScopeChip status={item.name as ActorScopeEnum} code={item.code} key={index} />
-                ))}
+                {actor?.scopes?.length > 2 && isUp1194 ? (
+                  <GroupedScopes scopes={actor.scopes} />
+                ) : (
+                  actor?.scopes?.map((item, index) => (
+                    <ScopeChip status={item.name as ActorScopeEnum} code={item.code} key={index} />
+                  ))
+                )}
               </ScopeSection>
             </ActorAboutLink>
 
@@ -497,6 +510,7 @@ const WrapperCategoryScopeMobile = styled.div({
   flexDirection: 'row',
   justifyContent: 'space-between',
   marginBottom: 15,
+
   [lightTheme.breakpoints.up('table_834')]: {
     display: 'none',
   },
@@ -550,4 +564,8 @@ const WrapperHiddenOnlyMobileScope = styled.div({
 const LinkSpace = styled.div({
   display: 'flex',
   flex: 1,
+});
+
+const MobileGroupedScopesBox = styled.div({
+  paddingRight: 16,
 });

--- a/src/stories/containers/Actors/components/ActorItem/GroupedScopes.tsx
+++ b/src/stories/containers/Actors/components/ActorItem/GroupedScopes.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+import SESTooltip from '@ses/components/SESTooltip/SESTooltip';
+import ScopeChip from '../ScopeChip/ScopeChip';
+import type { ActorScopeEnum } from '@ses/core/enums/actorScopeEnum';
+import type { Scope } from '@ses/core/models/interfaces/scopes';
+
+interface GroupedScopesProps {
+  scopes: Scope[];
+}
+const GroupedScopes: React.FC<GroupedScopesProps> = ({ scopes }) => (
+  <SESTooltip
+    placement="bottom-start"
+    content={
+      <TooltipContent>
+        {scopes?.map((item, index) => (
+          <ScopeChip status={item.name as ActorScopeEnum} code={item.code} key={index} />
+        ))}
+      </TooltipContent>
+    }
+  >
+    <Group columns={Math.ceil(scopes.length / 2)}>
+      {scopes?.map((item, index) => (
+        <ScopeChip status={item.name as ActorScopeEnum} code={item.code} codeOnly key={index} />
+      ))}
+    </Group>
+  </SESTooltip>
+);
+
+export default GroupedScopes;
+
+const Group = styled.div<{ columns: number }>(({ columns }) => ({
+  display: 'grid',
+  gap: 4,
+  gridTemplateColumns: `repeat(${columns}, 1fr)`,
+}));
+
+const TooltipContent = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+});

--- a/src/stories/containers/Actors/components/ScopeChip/ScopeChip.tsx
+++ b/src/stories/containers/Actors/components/ScopeChip/ScopeChip.tsx
@@ -3,13 +3,13 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { getScopeColor } from '@ses/core/utils/colors';
 import React from 'react';
 import type { ActorScopeEnum } from '@ses/core/enums/actorScopeEnum';
-
 import type { CSSProperties } from 'react';
 
 interface ScopeChipProps {
   status: ActorScopeEnum;
   style?: CSSProperties;
   code: string;
+  codeOnly?: boolean;
 }
 
 const ScopeChip = (props: ScopeChipProps) => {
@@ -21,11 +21,15 @@ const ScopeChip = (props: ScopeChipProps) => {
       style={{
         color: isLight ? colorsChip.color : colorsChip.darkColor,
         background: isLight ? colorsChip.background : colorsChip.darkBackground,
+        ...(props.codeOnly && {
+          width: 46,
+          justifyContent: 'center',
+        }),
         ...props.style,
       }}
     >
       <Code>{props.code}</Code>
-      <Scope>{props.status}</Scope>
+      {!props.codeOnly && <Scope>{props.status}</Scope>}
     </Chip>
   );
 };

--- a/src/stories/containers/EndgamePhaseOneProgress/components/RoadmapTimeline/RoadmapTimeline.tsx
+++ b/src/stories/containers/EndgamePhaseOneProgress/components/RoadmapTimeline/RoadmapTimeline.tsx
@@ -55,15 +55,14 @@ const RoadmapTimeline = () => {
               </CardWrapper>
             ))}
           </Up>
-          {milestones.length > 4 && (
-            <Down shouldAddPadding={shouldAddPadding} isLight={isLight}>
-              {down.map((_, i) => (
+          <Down shouldAddPadding={shouldAddPadding} isLight={isLight}>
+            {milestones.length > 4 &&
+              down.map((_, i) => (
                 <CardWrapper key={i} isLight={isLight}>
                   <MilestoneCard />
                 </CardWrapper>
               ))}
-            </Down>
-          )}
+          </Down>
         </DesktopTimeline>
       )}
     </div>


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Now when there are more than 2 scopes they're grouped to fit in the space they have

## What solved
- [X] Ecosystem Actors view. SES EA, Scope column.   **Expected Output:** The scopes should be accommodated in the row when there are more than 3. **Current Output:** Four scores are displayed and two of them are displayed out of the row.

## Screenshots (if apply)
![Screenshot_479](https://github.com/makerdao-ses/ecosystem-dashboard/assets/29311855/ee253dcd-8c62-4e15-8127-d6f5859b5daa)
