### PR TITLE
[POWER-305-eml] Add correct formatter for line chart quarterly

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
 import { createChartTooltip } from '@ses/containers/Finances/utils/chartTooltip';
-import { breakdownChartMonthly, breakdownChartQuarterly } from '@ses/containers/Finances/utils/utils';
+import { breakdownChartMonthly, breakdownChartQuarterlyMetric } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
@@ -56,7 +56,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
         selectedGranularity === 'monthly'
           ? breakdownChartMonthly(isMobile)
           : selectedGranularity === 'quarterly'
-          ? breakdownChartQuarterly()
+          ? breakdownChartQuarterlyMetric()
           : [''],
       splitLine: {
         show: false,
@@ -86,10 +86,16 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
           if (isMobile) {
             return value;
           }
-          return `{month|${value}}\n{year|${year}}`;
+          if (selectedGranularity === 'monthly') {
+            return `{value|${value}} \n {year|${year}}`;
+          }
+          if (selectedGranularity === 'quarterly') {
+            return `{value|${value}} {year|${year}}`;
+          }
+          return `{year|${year}}`;
         },
         rich: {
-          month: xAxisStyles,
+          value: xAxisStyles,
           year: xAxisStyles,
         },
       },

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -87,7 +87,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
             return value;
           }
           if (selectedGranularity === 'monthly') {
-            return `{value|${value}} \n {year|${year}}`;
+            return `{value|${value}}\n{year|${year}}`;
           }
           if (selectedGranularity === 'quarterly') {
             return `{value|${value}} {year|${year}}`;

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -782,6 +782,7 @@ export const breakdownChartMonthly = (isMobile: boolean) => [
 ];
 
 export const breakdownChartQuarterly = () => ['Q’1', 'Q’2', 'Q’3', 'Q’4'];
+export const breakdownChartQuarterlyMetric = () => ['1ST QUARTER ', '2ND QUARTER', '3RD QUARTER', '4TH QUARTER'];
 export const breakdownChartAnnually = () => ['Year'];
 export const getGranularity = (granularity: AnalyticGranularity, isMobile: boolean) => {
   switch (granularity.toLocaleLowerCase()) {


### PR DESCRIPTION
## Ticket
https://trello.com/c/Dy3KazCU/305-eml-1-expense-metrics-line-chart-v1

## Description
Add correct format to the legend

## What solved
- [X] The quarterly period in the x-axis should be displayed "# Quarter Year". Eg. 1st Quarter 2023. 
