### PR TITLE
[QC-r2] Fix snapshot expenses with no off chain data

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
@@ -222,9 +222,9 @@ export const buildExpensesComparisonRows = (
       const row = buildRowWithoutOffChain(
         [
           formatExpenseMonth(comparison.month),
-          formatExpenseWithCurrency(comparison.reportedActuals, currency),
-          formatExpenseWithCurrency(comparison.netExpenses.onChainOnly.amount, currency),
-          formatExpenseDifference(comparison.netExpenses.onChainOnly.difference),
+          formatExpenseWithCurrency(comparison.reportedActuals || 0, currency),
+          formatExpenseWithCurrency(comparison.netExpenses.onChainOnly.amount || 0, currency),
+          formatExpenseDifference(comparison.netExpenses.onChainOnly.difference || 0),
         ],
         comparison.month === currentPeriod,
         false
@@ -238,9 +238,9 @@ export const buildExpensesComparisonRows = (
         buildRowWithoutOffChain(
           [
             'Totals',
-            formatExpenseWithCurrency(totals.reportedActuals, currency),
-            formatExpenseWithCurrency(totals.netExpenses.onChainOnly.amount, currency),
-            formatExpenseDifference(totals.netExpenses.onChainOnly.difference),
+            formatExpenseWithCurrency(totals.reportedActuals || 0, currency),
+            formatExpenseWithCurrency(totals.netExpenses.onChainOnly.amount || 0, currency),
+            formatExpenseDifference(totals.netExpenses.onChainOnly.difference || 0),
           ],
           false,
           true


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Fix undefined values on account snapshot

## What solved
- [X] Accounts Snapshot view, Reported Expenses Comparison section. **Expected Output:**   **Current Output: ** REPORTED ACTUALS column is displaying "undefined" text instead of the value. The total percent is displayed with NaN instead of 0. 

