### PR TITLE
Add Swiper in the table size and when there is more than five items

### DIFF
--- a/src/stories/containers/EndgameBudgetContainerSecondLevel/EndgameBudgetContainerSecondLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerSecondLevel/EndgameBudgetContainerSecondLevel.tsx
@@ -56,6 +56,7 @@ const EndgameBudgetContainerSecondLevel: React.FC<Props> = ({ budgets, yearsRang
     breakdownTableSecondLevel,
     makerDAOExpensesMetrics,
     expenseReportSection,
+    showSwiper,
   } = useEndgameBudgetContainerSecondLevel(budgets, initialYear, allBudgets);
 
   return (
@@ -85,6 +86,8 @@ const EndgameBudgetContainerSecondLevel: React.FC<Props> = ({ budgets, yearsRang
               doughnutSeriesData={doughnutSeriesData}
               isCoreThirdLevel={false}
               changeAlignment={changeAlignment}
+              showSwiper={showSwiper}
+              numberSliderPerLevel={3}
             />
           </WrapperDesk>
           <WrapperMobile>

--- a/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
@@ -109,6 +109,7 @@ export const useEndgameBudgetContainerSecondLevel = (budgets: Budget[], initialY
     budgetCap,
     prediction,
     changeAlignment,
+    showSwiper,
   } = useCardChartOverview(budgets, budgetsAnalytics);
 
   // all the logic required by the breakdown chart section
@@ -205,5 +206,6 @@ export const useEndgameBudgetContainerSecondLevel = (budgets: Budget[], initialY
     makerDAOExpensesMetrics,
     expenseReportSection,
     breakdownTableSecondLevel,
+    showSwiper,
   };
 };

--- a/src/stories/containers/EndgameBudgetContainerThirdLevel/EndgameBudgetContainerThirdLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerThirdLevel/EndgameBudgetContainerThirdLevel.tsx
@@ -22,7 +22,7 @@ import { useEndgameBudgetContainerThirdLevel } from './useEndgameBudgetContainer
 import type { NavigationCard } from '../Finances/utils/types';
 import type { Budget } from '@ses/core/models/interfaces/budget';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
-import type { SwiperProps, SwiperRef } from 'swiper/react';
+import type { SwiperRef, SwiperProps } from 'swiper/react';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 import 'swiper/css/scrollbar';
@@ -70,6 +70,7 @@ const EndgameBudgetContainerThirdLevel: React.FC<Props> = ({ budgets, yearsRange
     changeAlignment,
     makerDAOExpensesMetrics,
     expenseReportSection,
+    showSwiper,
   } = useEndgameBudgetContainerThirdLevel(budgets, initialYear, allBudgets);
   const ref = useRef<SwiperRef>(null);
 
@@ -129,6 +130,7 @@ const EndgameBudgetContainerThirdLevel: React.FC<Props> = ({ budgets, yearsRange
               doughnutSeriesData={doughnutSeriesData}
               isCoreThirdLevel={true}
               changeAlignment={changeAlignment}
+              showSwiper={showSwiper}
             />
           </WrapperDesk>
           <WrapperMobile>

--- a/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
@@ -89,6 +89,7 @@ export const useEndgameBudgetContainerThirdLevel = (budgets: Budget[], initialYe
     budgetCap,
     prediction,
     changeAlignment,
+    showSwiper,
   } = useCardChartOverview(budgets, budgetsAnalytics);
 
   // all the logic required by the breakdown chart section
@@ -258,5 +259,6 @@ export const useEndgameBudgetContainerThirdLevel = (budgets: Budget[], initialYe
     changeAlignment,
     makerDAOExpensesMetrics,
     expenseReportSection,
+    showSwiper,
   };
 };

--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -77,6 +77,7 @@ const FinancesContainer: React.FC<Props> = ({ budgets, yearsRange, initialYear }
               doughnutSeriesData={cardOverViewSectionData.doughnutSeriesData}
               isCoreThirdLevel={false}
               changeAlignment={cardOverViewSectionData.changeAlignment}
+              showSwiper={cardOverViewSectionData.showSwiper}
             />
           </WrapperDesk>
           <WrapperMobile>

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
@@ -21,7 +21,7 @@ export const CellMonthly: React.FC<Props> = ({ metrics, title, isTotal = false, 
       <Month isLight={isLight}>{title}</Month>
       {activeMetrics?.map((metric, index) => (
         <Metrics key={index}>
-          <Name isLight={isLight}>Actulas</Name>
+          <Name isLight={isLight}>Actuals</Name>
           <Amount isLight={isLight}>{usLocalizedNumber(metrics[metric as keyof MetricValues] ?? 0)}</Amount>
         </Metrics>
       ))}

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
@@ -1,0 +1,142 @@
+import styled from '@emotion/styled';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import lightTheme from '@ses/styles/theme/light';
+import React from 'react';
+import type { DoughnutSeries } from '@ses/containers/Finances/utils/types';
+import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+
+interface Props {
+  isCoreThirdLevel?: boolean;
+  changeAlignment: boolean;
+  doughnutSeriesData: DoughnutSeries[];
+  toggleSeriesVisibility: (seriesName: string) => void;
+  onLegendItemLeave: (legendName: string) => void;
+  onLegendItemHover: (legendName: string) => void;
+}
+
+const CardLegend: React.FC<Props> = ({
+  changeAlignment,
+  isCoreThirdLevel = true,
+  doughnutSeriesData,
+  onLegendItemHover,
+  onLegendItemLeave,
+  toggleSeriesVisibility,
+}) => {
+  const { isLight } = useThemeContext();
+  return (
+    <ContainerLegend isCoreThirdLevel={isCoreThirdLevel} changeAlignment={changeAlignment}>
+      {doughnutSeriesData.map((data, index) => (
+        <LegendItem
+          key={index}
+          changeAlignment={changeAlignment}
+          isCoreThirdLevel={isCoreThirdLevel}
+          isLight={isLight}
+          onClick={() => toggleSeriesVisibility(data.name)}
+          onMouseEnter={() => onLegendItemHover(data.name)}
+          onMouseLeave={() => onLegendItemLeave(data.name)}
+        >
+          <IconWithName>
+            <LegendIcon backgroundColor={data.color || 'blue'} />
+            <NameOrCode isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>
+              {isCoreThirdLevel ? data.code : data.name}
+            </NameOrCode>
+          </IconWithName>
+          <Value isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>
+            {data.value?.toLocaleString('es-US')}
+
+            <span>DAI</span>
+            <span>{`(${data.percent}%)`}</span>
+          </Value>
+        </LegendItem>
+      ))}
+    </ContainerLegend>
+  );
+};
+
+export default CardLegend;
+
+const LegendIcon = styled.div<{ backgroundColor: string }>(({ backgroundColor }) => ({
+  backgroundColor,
+  minWidth: 8,
+  maxWidth: 8,
+  maxHeight: 8,
+  minHeight: 8,
+  borderRadius: '50%',
+}));
+const LegendItem = styled.div<WithIsLight & { isCoreThirdLevel: boolean; changeAlignment: boolean }>(
+  ({ isLight, isCoreThirdLevel, changeAlignment }) => ({
+    display: 'flex',
+    flexDirection: isCoreThirdLevel ? 'row' : 'column',
+    gap: isCoreThirdLevel ? 4 : 4,
+    fontSize: 12,
+    fontFamily: 'Inter, sans-serif',
+    color: isLight ? '#43435' : '#EDEFFF',
+    cursor: 'pointer',
+    minWidth: 190,
+    ...(changeAlignment && {
+      minWidth: 0,
+    }),
+    [lightTheme.breakpoints.up('desktop_1280')]: {
+      gap: 8,
+    },
+  })
+);
+const Value = styled.div<WithIsLight & { isCoreThirdLevel: boolean }>(({ isLight, isCoreThirdLevel }) => ({
+  color: isLight ? '#9FAFB9' : '#546978',
+  fontFamily: 'Inter, sans-serif',
+  fontSize: 14,
+  fontStyle: 'normal',
+  fontWeight: 400,
+  lineHeight: 'normal',
+  marginLeft: isCoreThirdLevel ? 4 : 14,
+  ...(isCoreThirdLevel && {
+    whiteSpace: 'revert',
+    overflow: 'revert',
+    textOverflow: 'revert',
+  }),
+  '& span': {
+    display: 'inline-block',
+    marginLeft: 4,
+  },
+}));
+
+const IconWithName = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: 6,
+  alignItems: 'center',
+});
+
+const NameOrCode = styled.div<WithIsLight & { isCoreThirdLevel: boolean }>(({ isLight, isCoreThirdLevel }) => ({
+  color: isLight ? (isCoreThirdLevel ? '#708390' : '#434358') : '#EDEFFF',
+  fontFamily: 'Inter, sans-serif',
+  fontSize: 12,
+  fontStyle: 'normal',
+  fontWeight: 400,
+  lineHeight: 'normal',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  width: isCoreThirdLevel ? 'fit-content' : 170,
+}));
+
+const ContainerLegend = styled.div<{ isCoreThirdLevel: boolean; changeAlignment: boolean }>(
+  ({ isCoreThirdLevel, changeAlignment }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    flexWrap: 'wrap',
+    justifyContent: isCoreThirdLevel && changeAlignment ? 'flex-start' : changeAlignment ? 'flex-start' : 'center',
+    gap: isCoreThirdLevel ? 16 : 14,
+    maxWidth: '100%',
+    maxHeight: 210,
+
+    overflow: 'hidden',
+    ...(changeAlignment && {
+      flex: 1,
+    }),
+
+    [lightTheme.breakpoints.up('desktop_1280')]: {
+      gap: 16,
+    },
+  })
+);

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -2,19 +2,28 @@ import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
 import { calculateValuesByBreakpoint } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-
 import lightTheme from '@ses/styles/theme/light';
 import ReactECharts from 'echarts-for-react';
 import React, { useEffect, useRef, useState } from 'react';
+import { Navigation, Pagination } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import CardLegend from './CardLegend';
+import { chunkArray } from './utils';
 import type { DoughnutSeries } from '@ses/containers/Finances/utils/types';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { EChartsOption } from 'echarts-for-react';
+import type { SwiperProps, SwiperRef } from 'swiper/react';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+import 'swiper/css/scrollbar';
+import 'swiper/css';
 
 interface Props {
   doughnutSeriesData: DoughnutSeries[];
   className?: string;
   isCoreThirdLevel?: boolean;
   changeAlignment: boolean;
+  showSwiper: boolean;
+  numberSliderPerLevel?: number;
 }
 
 const DoughnutChartFinances: React.FC<Props> = ({
@@ -22,8 +31,11 @@ const DoughnutChartFinances: React.FC<Props> = ({
   className,
   isCoreThirdLevel = true,
   changeAlignment,
+  showSwiper,
+  numberSliderPerLevel = 5,
 }) => {
   const chartRef = useRef<EChartsOption | null>(null);
+  const ref = useRef<SwiperRef>(null);
   const { isLight } = useThemeContext();
   const [visibleSeries, setVisibleSeries] = useState<DoughnutSeries[]>(doughnutSeriesData);
   const [legends, setLegends] = useState<DoughnutSeries[]>(doughnutSeriesData);
@@ -39,6 +51,7 @@ const DoughnutChartFinances: React.FC<Props> = ({
 
   const { center, radius } = calculateValuesByBreakpoint(isTable, isDesktop1024, isDesktop1280, isDesktop1440);
 
+  const doughnutSeriesChunks = chunkArray(doughnutSeriesData, numberSliderPerLevel);
   const options = {
     color: visibleSeries.map((data) => data.color),
     tooltip: {
@@ -174,6 +187,32 @@ const DoughnutChartFinances: React.FC<Props> = ({
     });
   };
 
+  // Options of Swiper
+  const swiperOptions = {
+    pagination: {
+      type: 'bullets',
+      enabled: true,
+      clickable: true,
+    },
+    breakpoints: {
+      768: {
+        spaceBetween: 16,
+      },
+      1024: {
+        spaceBetween: 2,
+      },
+      1280: {
+        spaceBetween: 2,
+      },
+      1440: {
+        spaceBetween: 2,
+      },
+      1920: {
+        spaceBetween: 2,
+      },
+    },
+  } as SwiperProps;
+
   return (
     <Container className={className}>
       <ContainerChart>
@@ -188,32 +227,47 @@ const DoughnutChartFinances: React.FC<Props> = ({
           opts={{ renderer: 'svg' }}
         />
       </ContainerChart>
-      <ContainerLegend isCoreThirdLevel={isCoreThirdLevel} changeAlignment={changeAlignment}>
-        {legends.map((data, index: number) => (
-          <LegendItem
-            changeAlignment={changeAlignment}
-            isCoreThirdLevel={isCoreThirdLevel}
-            isLight={isLight}
-            key={index}
-            onClick={() => toggleSeriesVisibility(data.name)}
-            onMouseEnter={() => onLegendItemHover(data.name)}
-            onMouseLeave={() => onLegendItemLeave(data.name)}
+      {showSwiper ? (
+        <SwiperWrapper isCoreThirdLevel={isCoreThirdLevel}>
+          <Swiper
+            direction="horizontal"
+            ref={ref}
+            modules={[Pagination, Navigation]}
+            centerInsufficientSlides
+            pagination={true}
+            {...swiperOptions}
           >
-            <IconWithName>
-              <LegendIcon backgroundColor={data.color || 'blue'} />
-              <NameOrCode isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>
-                {isCoreThirdLevel ? data.code : data.name}
-              </NameOrCode>
-            </IconWithName>
-            <Value isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>
-              {data.value?.toLocaleString('es-US')}
-
-              <span>DAI</span>
-              <span>{`(${data.percent}%)`}</span>
-            </Value>
-          </LegendItem>
-        ))}
-      </ContainerLegend>
+            <ContainerLegend isCoreThirdLevel={isCoreThirdLevel} changeAlignment={changeAlignment}>
+              {Array.from(doughnutSeriesChunks.entries()).map(([index, dataChunk]) => (
+                <SwiperSlide key={index}>
+                  <CardLegend
+                    key={index}
+                    changeAlignment={changeAlignment}
+                    doughnutSeriesData={dataChunk}
+                    toggleSeriesVisibility={toggleSeriesVisibility}
+                    onLegendItemHover={onLegendItemHover}
+                    onLegendItemLeave={onLegendItemLeave}
+                    isCoreThirdLevel={isCoreThirdLevel}
+                  />
+                </SwiperSlide>
+              ))}
+            </ContainerLegend>
+          </Swiper>
+        </SwiperWrapper>
+      ) : (
+        <ContainerLegend isCoreThirdLevel={isCoreThirdLevel} changeAlignment={changeAlignment}>
+          {
+            <CardLegend
+              changeAlignment={changeAlignment}
+              doughnutSeriesData={doughnutSeriesData}
+              toggleSeriesVisibility={toggleSeriesVisibility}
+              onLegendItemHover={onLegendItemHover}
+              onLegendItemLeave={onLegendItemLeave}
+              isCoreThirdLevel={isCoreThirdLevel}
+            />
+          }
+        </ContainerLegend>
+      )}
     </Container>
   );
 };
@@ -259,51 +313,6 @@ const ContainerChart = styled.div({
   },
 });
 
-const LegendIcon = styled.div<{ backgroundColor: string }>(({ backgroundColor }) => ({
-  backgroundColor,
-  minWidth: 8,
-  maxWidth: 8,
-  maxHeight: 8,
-  minHeight: 8,
-  borderRadius: '50%',
-}));
-const LegendItem = styled.div<WithIsLight & { isCoreThirdLevel: boolean; changeAlignment: boolean }>(
-  ({ isLight, isCoreThirdLevel, changeAlignment }) => ({
-    display: 'flex',
-    flexDirection: isCoreThirdLevel ? 'row' : 'column',
-    gap: isCoreThirdLevel ? 4 : 4,
-    fontSize: 12,
-    fontFamily: 'Inter, sans-serif',
-    color: isLight ? '#43435' : '#EDEFFF',
-    cursor: 'pointer',
-    minWidth: 190,
-    ...(changeAlignment && {
-      minWidth: 0,
-    }),
-    [lightTheme.breakpoints.up('desktop_1280')]: {
-      gap: 8,
-    },
-  })
-);
-const Value = styled.div<WithIsLight & { isCoreThirdLevel: boolean }>(({ isLight, isCoreThirdLevel }) => ({
-  color: isLight ? '#9FAFB9' : '#546978',
-  fontFamily: 'Inter, sans-serif',
-  fontSize: 14,
-  fontStyle: 'normal',
-  fontWeight: 400,
-  lineHeight: 'normal',
-  marginLeft: isCoreThirdLevel ? 4 : 14,
-  ...(isCoreThirdLevel && {
-    whiteSpace: 'revert',
-    overflow: 'revert',
-    textOverflow: 'revert',
-  }),
-  '& span': {
-    display: 'inline-block',
-    marginLeft: 4,
-  },
-}));
-
 const ContainerLegend = styled.div<{ isCoreThirdLevel: boolean; changeAlignment: boolean }>(
   ({ isCoreThirdLevel, changeAlignment }) => ({
     display: 'flex',
@@ -312,34 +321,41 @@ const ContainerLegend = styled.div<{ isCoreThirdLevel: boolean; changeAlignment:
     justifyContent: isCoreThirdLevel && changeAlignment ? 'flex-start' : changeAlignment ? 'flex-start' : 'center',
     gap: isCoreThirdLevel ? 16 : 14,
     maxWidth: '100%',
-    maxHeight: 210,
-    overflow: 'hidden',
-    ...(changeAlignment && {
-      flex: 1,
-    }),
-
     [lightTheme.breakpoints.up('desktop_1280')]: {
       gap: 16,
     },
   })
 );
 
-const IconWithName = styled.div({
-  display: 'flex',
-  flexDirection: 'row',
-  gap: 6,
-  alignItems: 'center',
-});
+const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean }>(({ isCoreThirdLevel }) => ({
+  display: 'none',
+  position: 'relative',
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    marginTop: !isCoreThirdLevel ? 10 : 0,
+    display: 'flex',
 
-const NameOrCode = styled.div<WithIsLight & { isCoreThirdLevel: boolean }>(({ isLight, isCoreThirdLevel }) => ({
-  color: isLight ? (isCoreThirdLevel ? '#708390' : '#434358') : '#EDEFFF',
-  fontFamily: 'Inter, sans-serif',
-  fontSize: 12,
-  fontStyle: 'normal',
-  fontWeight: 400,
-  lineHeight: 'normal',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  width: isCoreThirdLevel ? 'fit-content' : 170,
+    width: 200,
+  },
+
+  '& .swiper-slide': {
+    height: 'fit-content',
+    [lightTheme.breakpoints.up('tablet_768')]: {},
+  },
+  '& .swiper-wrapper': {},
+
+  '& .swiper-pagination-horizontal': {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  '& .swiper-pagination-bullet': {
+    width: 8,
+    height: 8,
+  },
+  '& .swiper-pagination-bullet-active': {
+    backgroundColor: '#2DC1B1 !important',
+  },
+  '& .swiper-slide-active': {
+    [lightTheme.breakpoints.up('tablet_768')]: {},
+  },
 }));

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -321,6 +321,7 @@ const ContainerLegend = styled.div<{ isCoreThirdLevel: boolean; changeAlignment:
     justifyContent: isCoreThirdLevel && changeAlignment ? 'flex-start' : changeAlignment ? 'flex-start' : 'center',
     gap: isCoreThirdLevel ? 16 : 14,
     maxWidth: '100%',
+    position: 'relative',
     [lightTheme.breakpoints.up('desktop_1280')]: {
       gap: 16,
     },
@@ -329,11 +330,9 @@ const ContainerLegend = styled.div<{ isCoreThirdLevel: boolean; changeAlignment:
 
 const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean }>(({ isCoreThirdLevel }) => ({
   display: 'none',
-  position: 'relative',
   [lightTheme.breakpoints.up('tablet_768')]: {
     marginTop: !isCoreThirdLevel ? 10 : 0,
     display: 'flex',
-
     width: 200,
   },
 
@@ -341,7 +340,10 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean }>(({ isCoreThirdLe
     height: 'fit-content',
     [lightTheme.breakpoints.up('tablet_768')]: {},
   },
-  '& .swiper-wrapper': {},
+
+  '& .swiper-pagination': {
+    bottom: '0 !important', // Its necessary for override the styles
+  },
 
   '& .swiper-pagination-horizontal': {
     display: 'flex',
@@ -351,6 +353,13 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean }>(({ isCoreThirdLe
   '& .swiper-pagination-bullet': {
     width: 8,
     height: 8,
+    borderRadius: 1,
+    '&:first-child': {
+      borderRadius: '6px 1px 1px 6px',
+    },
+    '&:last-child': {
+      borderRadius: '1px 6px 6px 1px',
+    },
   },
   '& .swiper-pagination-bullet-active': {
     backgroundColor: '#2DC1B1 !important',

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/utils.ts
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/utils.ts
@@ -1,0 +1,11 @@
+import type { DoughnutSeries } from '@ses/containers/Finances/utils/types';
+
+export const chunkArray = (array: DoughnutSeries[], chunkSize: number): Map<number, DoughnutSeries[]> => {
+  const result = new Map<number, DoughnutSeries[]>();
+
+  for (let i = 0; i < array.length; i += chunkSize) {
+    result.set(i / chunkSize, array.slice(i, i + chunkSize));
+  }
+
+  return result;
+};

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/CardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/CardChartOverview.tsx
@@ -17,6 +17,8 @@ interface Props {
   doughnutSeriesData: DoughnutSeries[];
   isCoreThirdLevel: boolean;
   changeAlignment: boolean;
+  showSwiper: boolean;
+  numberSliderPerLevel?: number;
 }
 const CardChartOverview: React.FC<Props> = ({
   filterSelected,
@@ -28,6 +30,8 @@ const CardChartOverview: React.FC<Props> = ({
   doughnutSeriesData,
   isCoreThirdLevel,
   changeAlignment,
+  showSwiper,
+  numberSliderPerLevel,
 }) => {
   const { isLight } = useThemeContext();
   const handleOnclick = (item: FilterDoughnut) => () => {
@@ -58,6 +62,8 @@ const CardChartOverview: React.FC<Props> = ({
             doughnutSeriesData={doughnutSeriesData}
             isCoreThirdLevel={isCoreThirdLevel}
             changeAlignment={changeAlignment}
+            showSwiper={showSwiper}
+            numberSliderPerLevel={numberSliderPerLevel}
           />
         </ContainerChat>
       </ContainerCardChart>

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -1,3 +1,4 @@
+import { useMediaQuery } from '@mui/material';
 import {
   existingColors,
   existingColorsDark,
@@ -6,6 +7,7 @@ import {
 } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { percentageRespectTo } from '@ses/core/utils/math';
+import lightTheme from '@ses/styles/theme/light';
 import { useState } from 'react';
 import type { BudgetMetricWithName, DoughnutSeries, FilterDoughnut } from '@ses/containers/Finances/utils/types';
 import type { BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
@@ -13,6 +15,8 @@ import type { Budget } from '@ses/core/models/interfaces/budget';
 const prefixToRemove = 'End-game';
 
 export const useCardChartOverview = (budgets: Budget[], budgetsAnalytics: BreakdownBudgetAnalytic | undefined) => {
+  const isTable = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
+  const isDesk1024 = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
   const filters: FilterDoughnut[] = ['Actual', 'Forecast', 'Net Expenses On-chain', 'Net Expenses Off-chain', 'Budget'];
   const [filterSelected, setFilterSelected] = useState<FilterDoughnut>('Budget');
   const { isLight } = useThemeContext();
@@ -98,6 +102,9 @@ export const useCardChartOverview = (budgets: Budget[], budgetsAnalytics: Breakd
     };
   });
   const changeAlignment = doughnutSeriesData.length > 4;
+
+  const showSwiper = (isTable || isDesk1024) && doughnutSeriesData.length > 4;
+
   return {
     actuals: metric.actuals,
     prediction: metric.forecast,
@@ -108,5 +115,6 @@ export const useCardChartOverview = (budgets: Budget[], budgetsAnalytics: Breakd
     filters,
     doughnutSeriesData,
     changeAlignment,
+    showSwiper,
   };
 };

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -103,7 +103,7 @@ export const useCardChartOverview = (budgets: Budget[], budgetsAnalytics: Breakd
   });
   const changeAlignment = doughnutSeriesData.length > 4;
 
-  const showSwiper = (isTable || isDesk1024) && doughnutSeriesData.length > 4;
+  const showSwiper = !!((isTable || isDesk1024) && doughnutSeriesData.length > 4);
 
   return {
     actuals: metric.actuals,


### PR DESCRIPTION
## Ticket
https://trello.com/c/JHKHOrzX/294-bsn-1-budget-summary-navigation

## Description
Add Swiper in the navigation card, when there is a lot items

## What solved
**RF59:** Should add the swiper for the third level in Doughnut Chart

