### PR TITLE
Fix/issues BS+N version 5

### DIFF
--- a/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerSecondLevel/useEndgameBudgetContainerSecondLevel.tsx
@@ -17,6 +17,7 @@ import {
   generateColorPalette,
   getBudgetsAnalytics,
   getLevelOfBudget,
+  nameChanged,
   newBudgetMetric,
 } from '../Finances/utils/utils';
 import type { BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
@@ -132,7 +133,7 @@ export const useEndgameBudgetContainerSecondLevel = (budgets: Budget[], initialY
   const expenseReportSection = useDelegateExpenseTrendFinances();
 
   const levelBudget = allBudgets?.find((budget) => budget.codePath === levelPath);
-  const title = levelBudget?.name || '';
+  const title = nameChanged(levelBudget?.name || '');
 
   const icon = levelBudget?.image;
   const handleChangeYearsEndgameAtlasBudget = (value: string) => {

--- a/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
+++ b/src/stories/containers/EndgameBudgetContainerThirdLevel/useEndgameBudgetContainerThirdLevel.tsx
@@ -19,6 +19,7 @@ import {
   generateColorPalette,
   getBudgetsAnalytics,
   getLevelOfBudget,
+  nameChanged,
   newBudgetMetric,
 } from '../Finances/utils/utils';
 import type { BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
@@ -113,7 +114,7 @@ export const useEndgameBudgetContainerThirdLevel = (budgets: Budget[], initialYe
 
   const icon = titleFirstPathBudget?.image;
 
-  const title = titleFirstPathBudget?.name || '';
+  const title = nameChanged(titleFirstPathBudget?.name || '');
 
   const handleChangeYearsEndgameAtlasBudget = (value: string) => {
     setYear(value);
@@ -170,11 +171,11 @@ export const useEndgameBudgetContainerThirdLevel = (budgets: Budget[], initialYe
       url: `${siteRoutes.newFinancesOverview}?year=${year}`,
     },
     {
-      label: levelBudgetPath?.name || '',
+      label: nameChanged(levelBudgetPath?.name || ''),
       url: `${siteRoutes.newFinancesOverview}/${levelBudgetPath?.codePath.replace('atlas/', '')}?year=${year}`,
     },
     ...breadcrumbs.map((adr) => ({
-      label: adr,
+      label: nameChanged(adr),
       url: router.asPath,
     })),
   ];

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
 import { createChartTooltip } from '@ses/containers/Finances/utils/chartTooltip';
-import { formatterBreakDownChart, getGranularity } from '@ses/containers/Finances/utils/utils';
+import { formatterBreakDownChart, getGranularity, nameChanged } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
@@ -189,7 +189,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
                 <circle cx="6.5" cy="6.5" r="4" fill={element.itemStyle.colorOriginal} />
               </svg>
             </SVGContainer>
-            {element.name}
+            {nameChanged(element.name)}
           </LegendItem>
         ))}
       </LegendContainer>

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { getShortNameForMetric } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
@@ -21,7 +22,7 @@ export const CellMonthly: React.FC<Props> = ({ metrics, title, isTotal = false, 
       <Month isLight={isLight}>{title}</Month>
       {activeMetrics?.map((metric, index) => (
         <Metrics key={index}>
-          <Name isLight={isLight}>Actuals</Name>
+          <Name isLight={isLight}>{getShortNameForMetric(metric)}</Name>
           <Amount isLight={isLight}>{usLocalizedNumber(metrics[metric as keyof MetricValues] ?? 0)}</Amount>
         </Metrics>
       ))}

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -1,5 +1,10 @@
 import { useMediaQuery } from '@mui/material';
-import { existingColors, existingColorsDark, generateColorPalette } from '@ses/containers/Finances/utils/utils';
+import {
+  existingColors,
+  existingColorsDark,
+  generateColorPalette,
+  nameChanged,
+} from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { percentageRespectTo } from '@ses/core/utils/math';
 import lightTheme from '@ses/styles/theme/light';
@@ -33,7 +38,7 @@ export const useCardChartOverview = (budgets: Budget[], budgetsAnalytics: Breakd
   const budgetMetrics: Record<string, BudgetMetricWithName> = {};
   budgets.forEach((budget) => {
     const budgetKey = budget.codePath;
-    const budgetName = budget.name;
+    const budgetName = nameChanged(budget.name);
     if (budgetMetrics[budget.codePath]) {
       const uniqueKey = `${budgetKey}-${budget.id}`;
       budgetMetrics[uniqueKey] = {
@@ -95,7 +100,7 @@ export const useCardChartOverview = (budgets: Budget[], budgetsAnalytics: Breakd
       const budgetMetric = budgetsAnalytics[budgetMetricKey];
       const correspondingBudget = budgets.find((budget) => budget.codePath === budgetMetricKey);
       // use the name of budget or add label
-      const budgetName = correspondingBudget ? correspondingBudget.name : 'There is not name';
+      const budgetName = correspondingBudget ? nameChanged(correspondingBudget.name) : 'There is not name';
       const budgetCode = correspondingBudget?.code || 'No-code';
       metric.actuals += budgetMetric[0].actuals.value || 0;
       metric.forecast += budgetMetric[0].forecast.value || 0;

--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterFallChartSection/useReservesWaterFallChart.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterFallChartSection/useReservesWaterFallChart.tsx
@@ -1,4 +1,5 @@
 import { useMediaQuery } from '@mui/material';
+import { nameChanged } from '@ses/containers/Finances/utils/utils';
 import { useBudgetContext } from '@ses/core/context/BudgetContext';
 
 import { useThemeContext } from '@ses/core/context/ThemeContext';
@@ -23,7 +24,7 @@ export const useReservesWaterFallChart = () => {
   const levelPath = 'atlas/' + router.query.firstPath?.toString();
 
   const levelBudget = allBudgets?.find((budget) => budget.codePath === levelPath);
-  const getTitleLevelBudget = levelBudget?.name || '';
+  const getTitleLevelBudget = nameChanged(levelBudget?.name || '');
 
   // Here will be 13, the first one is only for start and the last one is calculate to by duplicate
   // The firs element will be point to start its don't bellow to the serie

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -18,6 +18,7 @@ import {
   generateColorPalette,
   existingColors,
   existingColorsDark,
+  nameChanged,
 } from './utils/utils';
 import type { BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
 import type { Budget } from '@ses/core/models/interfaces/budget';
@@ -71,7 +72,7 @@ export const useFinances = (budgets: Budget[], initialYear: string) => {
 
     return {
       image: item.image || '/assets/img/default-icon-cards-budget.svg',
-      title: item.name || '',
+      title: nameChanged(item.name),
       description: item.description || 'Finances of the core governance constructs described in the Maker Atlas.',
       href: `${siteRoutes.newFinancesOverview}/${item.codePath.replace('atlas/', '')}?year=${year}`,
       valueDai: budgetMetric[0].budget.value,

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -1009,3 +1009,12 @@ export const getShortNameForMetric = (metric: string): string => {
   }
   return metric;
 };
+// Remove this when API return correct data
+export const nameChanged = (name: string) => {
+  const newName = removePrefix(name, prefixToRemove);
+  return newName === 'Atlas Immutable AA Budgets'
+    ? 'Atlas Immutable Budget'
+    : newName === 'Alignment Scope Budgets'
+    ? 'Scope Frameworks Budget'
+    : newName;
+};


### PR DESCRIPTION
## Ticket
https://trello.com/c/qmqD8fNL/311-rc-1-reserves-chart

## Description
Fix issues in the BSN stories

## What solved
- [X] :pray: **(2)**  Budgets tiles should read: Atlas Budget Immutable Budget, Scope Framework Budget, MakerDAO Legacy Budget; only these three tiles.  **Current Output:** The budgets are displayed with End-Game text as part of the name. The second budget is displayed as Alignment Scope Budgets. 

## Screenshots (if apply)
