### PR TITLE
[MER-1] Fix expense report filters

### DIFF
--- a/src/stories/containers/EndgameBudgetContainerSecondLevel/EndgameBudgetContainerSecondLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerSecondLevel/EndgameBudgetContainerSecondLevel.tsx
@@ -154,6 +154,7 @@ const EndgameBudgetContainerSecondLevel: React.FC<Props> = ({ budgets, yearsRang
             sortClick={expenseReportSection.onSortClick}
             handleLoadMore={expenseReportSection.handleLoadMore}
             showAllItems={expenseReportSection.showAllItems}
+            allItemsCount={expenseReportSection.expenseItemsCount}
           />
         </ContainerLastReport>
       </Container>

--- a/src/stories/containers/EndgameBudgetContainerThirdLevel/EndgameBudgetContainerThirdLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerThirdLevel/EndgameBudgetContainerThirdLevel.tsx
@@ -241,6 +241,7 @@ const EndgameBudgetContainerThirdLevel: React.FC<Props> = ({ budgets, yearsRange
             sortClick={expenseReportSection.onSortClick}
             handleLoadMore={expenseReportSection.handleLoadMore}
             showAllItems={expenseReportSection.showAllItems}
+            allItemsCount={expenseReportSection.expenseItemsCount}
           />
         </ContainerLastReport>
       </Container>

--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -190,6 +190,7 @@ const FinancesContainer: React.FC<Props> = ({ budgets, yearsRange, initialYear }
             sortClick={expenseReportSection.onSortClick}
             handleLoadMore={expenseReportSection.handleLoadMore}
             showAllItems={expenseReportSection.showAllItems}
+            allItemsCount={expenseReportSection.expenseItemsCount}
           />
         </ContainerLastReport>
       </Container>

--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.stories.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.stories.tsx
@@ -20,12 +20,14 @@ const variantsArgs = [
     handleLinkToPage: () => null,
     link: '#',
     isMobile: false,
+    selectedMetric: 'Actuals',
     expenseReport: mockDataApiTeam[0],
   },
   {
     handleLinkToPage: () => null,
     link: '#',
     isMobile: true,
+    selectedMetric: 'Actuals',
     expenseReport: mockDataApiTeam[0],
   },
 ];

--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
@@ -26,10 +26,11 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 interface Props {
   link?: string;
   expenseReport: MomentDataItem;
+  selectedMetric: string;
   now?: DateTime;
 }
 
-const DelegateExpenseTrendItem: React.FC<Props> = ({ link, expenseReport, now = DateTime.now() }) => {
+const DelegateExpenseTrendItem: React.FC<Props> = ({ link, expenseReport, selectedMetric, now = DateTime.now() }) => {
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const { isLight } = useThemeContext();
   const getDateExpenseModified = getExpenseMonthWithData(expenseReport);
@@ -80,7 +81,7 @@ const DelegateExpenseTrendItem: React.FC<Props> = ({ link, expenseReport, now = 
           <Date isLight={isLight}>{expenseReport.reportMonth?.toFormat('LLLL yyyy')}</Date>
         </ReportingMonth>
         <TotalActualsTable>
-          <LabelDescription isLight={isLight}>Total Actuals</LabelDescription>
+          <LabelDescription isLight={isLight}>{selectedMetric}</LabelDescription>
           <TotalNumber isLight={isLight}>{`${
             expenseReport.totalActuals.toLocaleString('es-US') || '0'
           } DAI`}</TotalNumber>
@@ -114,7 +115,7 @@ const DelegateExpenseTrendItem: React.FC<Props> = ({ link, expenseReport, now = 
         </ContainerReportingMobile>
 
         <TotalContainerMobile>
-          <Total isLight={isLight}>Total Actuals</Total>
+          <Total isLight={isLight}>{selectedMetric}</Total>
           <TotalNumber isLight={isLight}>
             {`${expenseReport.totalActuals.toLocaleString('es-US') || '0'} DAI`}
           </TotalNumber>

--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/HeaderDelegateExpense.stories.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/HeaderDelegateExpense.stories.tsx
@@ -11,10 +11,10 @@ export default meta;
 
 const variantsArgs = [
   {
-    columns: getHeadersExpenseReport(enumForStories, false),
+    columns: getHeadersExpenseReport(enumForStories, 'Actuals', false),
   },
   {
-    columns: getHeadersExpenseReport(enumForStories, true),
+    columns: getHeadersExpenseReport(enumForStories, 'Actuals', true),
   },
 ];
 

--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/DelegateExpenseTrendFinances.stories.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/DelegateExpenseTrendFinances.stories.tsx
@@ -14,7 +14,7 @@ export default meta;
 
 const args = [
   {
-    columns: getHeadersExpenseReport(enumForStories, false),
+    columns: getHeadersExpenseReport(enumForStories, 'Actuals', false),
     expenseReport: mockDataApiTeam.slice(0, 9),
     sortClick: () => null,
     handleLinkToPage: () => null,
@@ -22,7 +22,7 @@ const args = [
     showSome: true,
   },
   {
-    columns: getHeadersExpenseReport(enumForStories, true),
+    columns: getHeadersExpenseReport(enumForStories, 'Actuals', true),
     expenseReport: mockDataApiTeam.slice(0, 9),
     sortClick: () => null,
     handleLinkToPage: () => null,

--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/DelegateExpenseTrendFinances.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/DelegateExpenseTrendFinances.tsx
@@ -43,6 +43,7 @@ const DelegateExpenseTrendFinances: React.FC<Props> = ({
           <DelegateExpenseTrendItem
             key={index}
             expenseReport={expense}
+            selectedMetric={filterProps.selectedMetric}
             link={getLinkLastExpenseReport(expense.shortCode, expenseReport)}
           />
         ))}

--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/ExpenseReportsFilters.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/ExpenseReportsFilters.tsx
@@ -4,8 +4,10 @@ import ResetButton from '@ses/components/ResetButton/ResetButton';
 import SingleItemSelect from '@ses/components/SingleItemSelect/SingleItemSelect';
 import { Close } from '@ses/components/svg/close';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { BudgetStatus } from '@ses/core/models/interfaces/types';
+import { getExpenseReportStatusColor } from '@ses/core/utils/colors';
 import lightTheme from '@ses/styles/theme/light';
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { MultiSelectItem } from '@ses/components/CustomMultiSelect/CustomMultiSelect';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
@@ -16,6 +18,7 @@ export interface ExpenseReportsFiltersProps {
   onStatusSelectChange: (value: string[]) => void;
   statusesItems: MultiSelectItem[];
   handleResetFilter: () => void;
+  allItemsCount: number;
 }
 
 const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
@@ -25,10 +28,11 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
   onStatusSelectChange,
   statusesItems,
   handleResetFilter,
+  allItemsCount,
 }) => {
   const { isLight } = useThemeContext();
   const isDisabled = selectedMetric === 'Actual' && selectedStatuses.length === 0;
-  const colorButton = isLight ? (isDisabled ? '#ECEFF9' : '#231536') : isDisabled ? 'red' : '#48495F';
+  const colorButton = isLight ? (isDisabled ? '#ECEFF9' : '#231536') : isDisabled ? '#48495F' : '#D4D9E1';
 
   return (
     <FilterContainer>
@@ -47,7 +51,7 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
           useSelectedAsLabel
           selected={selectedMetric}
           onChange={onMetricChange}
-          items={['Budget', 'Actual', 'Forecast', 'Net Expenses On-chain', 'Net Expenses Off-chain']}
+          items={['Budget', 'Actuals', 'Forecast', 'Net Expenses On-chain', 'Net Expenses Off-chain']}
           PopperProps={{
             placement: 'bottom-end',
           }}
@@ -64,13 +68,12 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
           popupContainerWidth={256}
           listItemWidth={224}
           customAll={{
-            content: 'All',
+            content: <FilterChip text="All" />,
             id: 'all',
             params: { isAll: true },
-            count: 0,
+            count: allItemsCount,
           }}
           popupContainerHeight={220}
-          //   customItemRender={(props: SelectItemProps) => <ExpenseReportStatus status={BudgetStatus.Draft} />}
         />
       </SelectContainer>
 
@@ -83,11 +86,43 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
 
 export default ExpenseReportsFilters;
 
+export const FilterChip: React.FC<{ status?: BudgetStatus; text?: string }> = ({
+  status = BudgetStatus.Draft,
+  text,
+}) => {
+  const { isLight } = useThemeContext();
+  const variantColor = useMemo(() => getExpenseReportStatusColor(status), [status]);
+
+  return (
+    <ExpenseReportStatusStyled isLight={isLight} variantColorSet={variantColor}>
+      {text ?? status}
+    </ExpenseReportStatusStyled>
+  );
+};
+
+const ExpenseReportStatusStyled = styled.div<{ isLight: boolean; variantColorSet: { [key: string]: string } }>(
+  ({ isLight, variantColorSet }) => ({
+    fontFamily: 'Inter, sans-serif',
+    display: 'flex',
+    alignItems: 'center',
+    fontWeight: 400,
+    fontSize: '11px',
+    borderRadius: '12px',
+    padding: '4px 8px',
+    height: '22px',
+    width: 'fit-content',
+    lineHeight: '13px',
+    border: `1px solid ${isLight ? variantColorSet.color : variantColorSet.darkColor}`,
+    background: isLight ? variantColorSet.background : variantColorSet.darkBackground,
+    color: isLight ? variantColorSet.color : variantColorSet.darkColor,
+  })
+);
+
 const FilterContainer = styled.div({
   display: 'flex',
   justifyContent: 'flex-end',
   gap: 16,
-  zIndex: 1,
+  zIndex: 5,
 });
 
 const Reset = styled.div({
@@ -119,7 +154,9 @@ const ResponsiveButton = styled.div<WithIsLight & { isDisabled: boolean }>(({ is
   justifySelf: 'flex-end',
   height: '34px',
   width: '34px',
-  border: isLight ? `1px solid ${isDisabled ? '#ECEFF9' : '#D4D9E1'}` : `1px solid ${isDisabled ? 'red' : '#10191F'}`,
+  border: isLight
+    ? `1px solid ${isDisabled ? '#ECEFF9' : '#D4D9E1'}`
+    : `1px solid ${isDisabled ? '#10191F' : '#D4D9E1'}`,
   borderRadius: '22px',
   alignItems: 'center',
   justifyContent: 'center',

--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/useDelegateExpenseTrendFinances.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/useDelegateExpenseTrendFinances.tsx
@@ -5,18 +5,18 @@ import {
   getStatus,
   mockDataApiTeam,
 } from '@ses/containers/Finances/utils/utils';
-import ExpenseReportStatus from '@ses/containers/TransparencyReport/components/ExpenseReportStatus/ExpenseReportStatus';
 import { SortEnum } from '@ses/core/enums/sortEnum';
 import { BudgetStatus } from '@ses/core/models/interfaces/types';
 import lightTheme from '@ses/styles/theme/light';
 import orderBy from 'lodash/orderBy';
 import { DateTime } from 'luxon';
 import { useMemo, useState } from 'react';
+import { FilterChip } from './ExpenseReportsFilters';
 import type { MomentDataItem } from '@ses/containers/Finances/utils/types';
 
 export const useDelegateExpenseTrendFinances = () => {
   // metric filter:
-  const [selectedMetric, setSelectedMetric] = useState<string>('Actual');
+  const [selectedMetric, setSelectedMetric] = useState<string>('Actuals');
   const onMetricChange = (value: string) => setSelectedMetric(value);
 
   // status filter
@@ -24,7 +24,7 @@ export const useDelegateExpenseTrendFinances = () => {
   const onStatusSelectChange = (statuses: string[]) => setSelectedStatuses(statuses);
 
   const handleResetFilter = () => {
-    setSelectedMetric('Actual');
+    setSelectedMetric('Actuals');
     setSelectedStatuses([]);
   };
 
@@ -93,7 +93,7 @@ export const useDelegateExpenseTrendFinances = () => {
 
   const isSmallDesk = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
   // headers used for the UI table
-  const headersExpenseReport = getHeadersExpenseReport(headersSort, isSmallDesk);
+  const headersExpenseReport = getHeadersExpenseReport(headersSort, selectedMetric, isSmallDesk);
 
   // actual items fetched from the API
   const expenseReportItems: MomentDataItem[] = useMemo(() => mockDataApiTeam, []);
@@ -119,25 +119,25 @@ export const useDelegateExpenseTrendFinances = () => {
     () => [
       {
         id: BudgetStatus.Draft,
-        content: <ExpenseReportStatus status={BudgetStatus.Draft} />,
+        content: <FilterChip status={BudgetStatus.Draft} />,
         count: reportExpenseItems.filter((element) => getStatus(element.budgetStatements) === BudgetStatus.Draft)
           .length,
       },
       {
         id: BudgetStatus.Review,
-        content: <ExpenseReportStatus status={BudgetStatus.Review} />,
+        content: <FilterChip status={BudgetStatus.Review} />,
         count: reportExpenseItems.filter((element) => getStatus(element.budgetStatements) === BudgetStatus.Review)
           .length,
       },
       {
         id: BudgetStatus.Final,
-        content: <ExpenseReportStatus status={BudgetStatus.Final} />,
+        content: <FilterChip status={BudgetStatus.Final} />,
         count: reportExpenseItems.filter((element) => getStatus(element.budgetStatements) === BudgetStatus.Final)
           .length,
       },
       {
         id: BudgetStatus.Escalated,
-        content: <ExpenseReportStatus status={BudgetStatus.Escalated} />,
+        content: <FilterChip status={BudgetStatus.Escalated} />,
         count: reportExpenseItems.filter((element) => getStatus(element.budgetStatements) === BudgetStatus.Escalated)
           .length,
       },
@@ -155,6 +155,7 @@ export const useDelegateExpenseTrendFinances = () => {
     headersExpenseReport,
     onSortClick,
     reportExpenseItems,
+    expenseItemsCount: expenseReportItems.length,
     showAllItems,
     handleLoadMore,
   };

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -333,6 +333,7 @@ export const getExpenseMonthWithData = (expense: MomentDataItem) => {
 export const isCoreUnit = (item: MomentDataItem) => item?.type === ResourceType.CoreUnit;
 export const getHeadersExpenseReport = (
   headersSort: SortEnum[],
+  selectedMetric: string,
   isSmallDesk: boolean
 ): DelegateExpenseTableHeader[] => [
   {
@@ -363,7 +364,7 @@ export const getHeadersExpenseReport = (
     sort: headersSort[1],
   },
   {
-    header: 'Total Actuals',
+    header: selectedMetric,
     sort: headersSort[2],
     styles: {
       width: 130,


### PR DESCRIPTION
## Ticket
https://trello.com/c/zera64wM/312-mer-1-monthly-expense-reports

## Description
Fix issues in dark mode in the expense report/filter section

## What solved
- [X] Status filter. Dark mode. **Expected Output:** The "All" option should be displayed with the style defined in the design.  **Current Output:** The option is barely displayed with a black font color.
- [X]  Reset filter icon. Dark mode. **Expected Output:** The option should be visible white white color or default state. **Current Output:** The option is displayed in red color.

