### PR TITLE
[MER-1] Expense reports query typo

### DIFF
--- a/src/stories/containers/Finances/api/queries.ts
+++ b/src/stories/containers/Finances/api/queries.ts
@@ -83,8 +83,7 @@ interface ExpenseReportInput {
   page: number;
   budgetPath: string;
   sortByMonth: 'asc' | 'desc' | null;
-  // eslint-disable-next-line spellcheck/spell-checker
-  sortyByLastModified: 'asc' | 'desc' | null;
+  sortByLastModified: 'asc' | 'desc' | null;
   status: BudgetStatus[] | null;
 }
 
@@ -92,8 +91,7 @@ export const getExpenseReportsQuery = ({
   page,
   budgetPath,
   sortByMonth,
-  // eslint-disable-next-line spellcheck/spell-checker
-  sortyByLastModified,
+  sortByLastModified,
   status,
 }: ExpenseReportInput) => ({
   query: gql`
@@ -123,8 +121,7 @@ export const getExpenseReportsQuery = ({
     filter: {
       budgetPath,
       sortByMonth,
-      // eslint-disable-next-line spellcheck/spell-checker
-      sortyByLastModified,
+      sortByLastModified,
       status,
     },
     limit: 10,

--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/useDelegateExpenseTrendFinances.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/useDelegateExpenseTrendFinances.tsx
@@ -78,8 +78,7 @@ export const useDelegateExpenseTrendFinances = (budgetPath: string) => {
               ? 'desc'
               : null
             : null,
-        // eslint-disable-next-line spellcheck/spell-checker
-        sortyByLastModified:
+        sortByLastModified:
           sortColumn === 4
             ? headersSort[4] === SortEnum.Asc
               ? 'asc'


### PR DESCRIPTION
## Ticket
https://trello.com/c/zera64wM/312-mer-1-monthly-expense-reports

## Description
Fix a typo on the query

## What solved
- [X] Should ensure the sorting is applied only for Month and Last Modified columns. (Come from the API).
