### PR TITLE
[MER-1] Fix expense reports links

### DIFF
--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.stories.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.stories.tsx
@@ -17,12 +17,10 @@ export default meta;
 
 const variantsArgs = [
   {
-    link: '#',
     selectedMetric: 'Actuals',
     budget: mockDataApiTeam[0].budgetStatements[0],
   },
   {
-    link: '#',
     selectedMetric: 'Actuals',
     budget: mockDataApiTeam[0].budgetStatements[0],
   },

--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
@@ -4,6 +4,7 @@ import CircleAvatarWithIcon from '@ses/components/CircleAvatar/CircleAvatarWithI
 import ArrowNavigationForCards from '@ses/components/svg/ArrowNavigationForCards';
 import MultiUsers from '@ses/components/svg/MultiUsers';
 import MultiUsersMobile from '@ses/components/svg/MultiUsersMobile';
+import { siteRoutes } from '@ses/config/routes';
 import ActorLastModified from '@ses/containers/Actors/components/ActorLastModified/ActorLastModified';
 import GenericDelegateCard from '@ses/containers/RecognizedDelegates/components/GenericDelegateCard';
 import ExpenseReportStatusIndicator from '@ses/containers/TransparencyReport/components/ExpenseReportStatusIndicator/ExpenseReportStatusIndicator';
@@ -20,13 +21,12 @@ import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatemen
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
-  link?: string;
   budget: BudgetStatement;
   selectedMetric: string;
   now?: DateTime;
 }
 
-const DelegateExpenseTrendItem: React.FC<Props> = ({ link, budget, selectedMetric, now = DateTime.now() }) => {
+const DelegateExpenseTrendItem: React.FC<Props> = ({ budget, selectedMetric, now = DateTime.now() }) => {
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const { isLight } = useThemeContext();
   const lastModified = getExpenseMonthWithData(budget);
@@ -38,6 +38,21 @@ const DelegateExpenseTrendItem: React.FC<Props> = ({ link, budget, selectedMetri
   );
   const reportMonth = DateTime.fromFormat(budget.month, 'yyyy-LL-dd')?.toFormat('LLL yyyy');
   const isCoreUnitElement = budget.ownerType === 'CoreUnit';
+
+  const link = useMemo(() => {
+    if (budget.ownerType === 'CoreUnit') {
+      return `${siteRoutes.coreUnitReports(budget.owner.shortCode)}?viewMonth=${DateTime.fromFormat(
+        budget.month,
+        'yyyy-LL-dd'
+      ).toFormat('LLLyyyy')}`;
+    }
+
+    // ecosystem actor by default
+    return `${siteRoutes.ecosystemActorReports(budget.owner.shortCode)}?viewMonth=${DateTime.fromFormat(
+      budget.month,
+      'yyyy-LL-dd'
+    ).toFormat('LLLyyyy')}`;
+  }, [budget]);
 
   const value = useMemo(() => {
     switch (selectedMetric) {

--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/DelegateExpenseTrendFinances.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/DelegateExpenseTrendFinances.tsx
@@ -46,12 +46,7 @@ const DelegateExpenseTrendFinances: React.FC<Props> = ({
         {expenseReportResponse.data?.map((page, index) => (
           <React.Fragment key={`page-${index}`}>
             {page.map((budget) => (
-              <DelegateExpenseTrendItem
-                key={index}
-                budget={budget}
-                selectedMetric={filterProps.selectedMetric}
-                link={'getLinkLastExpenseReport(expense.shortCode, expenseReport)'}
-              />
+              <DelegateExpenseTrendItem key={index} budget={budget} selectedMetric={filterProps.selectedMetric} />
             ))}
           </React.Fragment>
         ))}


### PR DESCRIPTION
## Ticket
https://trello.com/c/zera64wM/312-mer-1-monthly-expense-reports

## Description
Fix the links on the View button of the expense reports section

## What solved
- [X] Clicking on the View option. **Expected Output:** It should redirect to the specific expense report. **Current Output:** It redirects to the 404 page 
