### PR TITLE
Hotfix: finances page chart tooltip and breakdown table labels

### DIFF
--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableHeader.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByBudgetTableHeader.tsx
@@ -12,7 +12,7 @@ const ByBudgetTableHeader: React.FC = () => {
     <TableHeader isLight={isLight}>
       <BudgetColumn>Budget</BudgetColumn>
       <TotalPercentageColumn>% of total</TotalPercentageColumn>
-      <TotalSpendColumn>Total Spend</TotalSpendColumn>
+      <TotalSpendColumn>Actuals</TotalSpendColumn>
       <ViewColumn />
     </TableHeader>
   );

--- a/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableHeader.tsx
+++ b/src/stories/containers/FinancesOverview/components/CostBreakdownTable/ByExpenseCategoryTableHeader.tsx
@@ -18,7 +18,7 @@ const ByExpenseCategoryTableHeader: React.FC<Props> = ({ onClick }) => (
     </CategoryColumn>
 
     <TotalPercentageColumn>% of total</TotalPercentageColumn>
-    <TotalSpendColumn>Total spend</TotalSpendColumn>
+    <TotalSpendColumn>Actuals</TotalSpendColumn>
   </TableHeader>
 );
 

--- a/src/stories/containers/FinancesOverview/components/ExpensesChart/ExpensesChart.tsx
+++ b/src/stories/containers/FinancesOverview/components/ExpensesChart/ExpensesChart.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
+import { formatNumber, replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import ReactECharts from 'echarts-for-react';
 
@@ -24,6 +24,42 @@ const ExpensesChart: React.FC<Props> = ({ newActual, newDiscontinued, newPredict
   const isZeroValue = false;
 
   const options = {
+    tooltip: {
+      show: upTable,
+      trigger: 'axis',
+      axisPointer: {
+        type: 'shadow',
+        shadowStyle: {
+          color: isLight ? '#D4D9E1' : '#231536',
+          opacity: 0.15,
+        },
+      },
+      padding: 0,
+      borderWidth: 1,
+      borderColor: isLight ? '#D4D9E1' : '#231536',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      formatter: function (params: any[]) {
+        return `
+          <div style="background-color:${
+            isLight ? '#fff' : '#000A13'
+          };padding:16px;minWidth:194px;overflow:auto;border-radius:3px;"> 
+            <div style="margin-bottom:16px;font-size:12px;font-weight:600;color:#B6BCC2;">${params?.[0]?.name}</div> 
+            <div style="display:flex;flex-direction:column;gap:12px">
+              ${params
+                .map(
+                  (item) => `<div style="display: flex;align-items:center;gap: 6px">
+                    <span style="width: 8px;height: 8px;border-radius: 50%;background-color:${item.color}"></span>
+                    <span style="font-size:14px;color:${isLight ? '#231536' : '#B6BCC2'};"> ${item.seriesName}:</span>
+                    <span style="font-size:16px;font-weight:700;color:${
+                      isLight ? '#231536' : '#EDEFFF'
+                    };">${formatNumber(item.value)}</span></div>`
+                )
+                .join('')}
+            </div>
+          </div>
+          `;
+      },
+    },
     grid: {
       height: upTable ? 300 : 204,
       right: '0%',

--- a/src/stories/containers/FinancesOverview/useFinancesOverview.ts
+++ b/src/stories/containers/FinancesOverview/useFinancesOverview.ts
@@ -35,7 +35,7 @@ const useFinancesOverview = (
       }),
     [quarterExpenses]
   );
-  const [selectedYear, setSelectedYear] = useState<number>(() => DateTime.local().year);
+  const [selectedYear, setSelectedYear] = useState<number>(2023);
 
   const { isLight } = useThemeContext();
   const isDownDesktop1280 = useMediaQuery(lightTheme.breakpoints.down('desktop_1280'));


### PR DESCRIPTION
## Ticket
https://trello.com/c/Bg7xkiIf/335-qa-bug-finding-r
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Add a tooltip to the finances chart, set 2023 as default year and changed the totals label by "Actuals"

## What solved
- [X] % OF TOTAL bar is not empty so as to match with the 0% in some expense and specific budget categories. @meraki suggested an ad hoc fix of making 2023 a default year.  + TOTAL SPEND column change to ACTUALS in both the Budget and Expense Category.
- [X] Homepage, Stacked bar chart on the left. **Expected Output:** Include a hover function where the values for the data will be shown upon mouse over. **Current Output:**  The exact numbers are not visible

