### PR TITLE
[MER-1] Remove budget metric

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/ExpenseReportsFilters.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/ExpenseReportsFilters.tsx
@@ -54,7 +54,6 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
           selected={selectedMetric}
           onChange={onMetricChange}
           items={[
-            'Budget',
             'Actuals',
             'Forecast',
             !isMobile ? 'Net Expenses On-chain' : 'Net On-chain',


### PR DESCRIPTION
## Ticket
https://trello.com/c/zera64wM/312-mer-1-monthly-expense-reports

## Description
Removed the option budget from the metric select in the Expense reports section

## What solved
- [X] Should remove the Budget metric
