### PR TITLE
[QC-r2] Fix EA scopes on mobile

### DIFF
--- a/src/stories/containers/Actors/components/ActorItem/ActorItem.tsx
+++ b/src/stories/containers/Actors/components/ActorItem/ActorItem.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useMediaQuery } from '@mui/material';
 import { CircleAvatar } from '@ses/components/CircleAvatar/CircleAvatar';
 import SocialMediaComponent from '@ses/components/SocialMediaComponent/SocialMediaComponent';
 import { siteRoutes } from '@ses/config/routes';
@@ -25,7 +24,6 @@ interface Props {
 
 const ActorItem: React.FC<Props> = ({ actor, queryStrings }) => {
   const { isLight } = useThemeContext();
-  const isUp1194 = useMediaQuery(lightTheme.breakpoints.up('desktop_1194'));
 
   const ActorAboutLink: React.FC<PropsWithChildren> = ({ children }) => (
     <ContainerLinkColum>
@@ -88,7 +86,7 @@ const ActorItem: React.FC<Props> = ({ actor, queryStrings }) => {
           <ContainerScopeLastModified>
             <ActorAboutLink>
               <ScopeSection>
-                {actor?.scopes?.length > 2 && isUp1194 ? (
+                {actor?.scopes?.length > 2 ? (
                   <GroupedScopes scopes={actor.scopes} />
                 ) : (
                   actor?.scopes?.map((item, index) => (

--- a/src/stories/containers/Actors/components/ActorItem/GroupedScopes.tsx
+++ b/src/stories/containers/Actors/components/ActorItem/GroupedScopes.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import SESTooltip from '@ses/components/SESTooltip/SESTooltip';
+import lightTheme from '@ses/styles/theme/light';
 import ScopeChip from '../ScopeChip/ScopeChip';
 import type { ActorScopeEnum } from '@ses/core/enums/actorScopeEnum';
 import type { Scope } from '@ses/core/models/interfaces/scopes';
@@ -32,6 +33,15 @@ const Group = styled.div<{ columns: number }>(({ columns }) => ({
   display: 'grid',
   gap: 4,
   gridTemplateColumns: `repeat(${columns}, 1fr)`,
+  direction: 'rtl',
+
+  [lightTheme.breakpoints.up('table_834')]: {
+    direction: 'ltr',
+  },
+
+  [lightTheme.breakpoints.between('table_834', 'desktop_1194')]: {
+    display: 'flex',
+  },
 }));
 
 const TooltipContent = styled.div({


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Show the scopes code only on tablet devices in the EA page

## What solved
- [X]  Ecosystem Actors view. SES EA, Scope column.   **Expected Output:** The scopes should be accommodated in the row when there are more than 3. **Current Output:** Four scores are displayed and two of them are displayed out of the row.

