### PR TITLE
fix: recognized delegate number source

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,7 @@
         "Wireframes"
     ],
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "editor.formatOnSave": true, // Tell VSCode to format files on save
     "editor.defaultFormatter": "esbenp.prettier-vscode" // Tell VSCode to use Prettier as default file formatter

--- a/src/core/businessLogic/recognizedDelegate.ts
+++ b/src/core/businessLogic/recognizedDelegate.ts
@@ -1,10 +1,5 @@
-import forEach from 'lodash/forEach';
-import groupBy from 'lodash/groupBy';
-import { DateTime } from 'luxon';
 import { LinkTypeEnum } from '../enums/linkTypeEnum';
-import { getNameDelegates } from '../utils/string';
 import type { DelegateSocialDto, RecognizedDelegatesDto } from '../models/dto/delegatesDTO';
-import type { ExpenseDto } from '../models/dto/expensesDTO';
 import type { LinkModel } from '@ses/components/SocialMediaComponent/SocialMediaComponent';
 
 export const getLinksFromRecognizedDelegates = (del: RecognizedDelegatesDto): LinkModel[] => {
@@ -41,75 +36,4 @@ export const getLinksFromRecognizedDelegates = (del: RecognizedDelegatesDto): Li
   }
 
   return result;
-};
-
-export const delegateWithActuals = (delegates: RecognizedDelegatesDto[], delegatesNumbers: ExpenseDto[]) => {
-  const delegatesWithActuals = delegates.map((delegate) => {
-    const expense = delegatesNumbers.find((number) => getNameDelegates(number.budget) === delegate.name);
-    return expense
-      ? {
-          ...delegate,
-          actuals: expense.actuals || 0,
-        }
-      : delegate;
-  });
-  return delegatesWithActuals;
-};
-
-export const sumActualsByPeriod = (expenses: ExpenseDto[]): number[] => {
-  const mapTotalDelegate: Record<string, number> = {};
-  forEach(expenses, (expense) => {
-    const { period, actuals } = expense;
-    if (period in mapTotalDelegate) {
-      mapTotalDelegate[period] += actuals;
-    } else {
-      mapTotalDelegate[period] = actuals;
-    }
-  });
-  const totalMonthlyDelegates = Object.entries(mapTotalDelegate).map(([, value]) => value);
-  return totalMonthlyDelegates;
-};
-
-const generateArrayDates = (startDate: DateTime, endDate: DateTime) => {
-  const monthsArray = [];
-
-  let currentDate = startDate;
-  while (currentDate <= endDate) {
-    const formattedDate = currentDate.toFormat('yyyy-MM');
-    monthsArray.push(formattedDate);
-    currentDate = currentDate.plus({ months: 1 });
-  }
-  return monthsArray;
-};
-
-const generateActualsArray = (expenses: ExpenseDto[]): number[] => {
-  const allPeriodWithDataDelegate = expenses.map((delegate) => delegate.period);
-  const resultActualsPerDelegateForDate: number[] = [];
-  const startDate = DateTime.fromISO('2021-11-01');
-  const endDate = DateTime.fromISO('2023-03-01');
-  const monthlyArray = generateArrayDates(startDate, endDate);
-  monthlyArray.forEach((monthlyArray) => {
-    if (allPeriodWithDataDelegate.includes(monthlyArray)) {
-      resultActualsPerDelegateForDate.push(expenses.find((item) => item.period === monthlyArray)?.actuals || 0);
-    } else {
-      resultActualsPerDelegateForDate.push(0);
-    }
-  });
-  return resultActualsPerDelegateForDate;
-};
-
-export const filteredDelegatesChart = (expenses: ExpenseDto[], activeElements: string[]) => {
-  const filteredDelegates = expenses.filter((delegate: ExpenseDto) =>
-    activeElements.includes(getNameDelegates(delegate.budget))
-  );
-
-  const resultGroupEachDelegate = groupBy(filteredDelegates, 'budget');
-  let sumArrayDelegate: number[] = [];
-  for (const key in resultGroupEachDelegate) {
-    sumArrayDelegate = sumArrayDelegate.length
-      ? sumArrayDelegate.map((value, index) => value + generateActualsArray(resultGroupEachDelegate[key])[index])
-      : generateActualsArray(resultGroupEachDelegate[key]);
-  }
-
-  return sumArrayDelegate;
 };

