### PR TITLE
[RMV-1] Implement the Milestones details card aside

### DIFF
--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -152,6 +152,7 @@ const dictionary = [
   'linecap',
   'toggleable',
   'Roadmaps',
+  'nums',
 ];
 
 module.exports = dictionary;

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.stories.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.stories.tsx
@@ -49,26 +49,26 @@ LightMode.parameters = {
         },
       },
       1024: {
-        component: '',
+        component: 'https://www.figma.com/file/nubRdNZLDrQJLDgh8caMrQ/Untitled?type=design&node-id=1612-34674',
         options: {
           componentStyle: {
-            width: 181.4,
+            width: 960,
           },
           style: {
-            top: -20,
-            left: -40,
+            top: -4,
+            left: 0,
           },
         },
       },
       1280: {
-        component: '',
+        component: 'https://www.figma.com/file/nubRdNZLDrQJLDgh8caMrQ/Untitled?type=design&node-id=1616-37493',
         options: {
           componentStyle: {
-            width: 223.8,
+            width: 1184,
           },
           style: {
-            top: -20,
-            left: -40,
+            top: -4,
+            left: 0,
           },
         },
       },

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.stories.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.stories.tsx
@@ -37,14 +37,14 @@ LightMode.parameters = {
         },
       },
       768: {
-        component: '',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=28417-454588',
         options: {
           componentStyle: {
-            width: 133,
+            width: 704,
           },
           style: {
-            top: -20,
-            left: -40,
+            top: -3,
+            left: -17,
           },
         },
       },

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.stories.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.stories.tsx
@@ -25,14 +25,14 @@ LightMode.parameters = {
   figma: {
     component: {
       0: {
-        component: '',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=28869-260079',
         options: {
           componentStyle: {
             width: 343,
           },
           style: {
-            top: -2,
-            left: -6,
+            top: -20,
+            left: -40,
           },
         },
       },

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
@@ -43,8 +43,14 @@ const MilestoneDetailsCard: React.FC = () => (
     </MobileHeader>
     <Aside>
       <AsideContent>
+        <Code>BASE</Code>
         <MilestoneProgress />
+        <Divider />
         <StatsData />
+        <Divider />
+        <div>coordinators</div>
+        <Divider />
+        <div>Ecosystem Actors</div>
       </AsideContent>
       <DescriptionContent>
         <Paragraph>
@@ -61,7 +67,28 @@ const MilestoneDetailsCard: React.FC = () => (
       </DescriptionContent>
     </Aside>
     <MilestoneContent>
-      <DeliverablesSection>all deliverables here...</DeliverablesSection>
+      <ShowOn1024Up>
+        <HeaderGroupBox>
+          <Name>Exploration Base</Name>
+          <MilestoneNumber>Milestone 1</MilestoneNumber>
+        </HeaderGroupBox>
+
+        <DescriptionContentForDesktop>
+          <Paragraph>
+            Feature exploration and open design questions, smart contracts project, chatbot, UI intergration, marcomms
+            project.
+          </Paragraph>
+          <Paragraph>
+            Milestone 1, set for August 1, marks the initial phase of Exploration Base. Projects include Smart
+            Contracts, focused on establishing foundations and addressing design questions. The Chatbot Project aims to
+            enhance the conversational UX with low hanging fruit execution, prioritizing clarity and correctness.
+            Overall, this milestone lays the groundwork, explores design possibilities, and strives to improve the user
+            experience in the MakerDAO ecosystem.
+          </Paragraph>
+        </DescriptionContentForDesktop>
+      </ShowOn1024Up>
+
+      <DeliverablesSection>Deliverables section WIP</DeliverablesSection>
     </MilestoneContent>
   </Card>
 );
@@ -69,6 +96,7 @@ const MilestoneDetailsCard: React.FC = () => (
 export default MilestoneDetailsCard;
 
 const Card = styled('article')(({ theme }) => ({
+  position: 'relative',
   background: theme.palette.mode === 'light' ? '#fff' : 'red',
   border: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'red'}`,
   borderRadius: 6,
@@ -81,6 +109,15 @@ const Card = styled('article')(({ theme }) => ({
       theme.palette.mode === 'light'
         ? '1px 1px 5px 0px rgba(190, 190, 190, 0.25), 0px 12px 16px 0px rgba(219, 227, 237, 0.40)'
         : '1px 1px 5px 0px red, 0px 12px 16px 0px red',
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    padding: 0,
+    background: 'transparent',
+    border: 'none',
+    boxShadow: 'none',
+    display: 'flex',
+    gap: 24,
   },
 }));
 
@@ -106,6 +143,10 @@ const HeaderGroupBox = styled('div')(({ theme }) => ({
 
   [theme.breakpoints.up('tablet_768')]: {
     gap: 16,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    marginBottom: 24,
   },
 }));
 
@@ -136,6 +177,15 @@ const Name = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('tablet_768')]: {
     display: 'none',
   },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'block',
+    fontSize: 20,
+    fontWeight: 600,
+    lineHeight: 'normal',
+    letterSpacing: 0.4,
+    color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  },
 }));
 
 const MilestoneNumber = styled('div')(({ theme }) => ({
@@ -150,6 +200,12 @@ const MilestoneNumber = styled('div')(({ theme }) => ({
     fontSize: 16,
     fontWeight: 700,
   },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontSize: 20,
+    fontWeight: 600,
+    letterSpacing: 0.4,
+  },
 }));
 
 const Aside = styled('aside')(({ theme }) => ({
@@ -161,6 +217,21 @@ const Aside = styled('aside')(({ theme }) => ({
     flexDirection: 'row',
     gap: 32,
     marginTop: 32,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    flexDirection: 'column',
+    marginTop: 0,
+    width: 306,
+    height: 'fit-content',
+    padding: '24px 16px',
+    alignItems: 'flex-start',
+    alignSelf: 'stretch',
+    borderRadius: '0 0 6px 6px',
+    background: theme.palette.mode === 'light' ? '#F6F8F9' : 'red',
+    position: 'sticky',
+    top: 140,
+    gap: 40,
   },
 }));
 
@@ -174,6 +245,32 @@ const AsideContent = styled('div')(({ theme }) => ({
     width: 336,
     minWidth: 336,
   },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    width: '100%',
+    minWidth: '100%',
+  },
+}));
+
+const Divider = styled('div')(({ theme }) => ({
+  display: 'none',
+  width: '100%',
+  position: 'relative',
+  height: 17,
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'block',
+
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      width: 'calc(100% - 32px)',
+      height: 1,
+      background: theme.palette.mode === 'light' ? '#D4D9E1' : 'red',
+      top: 8,
+      left: 16,
+    },
+  },
 }));
 
 const DescriptionContent = styled('div')(({ theme }) => ({
@@ -184,6 +281,10 @@ const DescriptionContent = styled('div')(({ theme }) => ({
     flexDirection: 'column',
     gap: 16,
   },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'none',
+  },
 }));
 
 const Paragraph = styled('p')(({ theme }) => ({
@@ -193,6 +294,32 @@ const Paragraph = styled('p')(({ theme }) => ({
   color: theme.palette.mode === 'light' ? '#231536' : 'red',
 }));
 
-const MilestoneContent = styled('div')({});
+const MilestoneContent = styled('div')(({ theme }) => ({
+  [theme.breakpoints.up('desktop_1024')]: {
+    paddingTop: 24,
+  },
+}));
 
-const DeliverablesSection = styled('div')({});
+const ShowOn1024Up = styled('div')(({ theme }) => ({
+  display: 'none',
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'block',
+  },
+}));
+
+const DescriptionContentForDesktop = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+}));
+
+const DeliverablesSection = styled('div')({
+  marginTop: 32,
+  borderRadius: 8,
+  background: '#F6F8F9',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: '16px 0',
+});

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
@@ -42,9 +42,23 @@ const MilestoneDetailsCard: React.FC = () => (
       </HeaderGroupBox>
     </MobileHeader>
     <Aside>
-      <MilestoneProgress />
-      <StatsData />
-      stats, charts, coordinators and ecosystem actors
+      <AsideContent>
+        <MilestoneProgress />
+        <StatsData />
+      </AsideContent>
+      <DescriptionContent>
+        <Paragraph>
+          Feature exploration and open design questions, smart contracts project, chatbot, UI intergration, marcomms
+          project.
+        </Paragraph>
+        <Paragraph>
+          Milestone 1, set for August 1, marks the initial phase of Exploration Base. Projects include Smart Contracts,
+          focused on establishing foundations and addressing design questions. The Chatbot Project aims to enhance the
+          conversational UX with low hanging fruit execution, prioritizing clarity and correctness. Overall, this
+          milestone lays the groundwork, explores design possibilities, and strives to improve the user experience in
+          the MakerDAO ecosystem.
+        </Paragraph>
+      </DescriptionContent>
     </Aside>
     <MilestoneContent>
       <DeliverablesSection>all deliverables here...</DeliverablesSection>
@@ -59,6 +73,15 @@ const Card = styled('article')(({ theme }) => ({
   border: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'red'}`,
   borderRadius: 6,
   padding: '16px 16px 24px 16px',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    padding: 24,
+    border: `1px solid ${theme.palette.mode === 'light' ? '#F6F8F9' : 'red'}`,
+    boxShadow:
+      theme.palette.mode === 'light'
+        ? '1px 1px 5px 0px rgba(190, 190, 190, 0.25), 0px 12px 16px 0px rgba(219, 227, 237, 0.40)'
+        : '1px 1px 5px 0px red, 0px 12px 16px 0px red',
+  },
 }));
 
 const MobileHeader = styled('div')(({ theme }) => ({
@@ -129,12 +152,46 @@ const MilestoneNumber = styled('div')(({ theme }) => ({
   },
 }));
 
-const Aside = styled('aside')({
+const Aside = styled('aside')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  marginTop: 16,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    flexDirection: 'row',
+    gap: 32,
+    marginTop: 32,
+  },
+}));
+
+const AsideContent = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: 16,
-  marginTop: 16,
-});
+
+  [theme.breakpoints.up('tablet_768')]: {
+    gap: 32,
+    width: 336,
+    minWidth: 336,
+  },
+}));
+
+const DescriptionContent = styled('div')(({ theme }) => ({
+  display: 'none',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+  },
+}));
+
+const Paragraph = styled('p')(({ theme }) => ({
+  margin: 0,
+  fontSize: 16,
+  lineHeight: '22px',
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+}));
 
 const MilestoneContent = styled('div')({});
 

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
@@ -2,7 +2,8 @@ import { styled } from '@mui/system';
 import ProjectOwnerChip from '@ses/containers/ActorProjects/components/ProjectOwnerChip/ProjectOwnerChip';
 import SupportedTeamsAvatarGroup from '@ses/containers/ActorProjects/components/SupportedTeamsAvatarGroup/SupportedTeamsAvatarGroup';
 import { OwnerType } from '@ses/core/models/interfaces/projects';
