### PR TITLE
[RMV-1] Add coordinators and ecosystem actors data

### DIFF
--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/Coordinators.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/Coordinators.tsx
@@ -1,0 +1,60 @@
+import { styled } from '@mui/material';
+import AvatarPlaceholder from '@ses/components/svg/avatar-placeholder';
+
+const Coordinators: React.FC = () => (
+  <CoordinatorsBox>
+    <Title>Coordinator(s)</Title>
+
+    <CoordinatorsList>
+      <Coordinator>
+        <AvatarPlaceholder width={24} height={24} />
+        <CoordinatorName>P_Rose</CoordinatorName>
+      </Coordinator>
+      <Coordinator>
+        <AvatarPlaceholder width={24} height={24} />
+        <CoordinatorName>C_27</CoordinatorName>
+      </Coordinator>
+    </CoordinatorsList>
+  </CoordinatorsBox>
+);
+
+export default Coordinators;
+
+const CoordinatorsBox = styled('div')(({ theme }) => ({
+  display: 'none',
+  flexDirection: 'column',
+  gap: 32,
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+  },
+}));
+
+const Title = styled('div')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 600,
+  lineHeight: 'normal',
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  color: theme.palette.mode === 'light' ? '#434358' : 'red',
+}));
+
+const CoordinatorsList = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+}));
+
+const Coordinator = styled('div')(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  alignSelf: 'stretch',
+}));
+
+const CoordinatorName = styled('div')(({ theme }) => ({
+  fontSize: 16,
+  fontWeight: 700,
+  lineHeight: 'normal',
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+}));

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/EcosystemAcotrs.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/EcosystemAcotrs.tsx
@@ -1,0 +1,72 @@
+import { Avatar, styled } from '@mui/material';
+
+const EcosystemActors: React.FC = () => (
+  <EcosystemActorsBox>
+    <Title>Ecosystem Actor(s)</Title>
+
+    <ActorList>
+      <Actor>
+        <ActorAvatar src="https://makerdao-ses.github.io/ecosystem-dashboard/ecosystem-actors/POWERHOUSE/POWERHOUSE_logo.png" />
+        <ActorName>Powerhouse Inc.</ActorName>
+      </Actor>
+      <Actor>
+        <ActorAvatar src="https://makerdao-ses.github.io/ecosystem-dashboard/ecosystem-actors/PHOENIX/PHOENIX_logo.png" />
+        <ActorName>Phoenix Labs</ActorName>
+      </Actor>
+      <Actor>
+        <ActorAvatar src="https://makerdao-ses.github.io/ecosystem-dashboard/ecosystem-actors/DEWIZ/DEWIZ_logo.png" />
+        <ActorName>Deviz</ActorName>
+      </Actor>
+      <Actor>
+        <ActorAvatar src="https://makerdao-ses.github.io/ecosystem-dashboard/ecosystem-actors/PHOENIX/PHOENIX_logo.png" />
+        <ActorName>Pull Up</ActorName>
+      </Actor>
+    </ActorList>
+  </EcosystemActorsBox>
+);
+
+export default EcosystemActors;
+
+const EcosystemActorsBox = styled('div')(({ theme }) => ({
+  display: 'none',
+  flexDirection: 'column',
+  gap: 32,
+  marginTop: -8,
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+  },
+}));
+
+const Title = styled('div')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 600,
+  lineHeight: 'normal',
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  color: theme.palette.mode === 'light' ? '#434358' : 'red',
+}));
+
+const ActorList = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+}));
+
+const Actor = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 16,
+});
+
+const ActorAvatar = styled(Avatar)({
+  width: 32,
+  height: 32,
+  boxShadow: '2px 4px 7px 0px rgba(26, 171, 155, 0.25)',
+});
+
+const ActorName = styled('div')(({ theme }) => ({
+  fontSize: 14,
+  lineHeight: 'normal',
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+}));

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
@@ -2,6 +2,8 @@ import { styled } from '@mui/system';
 import ProjectOwnerChip from '@ses/containers/ActorProjects/components/ProjectOwnerChip/ProjectOwnerChip';
 import SupportedTeamsAvatarGroup from '@ses/containers/ActorProjects/components/SupportedTeamsAvatarGroup/SupportedTeamsAvatarGroup';
 import { OwnerType } from '@ses/core/models/interfaces/projects';
+import Coordinators from './Coordinators';
+import EcosystemActors from './EcosystemAcotrs';
 import MilestoneProgress from './MilestoneProgress';
 import StatsData from './StatsData';
 
@@ -50,9 +52,9 @@ const MilestoneDetailsCard: React.FC = () => (
         <Divider />
         <StatsData />
         <Divider />
-        <div>coordinators</div>
+        <Coordinators />
         <Divider />
-        <div>Ecosystem Actors</div>
+        <EcosystemActors />
       </AsideContent>
       <DescriptionContent>
         <Paragraph>


### PR DESCRIPTION
## Ticket
https://trello.com/c/HIe66Yme/297-rmv-1-roadmaps-and-milestones-view

## Description
Added a UI section for the coordinators and ecosystem actors for the milestones details card

## What solved
- [X] Should have the second section: Coordinators and Ecosystem Actors (icon and name) in desktop resolution.

## Screenshots (if apply)
![Screenshot_539](https://github.com/makerdao-ses/ecosystem-dashboard/assets/29311855/7ef5d3ab-03f7-4e8d-8aea-9eb3ef23d78b)
