### PR TITLE
[BSN-330]Add limited for the code and change position of percent

### DIFF
--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import { threeDigitsPrecisionHumanization } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { getShortCode } from '../../SectionPages/CardChartOverview/utils';
@@ -31,7 +31,8 @@ const CardLegend: React.FC<Props> = ({
   return (
     <ContainerLegend isCoreThirdLevel={isCoreThirdLevel} changeAlignment={changeAlignment}>
       {doughnutSeriesData.map((data, index) => {
-        const valueRounded = usLocalizedNumber(data?.value);
+        const valueRounded = threeDigitsPrecisionHumanization(data?.value);
+
         return (
           <LegendItem
             key={index}
@@ -49,9 +50,9 @@ const CardLegend: React.FC<Props> = ({
               </NameOrCode>
             </IconWithName>
             <Value isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>
-              {valueRounded}
-              <span>DAI</span>
               <span>{`(${data.percent}%)`}</span>
+              <div>{valueRounded.value}</div>
+              <span>{valueRounded.suffix}</span>
             </Value>
           </LegendItem>
         );
@@ -95,6 +96,7 @@ const Value = styled.div<WithIsLight & { isCoreThirdLevel: boolean }>(({ isLight
   fontStyle: 'normal',
   fontWeight: 400,
   lineHeight: 'normal',
+  display: 'flex',
   marginLeft: isCoreThirdLevel ? 4 : 14,
   ...(isCoreThirdLevel && {
     whiteSpace: 'revert',
@@ -121,6 +123,7 @@ const NameOrCode = styled.div<WithIsLight & { isCoreThirdLevel: boolean; isShowS
     fontSize: 12,
     fontStyle: 'normal',
     fontWeight: 400,
+
     lineHeight: 'normal',
     ...(!isShowSwiper && {
       whiteSpace: 'nowrap',

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/utils.ts
@@ -21,10 +21,4 @@ export const getTotalAllMetricsBudget = (budgetsAnalytics: BreakdownBudgetAnalyt
   return metric;
 };
 
-export const getShortCode = (code: string) => {
-  if (code.length <= 7) {
-    return code;
-  }
-  const shortCode = code.substring(0, 7);
-  return shortCode;
-};
+export const getShortCode = (code: string) => (code.length > 8 ? code.substring(0, 8) + '...' : code);


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Solving issues in SB + N

## What solved
- [X]  Number formatting should be adjusted to 3 significant digits + size letter (same as the section on the left 1.49 M). Change the label to percentage number first. **Example: 5.2% (1.49M)** Drop the currency information (replace with information icon that says “All amounts are in DAI”), Legend label characters should be limited to 8 (so for longer words the 8th character can be  “…”).

## Screenshots (if apply)
