### PR TITLE
[EML-1] Fix line chart axis status

### DIFF
--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -162,11 +162,8 @@ const FinancesContainer: React.FC<Props> = ({ budgets, yearsRange, initialYear }
           <MakerDAOExpenseMetricsFinances
             handleGranularityChange={makerDAOExpensesMetrics.handleGranularityChange}
             selectedGranularity={makerDAOExpensesMetrics.selectedGranularity}
-            newActuals={makerDAOExpensesMetrics.newActuals}
-            newBudget={makerDAOExpensesMetrics.newBudget}
-            newForecast={makerDAOExpensesMetrics.newForecast}
-            newNetExpensesOffChain={makerDAOExpensesMetrics.newNetExpensesOffChain}
-            newNetExpensesOnChain={makerDAOExpensesMetrics.newNetExpensesOnChain}
+            series={makerDAOExpensesMetrics.series}
+            handleToggleSeries={makerDAOExpensesMetrics.handleToggleSeries}
             isLoading={makerDAOExpensesMetrics.isLoading}
             year={year}
           />

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -9,10 +9,10 @@ import React, { useEffect, useState } from 'react';
 import { setBorderRadiusForSeries } from '../utils';
 import type { BarChartSeries, BreakdownChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { AnalyticGranularity, BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
-
 import type { Budget } from '@ses/core/models/interfaces/budget';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { EChartsOption } from 'echarts-for-react';
+
 interface BreakdownChartProps {
   year: string;
   budgets: Budget[];

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics.stories.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics.stories.tsx
@@ -1,4 +1,4 @@
-import { atlasBudget, legacyBudget, scopeBudget } from '@ses/containers/Finances/utils/utils';
+import { buildExpenseMetricsLineChartSeries } from '@ses/containers/Finances/utils/utils';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import MakerDAOExpenseMetricsFinances from './MakerDAOExpenseMetrics';
 import type { Meta } from '@storybook/react';
@@ -16,21 +16,31 @@ const meta: Meta<typeof MakerDAOExpenseMetricsFinances> = {
 };
 export default meta;
 
+const chartData = {
+  budget: [123434, 123434, 123434, 123434, 100000, 250000, 900000, 1250000, 0, 1400000, 1400000, 1500000],
+  forecast: [123434, 123434, 123434, 123434, 100000, 250000, 900000, 1250000, 0, 1400000, 1400000, 1500000],
+  actuals: [123434, 123434, 123434, 123434, 100000, 250000, 900000, 1250000, 0, 1400000, 1400000, 1500000],
+  onChain: [123434, 123434, 123434, 123434, 100000, 250000, 900000, 1250000, 0, 1400000, 1400000, 1500000],
+  offChain: [123434, 123434, 123434, 123434, 100000, 250000, 900000, 1250000, 0, 1400000, 1400000, 1500000],
+};
 const args = [
   {
     year: 2023,
-    newActuals: atlasBudget,
-    newBudget: scopeBudget,
-    newForecast: legacyBudget,
-    newNetExpensesOffChain: atlasBudget,
-    newNetExpensesOnChain: scopeBudget,
+    series: buildExpenseMetricsLineChartSeries(chartData, [], true),
+    selectedGranularity: 'monthly',
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handleGranularityChange: (value: string) => null,
+  },
+  {
+    year: 2023,
+    series: buildExpenseMetricsLineChartSeries(chartData, [], false),
     selectedGranularity: 'monthly',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     handleGranularityChange: (value: string) => null,
   },
 ];
 
-const [[LightMode, DarkMode]] = createThemeModeVariants(MakerDAOExpenseMetricsFinances, args);
+const [[LightMode], [, DarkMode]] = createThemeModeVariants(MakerDAOExpenseMetricsFinances, args, false);
 export { LightMode, DarkMode };
 
 LightMode.parameters = {

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -6,27 +6,22 @@ import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import ReactECharts from 'echarts-for-react';
 import React, { useRef } from 'react';
+import type { LineChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { EChartsOption } from 'echarts-for-react';
 interface BreakdownChartProps {
   year: string;
   selectedGranularity: AnalyticGranularity;
-  newActuals: { value: number }[];
-  newBudget: { value: number }[];
-  newForecast: { value: number }[];
-  newNetExpensesOffChain: { value: number }[];
-  newNetExpensesOnChain: { value: number }[];
+  series: LineChartSeriesData[];
+  handleToggleSeries: (series: string) => void;
 }
 
 const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
   year,
   selectedGranularity,
-  newActuals,
-  newBudget,
-  newForecast,
-  newNetExpensesOnChain,
-  newNetExpensesOffChain,
+  series,
+  handleToggleSeries,
 }) => {
   const { isLight } = useThemeContext();
   const chartRef = useRef<EChartsOption | null>(null);
@@ -128,63 +123,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
         },
       },
     },
-    series: [
-      {
-        name: 'Budget',
-        data: newBudget,
-        type: 'line',
-        stack: 'Total',
-        showBackground: false,
-        itemStyle: {
-          color: isLight ? '#F99374' : '#F77249',
-        },
-        isVisible: true,
-      },
-      {
-        name: 'Forecast',
-        data: newForecast,
-        type: 'line',
-        stack: 'Total',
-        showBackground: false,
-        itemStyle: {
-          color: isLight ? '#447AFB' : '#447AFB',
-        },
-        isVisible: true,
-      },
-      {
-        name: 'Actuals',
-        data: newActuals,
-        type: 'line',
-        stack: 'Total',
-        showBackground: false,
-        itemStyle: {
-          color: isLight ? '#2DC1B1' : '#1AAB9B',
-        },
-        isVisible: true,
-      },
-      {
-        name: 'Net Expenses On-chain',
-        data: newNetExpensesOnChain,
-        type: 'line',
-        stack: 'Total',
-        showBackground: false,
-        itemStyle: {
-          color: isLight ? '#FBCC5F' : '#FDC134',
-        },
-        isVisible: true,
-      },
-      {
-        name: 'Net Expenses Off-chain',
-        data: newNetExpensesOffChain,
-        type: 'line',
-        stack: 'Total',
-        showBackground: false,
-        itemStyle: {
-          color: isLight ? '#7C6B95' : '#6C40AA',
-        },
-        isVisible: true,
-      },
-    ],
+    series,
   };
 
   const onLegendItemHover = (legendName: string) => {
@@ -201,14 +140,6 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
       type: 'downplay',
       seriesName: legendName,
     });
