### PR TITLE
[QC-r2] Fix snapshot expense comparison header

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -94,8 +94,8 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
   );
 
   const expensesComparisonRows = useMemo(
-    () => buildExpensesComparisonRows(actualsComparison, selectedToken, snapshot.period),
-    [actualsComparison, selectedToken, snapshot.period]
+    () => buildExpensesComparisonRows(actualsComparison, selectedToken, snapshot.period, hasOffChainData),
+    [actualsComparison, hasOffChainData, selectedToken, snapshot.period]
   );
 
   return {

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
@@ -179,12 +179,9 @@ export const getTotals = (values: ActualsComparison[]): ActualsComparison =>
 export const buildExpensesComparisonRows = (
   values: ActualsComparison[],
   currency: Token,
-  currentPeriod: string
+  currentPeriod: string,
+  hasOffChainData: boolean
 ): RowProps[] => {
-  const hasOffChainData = values.some(
-    (value) => value.netExpenses.offChainIncluded.amount || value.netExpenses.offChainIncluded.difference
-  );
-
   const rows: RowProps[] = [];
   if (hasOffChainData) {
     values.forEach((comparison) => {


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Fix the empty headers on the snapshot expenses comparison when there are not off-chain data

## What solved
- [X] Expense Reports view (CU and Ecosystem Actors). Account Snapshot tab. Reported Expenses Comparison section. **Expected Output:** When there are no OnChain values, the last column shouldn't be displayed.

