### PR TITLE
[QC] replace prediction by actuals

### DIFF
--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableRow.tsx
@@ -42,7 +42,7 @@ const ByBudgetTableRow: React.FC<ByBudgetTableRowProps> = ({
     <NavigableOnMobileRow isLight={isLight} isMobile={isMobile} href={link}>
       <MobileColumn>
         <NameColumnComponent isLight={isLight} shortCode={expense.shortCode ?? ''} name={expense.name} />
-        {isMobile && <TotalSpendColumnComponent isLight={isLight} total={expense.prediction} />}
+        {isMobile && <TotalSpendColumnComponent isLight={isLight} total={expense.actuals} />}
       </MobileColumn>
 
       <TotalPercentageColumnComponent
@@ -51,7 +51,7 @@ const ByBudgetTableRow: React.FC<ByBudgetTableRowProps> = ({
         expense={expense}
         maxPercentage={relativePercentage}
       />
-      {!isMobile && <TotalSpendColumnComponent isLight={isLight} total={expense.prediction} />}
+      {!isMobile && <TotalSpendColumnComponent isLight={isLight} total={expense.actuals} />}
 
       <ViewColumn isLight={isLight}>
         {isMobile ? (
@@ -92,7 +92,7 @@ const TotalPercentageColumnComponent: React.FC<
         prediction={expense.prediction || 0}
         maxPercentage={maxPercentage}
       />
-      <TotalPercentage isLight={isLight}>{Math.floor((expense.prediction * 100) / total)}%</TotalPercentage>
+      <TotalPercentage isLight={isLight}>{Math.floor((expense.actuals * 100) / total) || 0}%</TotalPercentage>
     </TotalBarContainer>
   </TotalPercentageColumn>
 );

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableRow.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableRow.tsx
@@ -28,7 +28,7 @@ const ByExpenseCategoryTableRow: React.FC<ByExpenseCategoryTableRowProps> = ({
     <Row isLight={isLight}>
       <MobileColumn>
         <NameColumnComponent name={name} isLight={isLight} />
-        {isMobile && <TotalSpendColumnComponent isLight={isLight} total={expense.prediction} />}
+        {isMobile && <TotalSpendColumnComponent isLight={isLight} total={expense.actuals} />}
       </MobileColumn>
 
       <TotalPercentageColumnComponent
@@ -38,7 +38,7 @@ const ByExpenseCategoryTableRow: React.FC<ByExpenseCategoryTableRowProps> = ({
         maxPercentage={relativePercentage}
       />
 
-      {!isMobile && <TotalSpendColumnComponent isLight={isLight} total={expense.prediction} />}
+      {!isMobile && <TotalSpendColumnComponent isLight={isLight} total={expense.actuals} />}
     </Row>
   );
 };
@@ -99,7 +99,7 @@ const TotalPercentageColumnComponent: React.FC<
         prediction={expense.prediction || 0}
         maxPercentage={maxPercentage}
       />
-      <TotalPercentage isLight={isLight}>{Math.floor((expense.prediction * 100) / total)}%</TotalPercentage>
+      <TotalPercentage isLight={isLight}>{Math.floor((expense.actuals * 100) / total) || 0}%</TotalPercentage>
     </TotalBarContainer>
   </TotalPercentageColumn>
 );

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/CostBreakdownTable.tsx
@@ -68,7 +68,10 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
                 <ByBudgetTableRow
                   expense={budget}
                   total={total}
-                  relativePercentage={percentageRespectTo(budget.prediction, maxValueByBudget)}
+                  relativePercentage={percentageRespectTo(
+                    Math.max(budget.actuals, budget.prediction),
+                    maxValueByBudget
+                  )}
                   rowType={
                     isCoreUnitExpense(budget)
                       ? 'coreUnit'
@@ -84,30 +87,27 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
                 <ByBudgetTableRow
                   expense={remainingBudgetCU}
                   total={total}
-                  relativePercentage={percentageRespectTo(
-                    remainingBudgetCU?.prediction,
-                    byBudgetExpenses[0]?.prediction
-                  )}
+                  relativePercentage={percentageRespectTo(remainingBudgetCU?.actuals, byBudgetExpenses[0]?.actuals)}
                   rowType={'remaining'}
                 />
-                {remainingBudgetDelegates?.prediction > 0 && (
+                {remainingBudgetDelegates?.actuals > 0 && (
                   <ByBudgetTableRow
                     expense={remainingBudgetDelegates}
                     total={total}
                     relativePercentage={percentageRespectTo(
-                      remainingBudgetDelegates?.prediction,
-                      byBudgetExpenses[0]?.prediction
+                      remainingBudgetDelegates?.actuals,
+                      byBudgetExpenses[0]?.actuals
                     )}
                     rowType={'remaining'}
                   />
                 )}
-                {remainingEcosystemActors?.prediction > 0 && (
+                {remainingEcosystemActors?.actuals > 0 && (
                   <ByBudgetTableRow
                     expense={remainingEcosystemActors}
                     total={total}
                     relativePercentage={percentageRespectTo(
-                      remainingEcosystemActors?.prediction,
-                      byBudgetExpenses[0]?.prediction
+                      remainingEcosystemActors?.actuals,
+                      byBudgetExpenses[0]?.actuals
                     )}
                     rowType={'remaining'}
                   />
@@ -125,7 +125,10 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
                   <ByExpenseCategoryTableRow
                     name={pascalCaseToNormalString(expense.category.split('/')[1])}
                     expense={expense}
-                    relativePercentage={percentageRespectTo(expense.prediction, maxValueByCategory)}
+                    relativePercentage={percentageRespectTo(
+                      Math.max(expense.actuals, expense.prediction),
+                      maxValueByCategory
+                    )}
                     total={total}
                     key={i}
                   />
@@ -136,7 +139,10 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
                   <ByExpenseCategoryTableRow
                     name={pascalCaseToNormalString(expense.category.split('/')[1])}
                     expense={expense}
-                    relativePercentage={percentageRespectTo(expense.prediction, maxValueByCategory)}
+                    relativePercentage={percentageRespectTo(
+                      Math.max(expense.actuals, expense.prediction),
+                      maxValueByCategory
+                    )}
                     total={total}
                     key={i}
                   />
@@ -146,7 +152,7 @@ const CostBreakdownTable: React.FC<CostBreakdownTableProps> = ({
                   <ByExpenseCategoryTableRow
                     name="All Remaining Categories"
                     expense={remainingCategories}
-                    relativePercentage={percentageRespectTo(remainingCategories.prediction, maxValueByCategory)}
+                    relativePercentage={percentageRespectTo(remainingCategories.actuals, maxValueByCategory)}
                     total={total}
                   />
                 </RemainingContainer>

--- a/src/stories/containers/FinancesOverview/useFinancesOverview.ts
+++ b/src/stories/containers/FinancesOverview/useFinancesOverview.ts
@@ -50,8 +50,8 @@ const useFinancesOverview = (
       (charValue) => DateTime.fromISO(charValue?.period || '').year === selectedYear
     );
 
-    const prediction = valuesYearSelect.map((item) => item?.prediction) || [];
-    const total = prediction?.reduce((current, next) => (current || 0) + (next || 0), 0);
+    const actuals = valuesYearSelect.map((item) => item?.actuals) || [];
+    const total = actuals?.reduce((current, next) => (current || 0) + (next || 0), 0);
 
     return Math.trunc(total || 0);
   }, [monthly, selectedYear]);
@@ -190,9 +190,9 @@ const useFinancesOverview = (
 
     byBudgetBreakdownExpenses
       .filter((expense) => expense.period === selectedYear.toString())
-      .sort((a, b) => b.prediction - a.prediction)
+      .sort((a, b) => b.actuals - a.actuals)
       .forEach((expense, index) => {
-        costBreakdownTotal += expense.prediction;
+        costBreakdownTotal += expense.actuals;
         if (index < 10) {
           byBudgetExpenses.push(expense);
         } else if (isCoreUnitExpense(expense)) {
@@ -205,8 +205,8 @@ const useFinancesOverview = (
       });
 
     const maxValueByBudget = Math.max(
-      ...[...byBudgetExpenses, remainingBudgetCU, remainingBudgetDelegates, remainingEcosystemActors].map(
-        (item) => item.prediction
+      ...[...byBudgetExpenses, remainingBudgetCU, remainingBudgetDelegates, remainingEcosystemActors].map((item) =>
+        Math.max(item.actuals, item.prediction)
       )
     );
 
@@ -237,7 +237,7 @@ const useFinancesOverview = (
 
     byCategoryBreakdownExpenses
       .filter((expense) => expense.period === selectedYear.toString())
-      .sort((a, b) => b.prediction - a.prediction)
+      .sort((a, b) => b.actuals - a.actuals)
       .forEach((expense) => {
         if (isHeadcountExpense(expense)) {
           byCategoryExpenses.headcount.push(expense);
@@ -249,8 +249,8 @@ const useFinancesOverview = (
       });
 
     const maxValueByCategory = Math.max(
-      ...[...byCategoryExpenses.headcount, ...byCategoryExpenses.nonHeadcount, remainingCategories].map(
-        (item) => item.prediction
+      ...[...byCategoryExpenses.headcount, ...byCategoryExpenses.nonHeadcount, remainingCategories].map((item) =>
+        Math.max(item.actuals, item.prediction)
       )
     );
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
replace the prediction by the actuals field in the breakdown table

## What solved
- [X] **Expected Output:** Data from predictions to reported actuals (including the totals + last row) should be changed. 