-  };
-
-  const onLegendItemClick = (legendName: string, data: { value: number }[]) => {
-    const chartInstance = chartRef.current.getEchartsInstance();
-    const seriesIndex: number = options.series.findIndex((s: { name: string }) => s.name === legendName);
-    options.series[seriesIndex].isVisible = !options.series[seriesIndex].isVisible;
-    options.series[seriesIndex].data = options.series[seriesIndex].isVisible ? data : [];
-    chartInstance.setOption(options);
   };
 
   return (
@@ -229,96 +160,26 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
           </YearXAxis>
         )}
         <LegendContainer>
-          <LegendItem
-            isLight={isLight}
-            onMouseEnter={() => onLegendItemHover('Budget')}
-            onMouseLeave={() => onLegendItemLeave('Budget')}
-            onClick={() => onLegendItemClick('Budget', newBudget)}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width={isMobile ? 13 : 16}
-              height={isMobile ? 13 : 16}
-              viewBox="0 0 13 13"
-              fill="none"
+          {series.map((seriesItem: LineChartSeriesData) => (
+            <LegendItem
+              isLight={isLight}
+              onMouseEnter={() => onLegendItemHover(seriesItem.name)}
+              onMouseLeave={() => onLegendItemLeave(seriesItem.name)}
+              onClick={() => handleToggleSeries(seriesItem.name)}
             >
-              <circle cx="6.5" cy="6.5" r="5.5" stroke={isLight ? '#F99374' : '#F77249'} />
-              <circle cx="6.5" cy="6.5" r="4" fill={isLight ? '#F99374' : '#F77249'} />
-            </svg>
-            Budget
-          </LegendItem>
-          <LegendItem
-            isLight={isLight}
-            onMouseEnter={() => onLegendItemHover('Forecast')}
-            onMouseLeave={() => onLegendItemLeave('Forecast')}
-            onClick={() => onLegendItemClick('Forecast', newForecast)}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width={isMobile ? 13 : 16}
-              height={isMobile ? 13 : 16}
-              viewBox="0 0 13 13"
-              fill="none"
-            >
-              <circle cx="6.5" cy="6.5" r="5.5" stroke={isLight ? '#447AFB' : '#447AFB'} />
-              <circle cx="6.5" cy="6.5" r="4" fill={isLight ? '#447AFB' : '#447AFB'} />
-            </svg>
-            Forecast
-          </LegendItem>
-          <LegendItem
-            isLight={isLight}
-            onMouseEnter={() => onLegendItemHover('Actuals')}
-            onMouseLeave={() => onLegendItemLeave('Actuals')}
-            onClick={() => onLegendItemClick('Actuals', newActuals)}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width={isMobile ? 13 : 16}
-              height={isMobile ? 13 : 16}
-              viewBox="0 0 13 13"
-              fill="none"
-            >
-              <circle cx="6.5" cy="6.5" r="5.5" stroke={isLight ? '#2DC1B1' : '#1AAB9B'} />
-              <circle cx="6.5" cy="6.5" r="4" fill={isLight ? '#2DC1B1' : '#1AAB9B'} />
-            </svg>
-            Actuals
-          </LegendItem>
-          <LegendItem
-            isLight={isLight}
-            onMouseEnter={() => onLegendItemHover('Net Expenses On-chain')}
-            onMouseLeave={() => onLegendItemLeave('Net Expenses On-chain')}
-            onClick={() => onLegendItemClick('Net Expenses On-chain', newNetExpensesOnChain)}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width={isMobile ? 13 : 16}
-              height={isMobile ? 13 : 16}
-              viewBox="0 0 13 13"
-              fill="none"
-            >
-              <circle cx="6.5" cy="6.5" r="5.5" stroke={isLight ? '#FBCC5F' : '#FDC134'} />
-              <circle cx="6.5" cy="6.5" r="4" fill={isLight ? '#FBCC5F' : '#FDC134'} />
-            </svg>
-            Net Expenses On-chain
-          </LegendItem>
-          <LegendItem
-            isLight={isLight}
-            onMouseEnter={() => onLegendItemHover('Net Expenses Off-chain')}
-            onMouseLeave={() => onLegendItemLeave('Net Expenses Off-chain')}
-            onClick={() => onLegendItemClick('Net Expenses Off-chain', newNetExpensesOffChain)}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width={isMobile ? 13 : 16}
-              height={isMobile ? 13 : 16}
-              viewBox="0 0 13 13"
-              fill="none"
-            >
-              <circle cx="6.5" cy="6.5" r="5.5" stroke={isLight ? '#7C6B95' : '#6C40AA'} />
-              <circle cx="6.5" cy="6.5" r="4" fill={isLight ? '#7C6B95' : '#6C40AA'} />
-            </svg>
-            {`${isMobile ? 'Net Expenses Off-chain' : 'Net Expenses Off-chain included'}`}
-          </LegendItem>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width={isMobile ? 13 : 16}
+                height={isMobile ? 13 : 16}
+                viewBox="0 0 13 13"
+                fill="none"
+              >
+                <circle cx="6.5" cy="6.5" r="5.5" stroke={seriesItem.itemStyle.color} />
+                <circle cx="6.5" cy="6.5" r="4" fill={seriesItem.itemStyle.color} />
+              </svg>
+              {seriesItem.name}
+            </LegendItem>
+          ))}
         </LegendContainer>
       </ChartContainer>
     </Wrapper>

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -177,7 +177,9 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
                 <circle cx="6.5" cy="6.5" r="5.5" stroke={seriesItem.itemStyle.color} />
                 <circle cx="6.5" cy="6.5" r="4" fill={seriesItem.itemStyle.color} />
               </svg>