-import PercentageProgressBar from './PercentageProgressBar';
+import MilestoneProgress from './MilestoneProgress';
+import StatsData from './StatsData';
 
 const MilestoneDetailsCard: React.FC = () => (
   <Card>
@@ -41,7 +42,8 @@ const MilestoneDetailsCard: React.FC = () => (
       </HeaderGroupBox>
     </MobileHeader>
     <Aside>
-      <PercentageProgressBar value={75.0} />
+      <MilestoneProgress />
+      <StatsData />
       stats, charts, coordinators and ecosystem actors
     </Aside>
     <MilestoneContent>
@@ -127,7 +129,12 @@ const MilestoneNumber = styled('div')(({ theme }) => ({
   },
 }));
 
-const Aside = styled('aside')({});
+const Aside = styled('aside')({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  marginTop: 16,
+});
 
 const MilestoneContent = styled('div')({});
 

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
@@ -43,7 +43,9 @@ const MilestoneDetailsCard: React.FC = () => (
     </MobileHeader>
     <Aside>
       <AsideContent>
-        <Code>BASE</Code>
+        <CodeBox>
+          <Code>BASE</Code>
+        </CodeBox>
         <MilestoneProgress />
         <Divider />
         <StatsData />
@@ -118,6 +120,10 @@ const Card = styled('article')(({ theme }) => ({
     boxShadow: 'none',
     display: 'flex',
     gap: 24,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    gap: 48,
   },
 }));
 
@@ -223,6 +229,7 @@ const Aside = styled('aside')(({ theme }) => ({
     flexDirection: 'column',
     marginTop: 0,
     width: 306,
+    minWidth: 306,
     height: 'fit-content',
     padding: '24px 16px',
     alignItems: 'flex-start',
@@ -231,7 +238,12 @@ const Aside = styled('aside')(({ theme }) => ({
     background: theme.palette.mode === 'light' ? '#F6F8F9' : 'red',
     position: 'sticky',
     top: 140,
-    gap: 40,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    width: 383,
+    minWidth: 383,
+    padding: '24px 32px 24px 24px',
   },
 }));
 
@@ -247,8 +259,17 @@ const AsideContent = styled('div')(({ theme }) => ({
   },
 
   [theme.breakpoints.up('desktop_1024')]: {
+    gap: 40,
     width: '100%',
     minWidth: '100%',
+  },
+}));
+
+const CodeBox = styled('div')(({ theme }) => ({
+  display: 'none',
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
   },
 }));
 

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
@@ -1,3 +1,55 @@
-const MilestoneProgress: React.FC = () => <div>progress</div>;
+import { styled } from '@mui/material';
+import PercentageProgressBar from './PercentageProgressBar';
+
+const MilestoneProgress: React.FC = () => (
+  <OutlinedCard>
+    <PercentageProgressBar value={75.0} />
+
+    <TextProgressBox>
+      <TextProgress>
+        <span>55</span>/<span>74</span> Story Points Completed
+      </TextProgress>
+
+      <TextProgress>
+        <span>1</span>/<span>6</span> Deliverables Completed
+      </TextProgress>
+    </TextProgressBox>
+  </OutlinedCard>
+);
 
 export default MilestoneProgress;
+
+const OutlinedCard = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: 16,
+  alignSelf: 'stretch',
+  padding: '16px 0',
+  borderRadius: 6,
+  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : 'red'}`,
+}));
+
+const TextProgressBox = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 16,
+}));
+
+const TextProgress = styled('span')(({ theme }) => ({
+  fontSize: 14,
+  fontWeight: 500,
+  lineHeight: '18px',
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+
+  '& span:nth-child(1)': {
+    color: theme.palette.mode === 'light' ? '#1AAB9B' : 'red',
+  },
+
+  '& span:nth-child(2)': {
+    color: theme.palette.mode === 'light' ? '#708390' : 'red',
+    fontWeight: 700,
+  },
+}));

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
@@ -33,6 +33,11 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('tablet_768')]: {
     borderRadius: 16,
   },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    padding: 0,
+    border: 'none',
+  },
 }));
 
 const TextProgressBox = styled('div')(() => ({

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
@@ -29,6 +29,10 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   padding: '16px 0',
   borderRadius: 6,
   border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : 'red'}`,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    borderRadius: 16,
