### PR TITLE
[BC-1] Persist breakdown chart legend status

### DIFF
--- a/src/stories/containers/EndgameBudgetContainerSecondLevel/EndgameBudgetContainerSecondLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerSecondLevel/EndgameBudgetContainerSecondLevel.tsx
@@ -42,16 +42,7 @@ const EndgameBudgetContainerSecondLevel: React.FC<Props> = ({ budgets, yearsRang
     handleLoadMoreCards,
     loadMoreCards,
     cardsToShow,
-    selectedBreakdownMetric,
-    selectedBreakdownGranularity,
-    handleBreakdownMetricChange,
-    handleBreakdownGranularityChange,
-    isDisabled,
-    handleResetFilterBreakDownChart,
-    budgetsAnalyticsMonthly,
-    budgetsAnalyticsQuarterly,
-    series,
-    refBreakDownChart,
+    breakdownChartSectionData,
     changeAlignment,
     breakdownTableSecondLevel,
     makerDAOExpensesMetrics,
@@ -98,17 +89,18 @@ const EndgameBudgetContainerSecondLevel: React.FC<Props> = ({ budgets, yearsRang
         </ContainerSections>
         <BreakdownChartSection
           year={year}
-          selectedMetric={selectedBreakdownMetric}
-          selectedGranularity={selectedBreakdownGranularity}
-          onMetricChange={handleBreakdownMetricChange}
-          onGranularityChange={handleBreakdownGranularityChange}
-          isDisabled={isDisabled}
-          handleResetFilter={handleResetFilterBreakDownChart}
+          selectedMetric={breakdownChartSectionData.selectedBreakdownMetric}
+          selectedGranularity={breakdownChartSectionData.selectedBreakdownGranularity}
+          onMetricChange={breakdownChartSectionData.handleBreakdownMetricChange}
+          onGranularityChange={breakdownChartSectionData.handleBreakdownGranularityChange}
+          isDisabled={breakdownChartSectionData.isDisabled}
+          handleResetFilter={breakdownChartSectionData.handleResetFilterBreakDownChart}
           budgets={budgets}
-          budgetsAnalyticsMonthly={budgetsAnalyticsMonthly}
-          budgetsAnalyticsQuarterly={budgetsAnalyticsQuarterly}
-          series={series}
-          refBreakDownChart={refBreakDownChart}
+          budgetsAnalyticsMonthly={breakdownChartSectionData.budgetsAnalyticsMonthly}
+          budgetsAnalyticsQuarterly={breakdownChartSectionData.budgetsAnalyticsQuarterly}
+          series={breakdownChartSectionData.series}
+          handleToggleSeries={breakdownChartSectionData.handleToggleSeries}
+          refBreakDownChart={breakdownChartSectionData.refBreakDownChart}
         />
       </Container>
       <ConditionalWrapper period={breakdownTableSecondLevel.periodFilter}>

--- a/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
@@ -187,7 +187,7 @@ export const useEndgameBudgetContainerSecondLevel = (budgets: Budget[], initialY
     filters,
     filterSelected,
     doughnutSeriesData,
-    ...breakdownChartSectionData,
+    breakdownChartSectionData,
     actuals,
     budgetCap,
     prediction,

--- a/src/stories/containers/EndgameBudgetContainerThirdLevel/EndgameBudgetContainerThirdLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerThirdLevel/EndgameBudgetContainerThirdLevel.tsx
@@ -55,18 +55,8 @@ const EndgameBudgetContainerThirdLevel: React.FC<Props> = ({ budgets, yearsRange
     handleLoadMoreCards,
     isLight,
     cardsToShow,
-
     breakdownTableThirdLevel,
-    selectedBreakdownMetric,
-    selectedBreakdownGranularity,
-    handleBreakdownMetricChange,
-    handleBreakdownGranularityChange,
-    isDisabled,
-    handleResetFilterBreakDownChart,
-    budgetsAnalyticsMonthly,
-    budgetsAnalyticsQuarterly,
-    series,
-    refBreakDownChart,
+    breakdownChartSectionData,
     changeAlignment,
     makerDAOExpensesMetrics,
     expenseReportSection,
@@ -103,6 +93,7 @@ const EndgameBudgetContainerThirdLevel: React.FC<Props> = ({ budgets, yearsRange
       },
     },
   } as SwiperProps;
+
   return (
     <PageContainer>
       <BreadcrumbYearNavigation
@@ -181,17 +172,18 @@ const EndgameBudgetContainerThirdLevel: React.FC<Props> = ({ budgets, yearsRange
         </ContainerSections>
         <BreakdownChartSection
           year={year}
-          selectedMetric={selectedBreakdownMetric}
-          selectedGranularity={selectedBreakdownGranularity}
-          onMetricChange={handleBreakdownMetricChange}
-          onGranularityChange={handleBreakdownGranularityChange}
-          isDisabled={isDisabled}
-          handleResetFilter={handleResetFilterBreakDownChart}
+          selectedMetric={breakdownChartSectionData.selectedBreakdownMetric}
+          selectedGranularity={breakdownChartSectionData.selectedBreakdownGranularity}
+          onMetricChange={breakdownChartSectionData.handleBreakdownMetricChange}
+          onGranularityChange={breakdownChartSectionData.handleBreakdownGranularityChange}
+          isDisabled={breakdownChartSectionData.isDisabled}
+          handleResetFilter={breakdownChartSectionData.handleResetFilterBreakDownChart}
           budgets={budgets}
-          budgetsAnalyticsMonthly={budgetsAnalyticsMonthly}
-          budgetsAnalyticsQuarterly={budgetsAnalyticsQuarterly}
-          series={series}
-          refBreakDownChart={refBreakDownChart}
+          budgetsAnalyticsMonthly={breakdownChartSectionData.budgetsAnalyticsMonthly}
+          budgetsAnalyticsQuarterly={breakdownChartSectionData.budgetsAnalyticsQuarterly}
+          series={breakdownChartSectionData.series}
+          handleToggleSeries={breakdownChartSectionData.handleToggleSeries}
+          refBreakDownChart={breakdownChartSectionData.refBreakDownChart}
         />
       </Container>
 

--- a/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
@@ -245,7 +245,7 @@ export const useEndgameBudgetContainerThirdLevel = (budgets: Budget[], initialYe
     prediction,
     cardsNavigationInformation,
     doughnutSeriesData,
-    ...breakdownChartSectionData,
+    breakdownChartSectionData,
     filtersThirdLevel,
     selectedThirdLevel,
     handleSelectFilterThirdLevel,

--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -106,6 +106,7 @@ const FinancesContainer: React.FC<Props> = ({ budgets, yearsRange, initialYear }
             budgetsAnalyticsMonthly={breakdownChartSectionData.budgetsAnalyticsMonthly}
             budgetsAnalyticsQuarterly={breakdownChartSectionData.budgetsAnalyticsQuarterly}
             series={breakdownChartSectionData.series}
+            handleToggleSeries={breakdownChartSectionData.handleToggleSeries}
             refBreakDownChart={breakdownChartSectionData.refBreakDownChart}
           />
         )}

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -7,7 +7,6 @@ import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import ReactECharts from 'echarts-for-react';
 import React, { useEffect, useState } from 'react';
-import { setBorderRadiusForSeries } from '../utils';
 import type { BreakdownChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { AnalyticGranularity, BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
 import type { Budget } from '@ses/core/models/interfaces/budget';
@@ -21,17 +20,23 @@ interface BreakdownChartProps {
   budgetsAnalyticsMonthly: BreakdownBudgetAnalytic | undefined;
   budgetsAnalyticsQuarterly: BreakdownBudgetAnalytic | undefined;
   series: BreakdownChartSeriesData[];
+  handleToggleSeries: (series: string) => void;
   refBreakDownChart: React.RefObject<EChartsOption | null>;
 }
 
-const BreakdownChart: React.FC<BreakdownChartProps> = ({ year, refBreakDownChart, series, selectedGranularity }) => {
+const BreakdownChart: React.FC<BreakdownChartProps> = ({
+  year,
+  refBreakDownChart,
+  series,
+  handleToggleSeries,
+  selectedGranularity,
+}) => {
   const { isLight } = useThemeContext();
   const isDesktop1280 = useMediaQuery(lightTheme.breakpoints.between('desktop_1280', 'desktop_1440'));
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const isTablet = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
   const upTable = useMediaQuery(lightTheme.breakpoints.up('tablet_768'));
   const isDesktop1024 = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
-  const barBorderRadius = isMobile ? 4 : 6;
 
   const [visibleSeries, setVisibleSeries] = useState<BreakdownChartSeriesData[]>(series);
   const [legends, setLegends] = useState<BreakdownChartSeriesData[]>(series);
@@ -145,47 +150,6 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year, refBreakDownChart
     });
   };
 
-  const toggleSeriesVisibility = (seriesName: string) => {
-    const updateSeries = visibleSeries.map((item) => {
-      if (item.name === seriesName) {
-        const isVisible = !item.isVisible;
-        return {
-          ...item,
-          isVisible,
-          // Add border 0 when element is hiddend
-          data: isVisible
-            ? item.dataOriginal
-            : item.data.map(() => ({
-                value: 0,
-                itemStyle: { borderRadius: [0, 0, 0, 0] },
-              })),
-        };
-      }
-      return item;
-    });
-
-    // iterate through legends
-    const newLegend = legends.map((item) => {
-      if (item.name === seriesName) {
-        const isVisible = !item.isVisible;
-        return {
-          ...item,
-          isVisible,
-          itemStyle: {
-            ...item.itemStyle,
-            color: isVisible ? item?.itemStyle.colorOriginal : 'rgb(204, 204, 204)',
-          },
-
-          data: item.dataOriginal || [],
-        };
-      }
-      return item;
-    });
-    const recalculatedSeries = setBorderRadiusForSeries(updateSeries, barBorderRadius);
-    setVisibleSeries(recalculatedSeries);
-    setLegends(newLegend);
-  };
-
   return (
     <Wrapper>
       <ChartContainer>
@@ -211,7 +175,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year, refBreakDownChart
             isLight={isLight}
             onMouseEnter={() => onLegendItemHover(element.name)}
             onMouseLeave={() => onLegendItemLeave(element.name)}
-            onClick={() => toggleSeriesVisibility(element.name)}
+            onClick={() => handleToggleSeries(element.name)}
           >
             <SVGContainer>
               <svg
@@ -221,8 +185,8 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({ year, refBreakDownChart
                 viewBox="0 0 13 13"
                 fill="none"
               >
-                <circle cx="6.5" cy="6.5" r="5.5" stroke={element.itemStyle.color} />
-                <circle cx="6.5" cy="6.5" r="4" fill={element.itemStyle.color} />
+                <circle cx="6.5" cy="6.5" r="5.5" stroke={element.itemStyle.colorOriginal} />
+                <circle cx="6.5" cy="6.5" r="4" fill={element.itemStyle.colorOriginal} />
               </svg>
             </SVGContainer>
             {element.name}

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
@@ -21,6 +21,7 @@ export interface BreakdownChartSectionProps {
   budgetsAnalyticsMonthly: BreakdownBudgetAnalytic | undefined;
   budgetsAnalyticsQuarterly: BreakdownBudgetAnalytic | undefined;
   series: BreakdownChartSeriesData[];
+  handleToggleSeries: (series: string) => void;
   refBreakDownChart: React.RefObject<EChartsOption | null>;
 }
 
@@ -36,11 +37,15 @@ const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
   budgetsAnalyticsMonthly,
   budgetsAnalyticsQuarterly,
   series,
+  handleToggleSeries,
   refBreakDownChart,
 }) => (
   <Section>
     <HeaderContainer>
-      <SectionTitle title="Breakdown Chart" tooltip="No data" />
+      <SectionTitle
+        title="Breakdown Chart"
+        tooltip="Explore comprehensive financial data by adjusting the chart's time granularity and selecting specific metrics for tailored insights."
+      />
       <BreakdownChartFilter
         selectedMetric={selectedMetric}
         selectedGranularity={selectedGranularity}
@@ -58,6 +63,7 @@ const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
       budgetsAnalyticsQuarterly={budgetsAnalyticsQuarterly}
       selectedGranularity={selectedGranularity as AnalyticGranularity}
       series={series}
+      handleToggleSeries={handleToggleSeries}
       refBreakDownChart={refBreakDownChart}
     />
   </Section>

--- a/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -78,7 +78,39 @@ const useBreakdownChart = (
     [barWidth, budgets, budgetsAnalytics, isLight, selectedBreakdownMetric]
   );
 
-  const series = setBorderRadiusForSeries(seriesWithoutBorder, barBorderRadius);
+  const allSeries = setBorderRadiusForSeries(seriesWithoutBorder, barBorderRadius);
+
+  // series to be "hidden" in the chart
+  const [inactiveSeries, setInactiveSeries] = useState<string[]>([]);
+  const handleToggleSeries = (toggleSeries: string) => {
+    setInactiveSeries(
+      inactiveSeries.includes(toggleSeries)
+        ? inactiveSeries.filter((series) => series !== toggleSeries)
+        : [...inactiveSeries, toggleSeries]
+    );
+  };
+  const series = useMemo(() => {
+    const xx = allSeries.map((item) => {
+      if (inactiveSeries.includes(item.name)) {
+        return {
+          ...item,
+          isVisible: false,
+          itemStyle: {
+            ...item.itemStyle,
+            colorOriginal: '#ccc',
+          },
+          data: item.data.map(() => ({
+            value: 0, // set value to 0 to hide the bar
+            itemStyle: { borderRadius: [0, 0, 0, 0] },
+          })),
+        };
+      }
+
+      return item;
+    });
+
+    return setBorderRadiusForSeries(xx, barBorderRadius);
+  }, [allSeries, barBorderRadius, inactiveSeries]);
 
   return {
     selectedBreakdownMetric,
@@ -88,6 +120,7 @@ const useBreakdownChart = (
 
     isDisabled,
     handleResetFilterBreakDownChart,
+    handleToggleSeries,
     series,
     isMobile,
     isTablet,


### PR DESCRIPTION
## Ticket
https://trello.com/c/lJtOvFKL/304-bc-11-non-configurable-breakdown-chart

## Description
Persist the legend status when changing the year or theme mode

## What solved
- [X] Should remain the legend state and the filter selected when you change between years and sublevels