-              {seriesItem.name}
+              {seriesItem.name === 'Net Expenses Off-chain'
+                ? `${isMobile ? 'Net Expenses Off-chain' : 'Net Expenses Off-chain included'}`
+                : seriesItem.name}
             </LegendItem>
           ))}
         </LegendContainer>

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOExpenseMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOExpenseMetrics.tsx
@@ -3,16 +3,14 @@ import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import MakerDAOChartMetrics from './MakerDAOChartMetrics/MakerDAOChartMetrics';
 import TitleFilterComponent from './TitleFilterComponent';
+import type { LineChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
 
 interface Props {
   handleGranularityChange: (value: AnalyticGranularity) => void;
   selectedGranularity: AnalyticGranularity;
-  newActuals: { value: number }[];
-  newBudget: { value: number }[];
-  newForecast: { value: number }[];
-  newNetExpensesOffChain: { value: number }[];
-  newNetExpensesOnChain: { value: number }[];
+  series: LineChartSeriesData[];
+  handleToggleSeries: (series: string) => void;
   year: string;
   isLoading: boolean;
 }
@@ -20,11 +18,8 @@ interface Props {
 const MakerDAOExpenseMetricsFinances: React.FC<Props> = ({
   handleGranularityChange,
   selectedGranularity,
-  newActuals,
-  newBudget,
-  newForecast,
-  newNetExpensesOffChain,
-  newNetExpensesOnChain,
+  series,
+  handleToggleSeries,
   year,
   isLoading,
 }) => (
@@ -47,11 +42,8 @@ const MakerDAOExpenseMetricsFinances: React.FC<Props> = ({
         <MakerDAOChartMetrics
           year={year}
           selectedGranularity={selectedGranularity}
-          newActuals={newActuals}
-          newBudget={newBudget}
-          newForecast={newForecast}
-          newNetExpensesOffChain={newNetExpensesOffChain}
-          newNetExpensesOnChain={newNetExpensesOnChain}
+          series={series}
+          handleToggleSeries={handleToggleSeries}
         />
       )}
     </ContainerChart>

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
@@ -1,72 +1,124 @@
 import { fetchAnalytics } from '@ses/containers/Finances/api/queries';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { useMemo, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
+import type { LineChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { AnalyticGranularity, AnalyticMetric, AnalyticSeriesRow } from '@ses/core/models/interfaces/analytic';
 
 export const useMakerDAOExpenseMetrics = (year: string) => {
+  const { isLight } = useThemeContext();
   const [selectedGranularity, setSelectedGranularity] = useState<AnalyticGranularity>('monthly');
   const handleGranularityChange = (value: AnalyticGranularity) => {
     setSelectedGranularity(value);
   };
 
+  // fetch actual data from the API
   const { data: analytics, error } = useSWRImmutable(['analytics', year, selectedGranularity], async () =>
     fetchAnalytics(selectedGranularity, year, 'atlas', 2)
   );
 
+  const isLoading = !analytics && !error;
+
   const data = useMemo(() => {
     const data = {
-      budget: [] as { value: number }[],
-      forecast: [] as { value: number }[],
-      actuals: [] as { value: number }[],
-      onChain: [] as { value: number }[],
-      offChain: [] as { value: number }[],
+      budget: [] as number[],
+      forecast: [] as number[],
+      actuals: [] as number[],
+      onChain: [] as number[],
+      offChain: [] as number[],
     };
     if (!analytics || !analytics.series) {
       return data;
     }
 
+    // calculate the sum of all the rows for a metric
     const reduceMetric = (rows: AnalyticSeriesRow[], metric: AnalyticMetric) =>
       rows.filter((element) => element.metric === metric).reduce((acc, current) => acc + Math.abs(current.value), 0);
 
     analytics.series.forEach((item) => {
-      data.budget.push({
-        value: reduceMetric(item.rows, 'Budget'),
-      });
-      data.forecast.push({
-        value: reduceMetric(item.rows, 'Forecast'),
-      });
-      data.actuals.push({
-        value: reduceMetric(item.rows, 'Actuals'),
-      });
-      data.onChain.push({
-        value: reduceMetric(item.rows, 'PaymentsOnChain'),
-      });
-      data.offChain.push({
-        value: reduceMetric(item.rows, 'PaymentsOffChainIncluded'),
-      });
+      data.budget.push(reduceMetric(item.rows, 'Budget'));
+      data.forecast.push(reduceMetric(item.rows, 'Forecast'));
+      data.actuals.push(reduceMetric(item.rows, 'Actuals'));
+      data.onChain.push(reduceMetric(item.rows, 'PaymentsOnChain'));
+      data.offChain.push(reduceMetric(item.rows, 'PaymentsOffChainIncluded'));
     });
 
     return data;
   }, [analytics]);
 
-  console.log(data);
+  // series to be "hidden" in the line chart
+  const [inactiveSeries, setInactiveSeries] = useState<string[]>([]);
+  const handleToggleSeries = (toggleSeries: string) => {
+    setInactiveSeries(
+      inactiveSeries.includes(toggleSeries)
+        ? inactiveSeries.filter((series) => series !== toggleSeries)
+        : [...inactiveSeries, toggleSeries]
+    );
+  };
 
-  const newBudget = data?.budget;
-  const newForecast = data?.forecast;
-  const newActuals = data?.actuals;
-  const newNetExpensesOnChain = data?.onChain;
-  const newNetExpensesOffChain = data?.offChain;
+  const series: LineChartSeriesData[] = useMemo(() => {
+    const disabled = {
+      Budget: inactiveSeries.includes('Budget'),
+      Forecast: inactiveSeries.includes('Forecast'),
+      Actuals: inactiveSeries.includes('Actuals'),
+      'Net Expenses On-chain': inactiveSeries.includes('Net Expenses On-chain'),
+      'Net Expenses Off-chain': inactiveSeries.includes('Net Expenses Off-chain'),
+    };
 
-  const isLoading = !analytics && !error;
+    return [
+      {
+        name: 'Budget',
+        data: disabled.Budget ? [] : data?.budget,
+        type: 'line',
+        itemStyle: {
+          color: disabled.Budget ? '#ccc' : isLight ? '#F99374' : '#F77249',
+        },
+        isVisible: !disabled.Budget,
+      },
+      {
+        name: 'Forecast',
+        data: disabled.Forecast ? [] : data?.forecast,
+        type: 'line',
+        itemStyle: {
+          color: disabled.Forecast ? '#ccc' : isLight ? '#447AFB' : '#447AFB',
+        },
+        isVisible: !disabled.Forecast,
+      },
+      {
+        name: 'Actuals',
+        data: disabled.Actuals ? [] : data?.actuals,
+        type: 'line',
+        itemStyle: {
+          color: disabled.Actuals ? '#ccc' : isLight ? '#2DC1B1' : '#1AAB9B',
+        },
+        isVisible: !disabled.Actuals,
+      },
+      {
+        name: 'Net Expenses On-chain',
+        data: disabled['Net Expenses On-chain'] ? [] : data?.onChain,
+        type: 'line',
+        itemStyle: {
+          color: disabled['Net Expenses On-chain'] ? '#ccc' : isLight ? '#FBCC5F' : '#FDC134',
+        },
+        isVisible: !disabled['Net Expenses On-chain'],
+      },
+      {
+        name: 'Net Expenses Off-chain',
+        data: disabled['Net Expenses Off-chain'] ? [] : data?.offChain,
+        type: 'line',
+        itemStyle: {
+          color: disabled['Net Expenses Off-chain'] ? '#ccc' : isLight ? '#7C6B95' : '#6C40AA',
+        },
+        isVisible: !disabled['Net Expenses Off-chain'],
+      },
+    ];
+  }, [data?.actuals, data?.budget, data?.forecast, data?.offChain, data?.onChain, inactiveSeries, isLight]);
 
   return {
     selectedGranularity,
     handleGranularityChange,
     isLoading,
-    newActuals,
-    newBudget,
-    newForecast,
-    newNetExpensesOffChain,
-    newNetExpensesOnChain,
+    series,
+    handleToggleSeries,
   };
 };

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
@@ -1,4 +1,5 @@
 import { fetchAnalytics } from '@ses/containers/Finances/api/queries';
+import { buildExpenseMetricsLineChartSeries } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { useMemo, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
@@ -56,63 +57,10 @@ export const useMakerDAOExpenseMetrics = (year: string) => {
     );
   };
 
-  const series: LineChartSeriesData[] = useMemo(() => {
-    const disabled = {
-      Budget: inactiveSeries.includes('Budget'),
-      Forecast: inactiveSeries.includes('Forecast'),
-      Actuals: inactiveSeries.includes('Actuals'),
-      'Net Expenses On-chain': inactiveSeries.includes('Net Expenses On-chain'),
-      'Net Expenses Off-chain': inactiveSeries.includes('Net Expenses Off-chain'),
-    };
-
-    return [
-      {
-        name: 'Budget',
-        data: disabled.Budget ? [] : data?.budget,
-        type: 'line',
-        itemStyle: {
-          color: disabled.Budget ? '#ccc' : isLight ? '#F99374' : '#F77249',
-        },
-        isVisible: !disabled.Budget,
-      },
-      {
-        name: 'Forecast',
-        data: disabled.Forecast ? [] : data?.forecast,
-        type: 'line',
-        itemStyle: {
-          color: disabled.Forecast ? '#ccc' : isLight ? '#447AFB' : '#447AFB',
-        },
-        isVisible: !disabled.Forecast,
-      },
-      {
-        name: 'Actuals',
-        data: disabled.Actuals ? [] : data?.actuals,
-        type: 'line',
-        itemStyle: {
-          color: disabled.Actuals ? '#ccc' : isLight ? '#2DC1B1' : '#1AAB9B',
-        },
-        isVisible: !disabled.Actuals,
-      },
-      {
-        name: 'Net Expenses On-chain',
-        data: disabled['Net Expenses On-chain'] ? [] : data?.onChain,
-        type: 'line',
-        itemStyle: {
-          color: disabled['Net Expenses On-chain'] ? '#ccc' : isLight ? '#FBCC5F' : '#FDC134',
-        },
-        isVisible: !disabled['Net Expenses On-chain'],
-      },
-      {
-        name: 'Net Expenses Off-chain',
-        data: disabled['Net Expenses Off-chain'] ? [] : data?.offChain,
-        type: 'line',
-        itemStyle: {
-          color: disabled['Net Expenses Off-chain'] ? '#ccc' : isLight ? '#7C6B95' : '#6C40AA',
-        },
-        isVisible: !disabled['Net Expenses Off-chain'],
-      },
-    ];
-  }, [data?.actuals, data?.budget, data?.forecast, data?.offChain, data?.onChain, inactiveSeries, isLight]);
+  const series: LineChartSeriesData[] = useMemo(
+    () => buildExpenseMetricsLineChartSeries(data, inactiveSeries, isLight),
+    [data, inactiveSeries, isLight]
+  );
 
   return {
     selectedGranularity,

--- a/src/stories/containers/Finances/utils/mockData.ts
+++ b/src/stories/containers/Finances/utils/mockData.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 // TODO:  Add builder for this mock data when Api is ready
 export interface BudgetData {
   q1: number;
@@ -952,5 +953,122 @@ export const mockDataTableQuarterlyArray: QuarterlyBudget[] = [
         },
       },
     ],
+  },
+];
+
+export const atlasBudget = [
+  {
+    value: 1450000,
+  },
+  {
+    value: 1450000,
+  },
+  {
+    value: 1450000,
+  },
+  {
+    value: 1300000,
+  },
+  {
+    value: 1400000,
+  },
+  {
+    value: 1280000,
+  },
+  {
+    value: 640000,
+  },
+  {
+    value: 320000,
+  },
+  {
+    value: 160000,
+  },
+  {
+    value: 80000,
+  },
+  {
+    value: 25000,
+  },
+  {
+    value: 10000,
+  },
+];
+
+export const scopeBudget = [
+  {
+    value: 123434,
+  },
+  {
+    value: 123434,
+  },
+  {
+    value: 123434,
+  },
+  {
+    value: 123434,
+  },
+  {
+    value: 100000,
+  },
+  {
+    value: 250000,
+  },
+  {
+    value: 900000,
+  },
+  {
+    value: 1250000,
+  },
+  {
+    value: 0,
+  },
+  {
+    value: 1400000,
+  },
+  {
+    value: 1400000,
+  },
+  {
+    value: 1500000,
+  },
+];
+
+export const legacyBudget = [
+  {
+    value: 0,
+  },
+  {
+    value: 43434,
+  },
+  {
+    value: 452342,
+  },
+  {
+    value: 23543,
+  },
+  {
+    value: 43434,
+  },
+  {
+    value: 0,
+  },
+  {
+    value: 54456,
+  },
+  {
+    value: 235425,
+  },
+  {
+    value: 175000,
+  },
+  {
+    value: 180000,
+  },
+  {
+    value: 220000,
+  },
+  {
+    value: 200000,
   },
 ];

--- a/src/stories/containers/Finances/utils/types.ts
+++ b/src/stories/containers/Finances/utils/types.ts
@@ -100,3 +100,13 @@ export interface BreakdownChartSeriesData {
   };
   isVisible: boolean;
 }
+
+export interface LineChartSeriesData {
+  name: string;
+  data: number[];
+  type: 'line';
+  itemStyle: {
+    color: string;
+  };
+  isVisible: boolean;
+}

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -9,6 +9,7 @@ import { DateTime } from 'luxon';
 import type { QuarterlyBudget, RowsItems } from './mockData';
 import type {
   DelegateExpenseTableHeader,
+  LineChartSeriesData,
   Metric,
   MetricsWithAmount,
   MomentDataItem,
@@ -644,123 +645,6 @@ export const getNumbersFromIdPath = (idPath: string) => {
   return numbers;
 };
 
-export const atlasBudget = [
-  {
-    value: 1450000,
-  },
-  {
-    value: 1450000,
-  },
-  {
-    value: 1450000,
-  },
-  {
-    value: 1300000,
-  },
-  {
-    value: 1400000,
-  },
-  {
-    value: 1280000,
-  },
-  {
-    value: 640000,
-  },
-  {
-    value: 320000,
-  },
-  {
-    value: 160000,
-  },
-  {
-    value: 80000,
-  },
-  {
-    value: 25000,
-  },
-  {
-    value: 10000,
-  },
-];
-
-export const scopeBudget = [
-  {
-    value: 123434,
-  },
-  {
-    value: 123434,
-  },
-  {
-    value: 123434,
-  },
-  {
-    value: 123434,
-  },
-  {
-    value: 100000,
-  },
-  {
-    value: 250000,
-  },
-  {
-    value: 900000,
-  },
-  {
-    value: 1250000,
-  },
-  {
-    value: 0,
-  },
-  {
-    value: 1400000,
-  },
-  {
-    value: 1400000,
-  },
-  {
-    value: 1500000,
-  },
-];
-
-export const legacyBudget = [
-  {
-    value: 0,
-  },
-  {
-    value: 43434,
-  },
-  {
-    value: 452342,
-  },
-  {
-    value: 23543,
-  },
-  {
-    value: 43434,
-  },
-  {
-    value: 0,
-  },
-  {
-    value: 54456,
-  },
-  {
-    value: 235425,
-  },
-  {
-    value: 175000,
-  },
-  {
-    value: 180000,
-  },
-  {
-    value: 220000,
-  },
-  {
-    value: 200000,
-  },
-];
-
 const fillArrayWhenNoData = (series: { value: number }[]) => {
   const filledArray = new Array<{ value: number }>(12).fill({ value: 0 });
 
@@ -1028,4 +912,72 @@ export const getCorrectMetric = (budgetMetric: BudgetMetric, selectedMetric: Met
       borderRadius: [0, 0, 0, 0],
     },
   };
+};
+
+export const buildExpenseMetricsLineChartSeries = (
+  data: {
+    budget: number[];
+    forecast: number[];
+    actuals: number[];
+    onChain: number[];
+    offChain: number[];
+  },
+  inactiveSeries: string[],
+  isLight: boolean
+) => {
+  const disabled = {
+    Budget: inactiveSeries.includes('Budget'),
+    Forecast: inactiveSeries.includes('Forecast'),
+    Actuals: inactiveSeries.includes('Actuals'),
+    'Net Expenses On-chain': inactiveSeries.includes('Net Expenses On-chain'),
+    'Net Expenses Off-chain': inactiveSeries.includes('Net Expenses Off-chain'),
+  };
+
+  return [
+    {
+      name: 'Budget',
+      data: disabled.Budget ? [] : data?.budget,
+      type: 'line',
+      itemStyle: {
+        color: disabled.Budget ? '#ccc' : isLight ? '#F99374' : '#F77249',
+      },
+      isVisible: !disabled.Budget,
+    },
+    {
+      name: 'Forecast',
+      data: disabled.Forecast ? [] : data?.forecast,
+      type: 'line',
+      itemStyle: {
+        color: disabled.Forecast ? '#ccc' : isLight ? '#447AFB' : '#447AFB',
+      },
+      isVisible: !disabled.Forecast,
+    },
+    {
+      name: 'Actuals',
+      data: disabled.Actuals ? [] : data?.actuals,
+      type: 'line',
+      itemStyle: {
+        color: disabled.Actuals ? '#ccc' : isLight ? '#2DC1B1' : '#1AAB9B',
+      },
+      isVisible: !disabled.Actuals,
+    },
+    {
+      name: 'Net Expenses On-chain',
+      data: disabled['Net Expenses On-chain'] ? [] : data?.onChain,
+      type: 'line',
+      itemStyle: {
+        color: disabled['Net Expenses On-chain'] ? '#ccc' : isLight ? '#FBCC5F' : '#FDC134',
+      },
+      isVisible: !disabled['Net Expenses On-chain'],
+    },
+    {
+      name: 'Net Expenses Off-chain',
+      data: disabled['Net Expenses Off-chain'] ? [] : data?.offChain,
+      type: 'line',
+      itemStyle: {
+        color: disabled['Net Expenses Off-chain'] ? '#ccc' : isLight ? '#7C6B95' : '#6C40AA',
+      },
+      isVisible: !disabled['Net Expenses Off-chain'],
+    },
+  ] as LineChartSeriesData[];
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/Dy3KazCU/305-eml-1-expense-metrics-line-chart-v1

## Description
Allow to enable/disable visually the series and fix the stacked mode in the chart

## What solved
- [X] Clicking on a legend. **Expected Output:** The legend should display its defined color if the data is reflected in the graph or the gray color if the data is hidden or there is no data to show. **Current Output:** The legend never changes its color.
- [X] Net Expenses Off-chain included line. **Expected Output:**  **Current Output:**The line is taking the same values of the Net Expenses On-chain, therefore the lines are overlaping.