+  },
 }));
 
 const TextProgressBox = styled('div')(() => ({

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
@@ -40,11 +40,15 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   },
 }));
 
-const TextProgressBox = styled('div')(() => ({
+const TextProgressBox = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   gap: 16,
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 12,
+  },
 }));
 
 const TextProgress = styled('span')(({ theme }) => ({

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/PercentageProgressBar.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/PercentageProgressBar.tsx
@@ -1,16 +1,27 @@
-import { CircularProgress, circularProgressClasses, styled } from '@mui/material';
+import { CircularProgress, circularProgressClasses, styled, useMediaQuery } from '@mui/material';
+import type { Theme } from '@mui/material';
 
 interface PercentageProgressBarProps {
   value: number;
 }
 
-const PercentageProgressBar: React.FC<PercentageProgressBarProps> = ({ value }) => (
-  <BarContainer>
-    <CircularBarBase variant="determinate" size={103} thickness={7} value={100} />
-    <CircularBarProgress variant="determinate" dir="rtl" size={103} thickness={7} value={value} />
-    <LabelContainer>{Math.round(value)}%</LabelContainer>
-  </BarContainer>
-);
+const PercentageProgressBar: React.FC<PercentageProgressBarProps> = ({ value }) => {
+  const isUp1024 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1024'));
+
+  return (
+    <BarContainer>
+      <CircularBarBase variant="determinate" size={isUp1024 ? 160 : 103} thickness={isUp1024 ? 11 : 7} value={100} />
+      <CircularBarProgress
+        variant="determinate"
+        dir="rtl"
+        size={isUp1024 ? 160 : 103}
+        thickness={isUp1024 ? 11 : 7}
+        value={value}
+      />
+      <LabelContainer>{Math.round(value)}%</LabelContainer>
+    </BarContainer>
+  );
+};
 
 export default PercentageProgressBar;
 
@@ -44,4 +55,9 @@ const LabelContainer = styled('div')(({ theme }) => ({
   justifyContent: 'center',
   color: theme.palette.mode === 'light' ? '#231536' : 'red',
   fontWeight: 700,
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontSize: 17.8,
+    letterSpacing: 0.4,
+  },
 }));

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/PercentageProgressBar.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/PercentageProgressBar.tsx
@@ -6,8 +6,8 @@ interface PercentageProgressBarProps {
 
 const PercentageProgressBar: React.FC<PercentageProgressBarProps> = ({ value }) => (
   <BarContainer>
-    <CircularBarBase variant="determinate" size={103} thickness={6} value={100} />
-    <CircularBarProgress variant="determinate" dir="rtl" size={103} thickness={6} value={value} />
+    <CircularBarBase variant="determinate" size={103} thickness={7} value={100} />
+    <CircularBarProgress variant="determinate" dir="rtl" size={103} thickness={7} value={value} />
     <LabelContainer>{Math.round(value)}%</LabelContainer>
   </BarContainer>
 );

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
@@ -56,6 +56,10 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   padding: 15,
   borderRadius: 6,
   border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : 'red'}`,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    borderRadius: 16,
+  },
 }));
 
 const Row = styled('div')(() => ({
@@ -85,6 +89,10 @@ const Value = styled('div')(({ theme }) => ({
   fontSize: 14,
   fontWeight: 700,
   color: theme.palette.mode === 'light' ? '#231536' : 'red',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 16,
+  },
 
   '& span': {
     fontSize: 16,
@@ -136,13 +144,6 @@ const LegendItem = styled('div')<{ dotColor: string }>(({ theme, dotColor }) => 
   alignItems: 'baseline',
   height: 'fit-content',
 
-  [theme.breakpoints.up('tablet_768')]: {
-    fontSize: 14,
-    lineHeight: '17px',
-    alignItems: 'center',
-    paddingRight: 10,
-  },
-
   [theme.breakpoints.up('desktop_1024')]: {
     paddingRight: 10,
   },
@@ -182,12 +183,6 @@ const LegendNumber = styled('div')(({ theme }) => ({
   fontVariantNumeric: 'lining-nums tabular-nums',
   letterSpacing: '0.3px',
 
-  [theme.breakpoints.up('tablet_768')]: {
-    fontSize: 12,
-    lineHeight: 'normal',
-    letterSpacing: '0.3px',
-  },
-
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 14,
     letterSpacing: 'normal',
@@ -207,12 +202,6 @@ const LegendNumberSuffix = styled('div')(({ theme }) => ({
   letterSpacing: '1px',
   fontWeight: 600,
 
-  [theme.breakpoints.up('tablet_768')]: {
-    fontSize: 10,
-    lineHeight: 'normal',
-    textTransform: 'uppercase',
-  },
-
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 12,
     marginLeft: 0,
@@ -226,13 +215,6 @@ const LegendNumberSuffix = styled('div')(({ theme }) => ({
 
 const LegendLabel = styled('div')(({ theme }) => ({
   marginLeft: 3.1,
-
-  [theme.breakpoints.up('tablet_768')]: {
-    marginLeft: 2,
-    fontWeight: 400,
-    fontSize: 12,
-    lineHeight: 'normal',
-  },
 
   [theme.breakpoints.up('desktop_1280')]: {
     marginLeft: 6,

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
@@ -1,10 +1,12 @@
-import { styled } from '@mui/material';
+import { styled, useMediaQuery } from '@mui/material';
 import HorizontalBudgetBar from '@ses/containers/FinancesOverview/components/HorizontalBudgetBar/HorizontalBudgetBar';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { threeDigitsPrecisionHumanization, usLocalizedNumber } from '@ses/core/utils/humanization';
+import type { Theme } from '@mui/material';
 
 const StatsData: React.FC = () => {
   const { isLight } = useThemeContext();
+  const isUp1024 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1024'));
   const humanizedActuals = threeDigitsPrecisionHumanization(20252244);
   const humanizedBudgetCap = threeDigitsPrecisionHumanization(45225544);
 
@@ -15,7 +17,7 @@ const StatsData: React.FC = () => {
         <Value>Q4 2023</Value>
       </Row>
       <Row>
-        <Label>Estimated Budget Cap</Label>
+        <Label>{isUp1024 ? 'Est.' : 'Estimated'} Budget Cap</Label>
         <Value>
           {usLocalizedNumber(12927312, 0)} <span>DAI</span>
         </Value>
@@ -64,6 +66,7 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('desktop_1024')]: {
     padding: 0,
     border: 'none',
+    gap: 24,
   },
 }));
 
@@ -121,6 +124,10 @@ const Percentage = styled('div')(({ theme }) => ({
   letterSpacing: 0.4,
   color: theme.palette.mode === 'light' ? '#231536' : 'red',
   fontVariantNumeric: 'lining-nums tabular-nums',
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontSize: 24,
+  },
 }));
 
 const ExtendedHorizontalBudgetBar = styled(HorizontalBudgetBar)({

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
@@ -53,7 +53,7 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   alignItems: 'flex-start',
   gap: 16,
   alignSelf: 'stretch',
-  padding: 16,
+  padding: 15,
   borderRadius: 6,
   border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : 'red'}`,
 }));