--- a/src/core/models/dto/delegatesDTO.ts
+++ b/src/core/models/dto/delegatesDTO.ts
@@ -1,4 +1,3 @@
-import type { ExpenseDto } from './expensesDTO';
 import type { ChangeTrackingEvent } from '../interfaces/activity';
 import type { BudgetStatement } from '../interfaces/budgetStatement';
 import type { ResourceType } from '../interfaces/types';
@@ -27,9 +26,4 @@ export interface RecognizedDelegatesDto {
   latestVotingContract: string;
   socials: DelegateSocialDto;
   actuals: number;
-}
-
-export interface TotalDelegateDto {
-  delegatesExpenses: ExpenseDto[];
-  totalExpenses: ExpenseDto[];
 }

--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -123,6 +123,7 @@ const dictionary = [
   'deco',
   'Feedblack',
   'Coldirion',
+  'Coldiron',
   'Gnosis',
   'Blockies',
   'Blockie',

--- a/src/core/utils/string.ts
+++ b/src/core/utils/string.ts
@@ -175,14 +175,6 @@ export const formatAddressForOutputDelegateWallet = (address: string | undefined
   return `${address.slice(0, 7)}...${address.slice(address.length - 4, address.length)}`;
 };
 
-export const getNameDelegates = (format: string) => {
-  if (!format) return 'No name';
-  const words = format.split('/');
-  const lastWord = words[words.length - 1];
-  const fullName = lastWord.replace('\\', '');
-  return fullName;
-};
-
 export const getResourceLabel = (resourceType?: ResourceType): string => {
   switch (resourceType) {
     case ResourceType.AlignedDelegates:

--- a/src/stories/containers/RecognizedDelegates/RecognizedDelegates.stories.tsx
+++ b/src/stories/containers/RecognizedDelegates/RecognizedDelegates.stories.tsx
@@ -1,10 +1,7 @@
 import { RecognizedDelegatesBuilder } from '@ses/core/businessLogic/builders/recognizedDelegatesBuilder';
-import { TotalExpenseReportsBuilder } from '@ses/core/businessLogic/builders/totalExpenseReportsBuilder';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import AppLayout from '../AppLayout/AppLayout';
 import RecognizedDelegatesContainer from './RecognizedDelegatesContainer';
-import type { TotalDelegateDto } from '@ses/core/models/dto/delegatesDTO';
-import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
 import type { Meta } from '@storybook/react';
 import type { FigmaParams } from 'sb-figma-comparator';
 
@@ -82,188 +79,21 @@ const variantsArgs = [
         })
         .build(),
     ],
-    delegatesNumbers: [
-      new TotalExpenseReportsBuilder()
-        .withPrediction(1821236)
-        .withActuals(20144)
-        .withBudget('makerdao/delegates/Flip Flop Flap Delegate LLC')
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 4)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(1236845)
-        .withActuals(192)
-        .withBudget('makerdao/delegates/Feedblack Loops LLC')
-        .withBudgetCap(6523658)
-        .withQuarterPeriod(2022, 1)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(3690)
-        .withActuals(14292)
-        .withBudget('makerdao/delegates/GFX Labs')
-        .withBudgetCap(9562451)
-        .withQuarterPeriod(2022, 2)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4232845)
-        .withActuals(13292)
-        .withBudget('makerdao/delegates/Coldirion.eth')
-        .withBudgetCap(6392563)
-        .withQuarterPeriod(2022, 3)
-        .build(),
-    ] as ExpenseDto[],
-    totalQuarterlyExpenses: {
-      delegatesExpenses: [
-        new TotalExpenseReportsBuilder()
-          .withPrediction(5821236)
-          .withActuals(2082362)
-          .withBudgetCap(8392323)
-          .withQuarterPeriod(2022, 4)
-          .build(),
-        new TotalExpenseReportsBuilder()
-          .withPrediction(4231563)
-          .withActuals(2082362)
-          .withBudgetCap(8392323)
-          .withQuarterPeriod(2023, 1)
-          .build(),
-        new TotalExpenseReportsBuilder()
-          .withPrediction(4231563)
-          .withActuals(2082362)
-          .withBudgetCap(8392323)
-          .withQuarterPeriod(2023, 1)
-          .build(),
-        new TotalExpenseReportsBuilder()
-          .withPrediction(4231563)
-          .withActuals(12394)
-          .withBudgetCap(8392323)
-          .withQuarterPeriod(2023, 1)
-          .build(),
-        new TotalExpenseReportsBuilder()
-          .withPrediction(4231563)
-          .withActuals(5082362)
-          .withBudgetCap(8392323)
-          .withQuarterPeriod(2023, 1)
-          .build(),
-      ] as ExpenseDto[],
-      totalExpenses: [
-        new TotalExpenseReportsBuilder()
-          .withPrediction(5821236)
-          .withActuals(5082362)
-          .withBudgetCap(8392323)
-          .withQuarterPeriod(2022, 4)
-          .build(),
-        new TotalExpenseReportsBuilder()
-          .withPrediction(4231563)
-          .withActuals(5082362)
-          .withBudgetCap(8392323)
-          .withQuarterPeriod(2023, 1)
-          .build(),
-      ] as ExpenseDto[],
-    } as TotalDelegateDto,
-    totalMonthlyExpenses: [
-      new TotalExpenseReportsBuilder()
-        .withPrediction(5821236)
-        .withActuals(22362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2021, 11)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(245362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2021, 12)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(345452)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 1)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(432345)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 2)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(332362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 3)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(332362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 4)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(332362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 5)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(482362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 6)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(482362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 7)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(482362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 8)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(562362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 9)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(562362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 10)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(562362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 11)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(562362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2022, 12)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(562362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2023, 1)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(562362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2023, 2)
-        .build(),
-      new TotalExpenseReportsBuilder()
-        .withPrediction(4231563)
-        .withActuals(562362)
-        .withBudgetCap(8392323)
-        .withQuarterPeriod(2023, 3)
-        .build(),
-    ] as ExpenseDto[],
+    totalMakerDAOExpenses: 1493489,
+    monthlyAnalytics: {
+      series: [
+        {
+          rows: [],
+        },
+      ],
+    },
+    totalAnalytics: {
+      series: [
+        {
+          rows: [],
+        },
+      ],
+    },
   },
 ];
 

