### PR TITLE
[QC-r2] Fix snapshot expenses comparison numbers

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
@@ -188,11 +188,11 @@ export const buildExpensesComparisonRows = (
       const row = buildRow(
         [
           formatExpenseMonth(comparison.month),
-          formatExpenseWithCurrency(comparison.reportedActuals, currency),
-          formatExpenseWithCurrency(comparison.netExpenses.onChainOnly.amount, currency),
-          formatExpenseDifference(comparison.netExpenses.onChainOnly.difference),
-          formatExpenseWithCurrency(comparison.netExpenses.offChainIncluded.amount, currency),
-          formatExpenseDifference(comparison.netExpenses.offChainIncluded.difference),
+          formatExpenseWithCurrency(comparison.reportedActuals || 0, currency),
+          formatExpenseWithCurrency(comparison.netExpenses.onChainOnly.amount || 0, currency),
+          formatExpenseDifference(comparison.netExpenses.onChainOnly.difference || 0),
+          formatExpenseWithCurrency(comparison.netExpenses.offChainIncluded.amount || 0, currency),
+          formatExpenseDifference(comparison.netExpenses.offChainIncluded.difference || 0),
         ],
         comparison.month === currentPeriod,
         false
@@ -206,11 +206,11 @@ export const buildExpensesComparisonRows = (
         buildRow(
           [
             'Totals',
-            formatExpenseWithCurrency(totals.reportedActuals, currency),
-            formatExpenseWithCurrency(totals.netExpenses.onChainOnly.amount, currency),
-            formatExpenseDifference(totals.netExpenses.onChainOnly.difference),
-            formatExpenseWithCurrency(totals.netExpenses.offChainIncluded.amount, currency),
-            formatExpenseDifference(totals.netExpenses.offChainIncluded.difference),
+            formatExpenseWithCurrency(totals.reportedActuals || 0, currency),
+            formatExpenseWithCurrency(totals.netExpenses.onChainOnly.amount || 0, currency),
+            formatExpenseDifference(totals.netExpenses.onChainOnly.difference || 0),
+            formatExpenseWithCurrency(totals.netExpenses.offChainIncluded.amount || 0, currency),
+            formatExpenseDifference(totals.netExpenses.offChainIncluded.difference || 0),
           ],
           false,
           true


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Some numbers in the expenses comparison of the snapshot section was showing undefined values

## What solved
- [X] Accounts Snapshot view, Reported Expenses Comparison section. **Expected Output:**   **Current Output: ** REPORTED ACTUALS column is displaying "undefined" text instead of the value. The total percent is displayed with NaN instead of 0.