@@ -64,6 +64,7 @@ const Row = styled('div')(() => ({
   alignItems: 'center',
   alignSelf: 'stretch',
   gap: 16,
+  lineHeight: 'normal',
 }));
 
 const Label = styled('div')(({ theme }) => ({
@@ -72,6 +73,7 @@ const Label = styled('div')(({ theme }) => ({
   letterSpacing: 1,
   textTransform: 'uppercase',
   color: theme.palette.mode === 'light' ? '#434358' : 'red',
+  alignSelf: 'normal',
 }));
 
 const Value = styled('div')(({ theme }) => ({
@@ -95,7 +97,7 @@ const BudgetBox = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  gap: 8,
+  gap: 3,
   alignSelf: 'stretch',
 }));
 
@@ -121,17 +123,17 @@ const Legend = styled('div')({
   display: 'flex',
   justifyContent: 'space-between',
   width: '100%',
+  marginTop: 5,
 });
 
 const LegendItem = styled('div')<{ dotColor: string }>(({ theme, dotColor }) => ({
   position: 'relative',
-  fontSize: 10,
-  lineHeight: '12px',
-  fontWeight: 500,
+  fontSize: 14,
+  lineHeight: 'normal',
   color: theme.palette.mode === 'light' ? '#231536' : '#EDEFFF',
-  paddingRight: 6,
+  paddingRight: 10,
   display: 'flex',
-  alignItems: 'flex-start ',
+  alignItems: 'baseline',
   height: 'fit-content',
 
   [theme.breakpoints.up('tablet_768')]: {
@@ -153,10 +155,10 @@ const LegendItem = styled('div')<{ dotColor: string }>(({ theme, dotColor }) => 
     content: '""',
     display: 'block',
     position: 'absolute',
-    top: 'calc(50% - 0.5px)',
+    top: 'calc(50% - 4px)',
     right: 0,
-    width: 4,
-    height: 4,
+    width: 8,
+    height: 8,
     borderRadius: '50%',
     backgroundColor: dotColor,
 
@@ -175,9 +177,10 @@ const LegendNumberWrapper = styled('div')({
 
 const LegendNumber = styled('div')(({ theme }) => ({
   fontWeight: 700,
-  fontSize: 10,
-  lineHeight: '12px',
-  fontFeatureSettings: "'tnum' on, 'lnum' on",
+  fontSize: 16,
+  lineHeight: 'normal',
+  fontVariantNumeric: 'lining-nums tabular-nums',
+  letterSpacing: '0.3px',
 
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 12,
@@ -198,15 +201,15 @@ const LegendNumber = styled('div')(({ theme }) => ({
 }));
 
 const LegendNumberSuffix = styled('div')(({ theme }) => ({
-  fontSize: 7,
-  lineHeight: '8px',
+  fontSize: 12,
+  lineHeight: 'normal',
   marginLeft: 1.1,
+  letterSpacing: '1px',
+  fontWeight: 600,
 
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 10,
-    fontWeight: 600,
     lineHeight: 'normal',
-    letterSpacing: '1px',
     textTransform: 'uppercase',
   },
 

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
@@ -60,6 +60,11 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('tablet_768')]: {
     borderRadius: 16,
   },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    padding: 0,
+    border: 'none',
+  },
 }));
 
 const Row = styled('div')(() => ({

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
@@ -1,0 +1,239 @@
+import { styled } from '@mui/material';
+import HorizontalBudgetBar from '@ses/containers/FinancesOverview/components/HorizontalBudgetBar/HorizontalBudgetBar';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { threeDigitsPrecisionHumanization, usLocalizedNumber } from '@ses/core/utils/humanization';
+
+const StatsData: React.FC = () => {
+  const { isLight } = useThemeContext();
+  const humanizedActuals = threeDigitsPrecisionHumanization(20252244);
+  const humanizedBudgetCap = threeDigitsPrecisionHumanization(45225544);
+
+  return (
+    <OutlinedCard>
+      <Row>
+        <Label>Target date</Label>
+        <Value>Q4 2023</Value>
+      </Row>
+      <Row>
+        <Label>Estimated Budget Cap</Label>
+        <Value>
+          {usLocalizedNumber(12927312, 0)} <span>DAI</span>
+        </Value>
+      </Row>
+
+      <BudgetBox>
+        <Percentage>58%</Percentage>
+        <ExtendedHorizontalBudgetBar actuals={200} prediction={250} budgetCap={300} />
+        <Legend>
+          <LegendItem dotColor={isLight ? '#2DC1B1' : '#1AAB9B'}>
+            <LegendNumberWrapper>
+              <LegendNumber>{humanizedActuals.value}</LegendNumber>
+              <LegendNumberSuffix>{humanizedActuals.suffix}</LegendNumberSuffix>
+            </LegendNumberWrapper>
+            <LegendLabel>Actuals</LegendLabel>
+          </LegendItem>
+          <LegendItem dotColor={'#F75524'}>
+            <LegendNumberWrapper>
+              <LegendNumber>{humanizedBudgetCap.value}</LegendNumber>
+              <LegendNumberSuffix>{humanizedBudgetCap.suffix}</LegendNumberSuffix>
+            </LegendNumberWrapper>
+            <LegendLabel>Cap</LegendLabel>
+          </LegendItem>
+        </Legend>
+      </BudgetBox>
+    </OutlinedCard>
+  );
+};
+
+export default StatsData;
+
+const OutlinedCard = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  gap: 16,
+  alignSelf: 'stretch',
+  padding: 16,
+  borderRadius: 6,
+  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : 'red'}`,
+}));
+
+const Row = styled('div')(() => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  alignSelf: 'stretch',
+  gap: 16,
+}));
+
+const Label = styled('div')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 600,
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  color: theme.palette.mode === 'light' ? '#434358' : 'red',
+}));
+
+const Value = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'flex-end',
+  flexWrap: 'nowrap',
+  alignSelf: 'normal',
+  gap: 4,
+  fontSize: 14,
+  fontWeight: 700,
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+
+  '& span': {
+    fontSize: 16,
+    fontWeight: 700,
+    color: theme.palette.mode === 'light' ? '#9FAFB9' : 'red',
+  },
+}));
+
+const BudgetBox = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 8,
+  alignSelf: 'stretch',
+}));
+
+const Percentage = styled('div')(({ theme }) => ({
+  fontSize: 20,
+  fontWeight: 600,
+  lineHeight: 'normal',
+  letterSpacing: 0.4,
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  fontVariantNumeric: 'lining-nums tabular-nums',
+}));
+
+const ExtendedHorizontalBudgetBar = styled(HorizontalBudgetBar)({
+  height: 16,
+  borderRadius: 8,
+
+  '& > div': {
+    borderRadius: 8,
+  },
+});
+
+const Legend = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-between',
+  width: '100%',
+});
+
+const LegendItem = styled('div')<{ dotColor: string }>(({ theme, dotColor }) => ({
+  position: 'relative',
+  fontSize: 10,
+  lineHeight: '12px',
+  fontWeight: 500,
+  color: theme.palette.mode === 'light' ? '#231536' : '#EDEFFF',
+  paddingRight: 6,
+  display: 'flex',
+  alignItems: 'flex-start ',
+  height: 'fit-content',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 14,
+    lineHeight: '17px',
+    alignItems: 'center',
+    paddingRight: 10,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    paddingRight: 10,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    paddingRight: 12,
+  },
+
+  '&::after': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 'calc(50% - 0.5px)',
+    right: 0,
+    width: 4,
+    height: 4,
+    borderRadius: '50%',
+    backgroundColor: dotColor,
+
+    [theme.breakpoints.up('tablet_768')]: {
+      width: 8,
+      height: 8,
+      top: 'calc(50% - 4px)',
+    },
+  },
+}));
+
+const LegendNumberWrapper = styled('div')({
+  display: 'flex',
+  alignItems: 'baseline',
+});
+
+const LegendNumber = styled('div')(({ theme }) => ({
+  fontWeight: 700,
+  fontSize: 10,
+  lineHeight: '12px',
+  fontFeatureSettings: "'tnum' on, 'lnum' on",
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 12,
+    lineHeight: 'normal',
+    letterSpacing: '0.3px',
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontSize: 14,
+    letterSpacing: 'normal',
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    fontSize: 16,
+    letterSpacing: '0.3px',
+    lineHeight: '18px',
+  },
+}));
+
+const LegendNumberSuffix = styled('div')(({ theme }) => ({
+  fontSize: 7,
+  lineHeight: '8px',
+  marginLeft: 1.1,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 10,
+    fontWeight: 600,
+    lineHeight: 'normal',
+    letterSpacing: '1px',
+    textTransform: 'uppercase',
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontSize: 12,
+    marginLeft: 0,
+    letterSpacing: 'normal',
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    letterSpacing: '1px',
+  },
+}));
+
+const LegendLabel = styled('div')(({ theme }) => ({
+  marginLeft: 3.1,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    marginLeft: 2,
+    fontWeight: 400,
+    fontSize: 12,
+    lineHeight: 'normal',
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    marginLeft: 6,
+    fontSize: 14,
+    lineHeight: '18px',
+  },
+}));


### PR DESCRIPTION
## Ticket
https://trello.com/c/HIe66Yme/297-rmv-1-roadmaps-and-milestones-view

## Description
Implement the Milestones details card

## What solved
- [X] Should show the details of the milestones in two sections, one for the stats/progress bars and the other for the deliverables. On mobile and 768 it should be one column and two columns from >1024 resolutions. 
- [X] Should be included in the section header the name, the specific milestone number, and two short paragraphs.
- [X] Should not be displayed the paragraphs in mobile
- [X] Should be displayed above the progress indicator the code name
- [X] Should be displayed to the left of the section header a cylindrical visual progress indicator with a percentage in the middle. 
- [X] Should be represented below the progress indicator, the Milestone progress status: To do, In Progress, Finished.
- [X] Should the In Progress status have representations: With no progress bar, Progress bar with both percentage and deliverables completed as default (always available)