--- a/src/stories/containers/RecognizedDelegates/RecognizedDelegates.stories.tsx
+++ b/src/stories/containers/RecognizedDelegates/RecognizedDelegates.stories.tsx
@@ -28,7 +28,7 @@ const variantsArgs = [
     delegates: [
       new RecognizedDelegatesBuilder()
         .withName('Feedblack Loops LLC')
-        .withImage('https://live.staticflickr.com/65535/52832796763_a0e2339b3b_m.jpg')
+        .withImage('https://forum.makerdao.com/user_avatar/forum.makerdao.com/twblack88/90/16125_2.png')
         .withLatestVotingContract('0xF1792852BF860b4ef84a2869DF1550BC80eC0aB7')
         .withNumberDai(23325)
         .withSocials({
@@ -40,8 +40,8 @@ const variantsArgs = [
         })
         .build(),
       new RecognizedDelegatesBuilder()
-        .withName('Flip Flop Flap Delegate LLC')
-        .withImage('https://live.staticflickr.com/65535/52808669587_127cc79684_m.jpg')
+        .withName('Flip Flap Flop Delegate LLC')
+        .withImage('https://forum.makerdao.com/user_avatar/forum.makerdao.com/flipflopflapdelegate/90/24350_2.png')
         .withLatestVotingContract('0xF1792852BF860b4ef84a2869DF1550BC80eC0aB7')
         .withNumberDai(292325)
         .withSocials({
@@ -54,7 +54,7 @@ const variantsArgs = [
         .build(),
       new RecognizedDelegatesBuilder()
         .withName('GFX Labs')
-        .withImage('https://live.staticflickr.com/65535/52832350651_0506c1ff2a_m.jpg')
+        .withImage('https://forum.makerdao.com/user_avatar/forum.makerdao.com/gfxlabs/90/13005_2.png')
         .withLatestVotingContract('0xF1792852BF860b4ef84a2869DF1550BC80eC0aB7')
         .withNumberDai(282325)
         .withSocials({
@@ -66,8 +66,8 @@ const variantsArgs = [
         })
         .build(),
       new RecognizedDelegatesBuilder()
-        .withName('Coldirion.eth')
-        .withImage('https://live.staticflickr.com/65535/52832350671_ac70b94b13_m.jpg')
+        .withName('Coldiron.eth')
+        .withImage('https://forum.makerdao.com/user_avatar/forum.makerdao.com/coldiron.eth/240/25270_2.png')
         .withLatestVotingContract('0xF1792852BF860b4ef84a2869DF1550BC80eC0aB7')
         .withNumberDai(272325)
         .withSocials({
@@ -79,7 +79,7 @@ const variantsArgs = [
         })
         .build(),
     ],
-    totalMakerDAOExpenses: 1493489,
+    totalMakerDAOExpenses: 33000000,
     monthlyAnalytics: {
       series: [
         {
@@ -90,7 +90,71 @@ const variantsArgs = [
     totalAnalytics: {
       series: [
         {
-          rows: [],
+          period: 'total',
+          start: '2021-11-01T00:00:00.000Z',
+          end: '2023-04-01T00:00:00.000Z',
+          rows: [
+            {
+              dimensions: [
+                {
+                  path: 'atlas/legacy/recognized-delegates/*/*',
+                  name: 'budget',
+                },
+                {
+                  path: 'atlas/Feedblack Loops LLC',
+                  name: 'project',
+                },
+              ],
+              metric: 'Actuals',
+              value: 193635,
+              sum: 193635,
+            },
+            {
+              dimensions: [
+                {
+                  path: 'atlas/legacy/recognized-delegates/*/*',
+                  name: 'budget',
+                },
+                {
+                  path: 'atlas/Flip Flap Flop Delegate LLC',
+                  name: 'project',
+                },
+              ],
+              metric: 'Actuals',
+              value: 201228,
+              sum: 201228,
+            },
+            {
+              dimensions: [
+                {
+                  path: 'atlas/legacy/recognized-delegates/*/*',
+                  name: 'budget',
+                },
+                {
+                  path: 'atlas/GFX Labs',
+                  name: 'project',
+                },
+              ],
+              metric: 'Actuals',
+              value: 102878,
+              sum: 102878,
+            },
+            {
+              dimensions: [
+                {
+                  path: 'atlas/legacy/recognized-delegates/*/*',
+                  name: 'budget',
+                },
+                {
+                  path: 'atlas/Coldiron.eth',
+                  name: 'project',
+                },
+              ],
+              metric: 'Actuals',
+              value: 34452,
+              sum: 34452,
+            },
+          ],
         },
       ],
     },

--- a/src/stories/containers/RecognizedDelegates/RecognizedDelegatesContainer.tsx
+++ b/src/stories/containers/RecognizedDelegates/RecognizedDelegatesContainer.tsx
@@ -15,28 +15,27 @@ import DelegateExpenseTrend from './DelegateExpenseTrend';
 
 import TotalAndKeyStatsComponent from './TotalAndKeyStatsComponent/TotalAndkeyStatusComponent';
 import { useRecognizedDelegates } from './useRecognizedDelegates';
-import type { RecognizedDelegatesDto, TotalDelegateDto } from '@ses/core/models/dto/delegatesDTO';
-import type { ExpenseDto } from '@ses/core/models/dto/expensesDTO';
+import type { RecognizedDelegatesDto } from '@ses/core/models/dto/delegatesDTO';
+import type { Analytic } from '@ses/core/models/interfaces/analytic';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   delegates: RecognizedDelegatesDto[];
-  delegatesNumbers: ExpenseDto[];
-  totalQuarterlyExpenses: TotalDelegateDto;
-  totalMonthlyExpenses: ExpenseDto[];
+  totalMakerDAOExpenses: number;
+  monthlyAnalytics: Analytic;
+  totalAnalytics: Analytic;
 }
 
 const RecognizedDelegatesContainer: React.FC<Props> = ({
   delegates,
-  delegatesNumbers,
-  totalQuarterlyExpenses,
-  totalMonthlyExpenses,
+  totalMakerDAOExpenses,
+  monthlyAnalytics,
+  totalAnalytics,
 }) => {
   const { isLight } = useThemeContext();
   const {
     totalDAI,
     mediaAnnual,
-
     shadowTotal,
     recognizedDelegates,
     startDate,
@@ -50,7 +49,7 @@ const RecognizedDelegatesContainer: React.FC<Props> = ({
     otherExpenses,
     maxValuesRelative,
     resultFilteredChart,
-  } = useRecognizedDelegates(delegates, delegatesNumbers, totalQuarterlyExpenses, totalMonthlyExpenses);
+  } = useRecognizedDelegates(delegates, totalMakerDAOExpenses, monthlyAnalytics, totalAnalytics);
 
   return (
     <ExtendedPageContainer isLight={isLight}>


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Change the queries used to fetch the numbers of the delegates page for the analytics query

## What solved
- [X]  Delegates view. Barchart section. **Expected Output:**  The graphic should display data for the recognized delegates.
- [X] Delegates view. Delegate Expense Breakdown section. **Expected Output:** Data coming from the API should be displayed properly. **Current Output: ** The data is displayed with 0 values.
