### PR TITLE
[BC-11] Fix breakdown chart shadow colors

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -56,6 +56,10 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year, refBreakDownChart
       trigger: 'axis',
       axisPointer: {
         type: 'shadow',
+        shadowStyle: {
+          color: isLight ? '#D4D9E1' : '#231536',
+          opacity: 0.15,
+        },
       },
       padding: 0,
       borderWidth: 1,
@@ -65,7 +69,9 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year, refBreakDownChart
         <div style="background-color:${
           isLight ? '#fff' : '#000A13'
         };padding:16px;minWidth:194px;overflow:auto;border-radius:3px;">
-          <div style="margin-bottom:16px;color:${isLight ? '#000' : '#EDEFFF'};">${params?.[0]?.name}</div>
+          <div style="margin-bottom:16px;font-size:12px;font-weight:600;color:#B6BCC2;">${
+            (selectedGranularity as string) === 'Annually' ? year : params?.[0]?.name
+          }</div>
           <div style="display:flex;flex-direction:column;gap:12px">
             ${params
               .reverse()
@@ -81,8 +87,10 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year, refBreakDownChart
                 <circle cx="6.5" cy="6.5" r="5.5" stroke="${item.color}" />
                 <circle cx="6.5" cy="6.5" r="4" fill="${item.color}" />
               </svg>
-              <span style="font-weight:bold;color:${isLight ? '#231536' : '#9FAFB9'};"> ${item.seriesName}:</span>
-              ${formatNumber(item.value)}</div>`
+              <span style="font-size:14px;color:${isLight ? '#231536' : '#B6BCC2'};"> ${item.seriesName}:</span>
+              <span style="font-size:16px;font-weight:700;color:${isLight ? '#231536' : '#EDEFFF'};">${formatNumber(
+                  item.value
+                )}</span></div>`
               )
               .join('')}
           </div>


### PR DESCRIPTION
## Ticket
https://trello.com/c/lJtOvFKL/304-bc-11-non-configurable-breakdown-chart

## Description
Fixed the bar shadow color on hover and the tooltip colors

## What solved
- [X] Hovering over the bars. ** Expected Output:**  The hover state should be visible only on the bar. **Current Output:** The hover state is displayed in a larger space than the bar
- [X] Hovering over the bars. ** Expected Output:**  The values should have color: #EDEFFF and the text legend should have #B6BCC2.  

