### PR TITLE
[QC] Fix finances year range

### DIFF
--- a/src/stories/containers/FinancesOverview/components/YearPicker/YearPicker.tsx
+++ b/src/stories/containers/FinancesOverview/components/YearPicker/YearPicker.tsx
@@ -59,7 +59,7 @@ const YearButton = styled(CustomButton)<WithIsLight & { selected: boolean }>(({ 
   borderRadius: '22px',
   fontFamily: 'Inter, sans serif',
   fontStyle: 'normal',
-  width: 83,
+  width: 75,
   height: 34,
 
   [lightTheme.breakpoints.up('tablet_768')]: {

--- a/src/stories/containers/FinancesOverview/useFinancesOverview.ts
+++ b/src/stories/containers/FinancesOverview/useFinancesOverview.ts
@@ -39,7 +39,7 @@ const useFinancesOverview = (
 
   const { isLight } = useThemeContext();
   const isDownDesktop1280 = useMediaQuery(lightTheme.breakpoints.down('desktop_1280'));
-  const years = [2021, 2022, 2023];
+  const years = Array.from({ length: new Date().getFullYear() - 2020 }, (_, i) => 2021 + i);
 
   const handleChangeSelectYear = (year: number) => {
     setSelectedYear(year);


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Show the current year (2024) in the finances year range.

## What solved
- [X] 2024 year should be added. **Current Output: **By default, 2024 data is displayed but the button related to this month is missing. 
