### PR TITLE
[BSN-330] Add optional label in the mobile

### DIFF
--- a/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
+++ b/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
@@ -10,6 +10,7 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 export interface SelectItem {
   label: string;
   value: string;
+  labelWhenSelected?: string;
 }
 
 interface SingleItemSelectProps {
@@ -23,6 +24,7 @@ interface SingleItemSelectProps {
   className?: string;
   selected?: string;
   onChange?: (value: string) => unknown;
+  isMobile?: boolean;
 }
 
 const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
@@ -35,6 +37,7 @@ const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
   className,
   selected,
   onChange,
+  isMobile = false,
 }) => {
   const { isLight } = useThemeContext();
   const menuListId = useId();
@@ -121,17 +124,23 @@ const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
 
       const index = items.findIndex((item) => compareItemWithValue(item, selected));
       if (index === -1) {
-        // the "selected" item is not present in the item list
-        // so get label or first item
         return label === undefined ? (typeof items[0] === 'string' ? items[0] : items[0].label) : label;
       }
 
       const item = items[index];
-      return typeof item === 'string' ? item : item.label;
+      if (typeof item === 'string') {
+        return item;
+      } else {
+        // Use the labelWhenSelected if its present and its mobile
+        if (open && isMobile) {
+          return item.labelWhenSelected ? item.labelWhenSelected : item.label;
+        }
+        return open || !isMobile ? item.label : item.labelWhenSelected || item.label;
+      }
     } else {
       return label;
     }
-  }, [items, label, selected, useSelectedAsLabel]);
+  }, [useSelectedAsLabel, label, items, selected, open, isMobile]);
 
   return (
     <div>

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -44,15 +44,33 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
 
       <SelectContainer>
         <MetricSelect
+          isMobile={isMobile}
           useSelectedAsLabel
           selected={selectedMetric}
           onChange={onMetricChange}
           items={[
-            'Budget',
-            'Actuals',
-            'Forecast',
-            !isMobile ? 'Net Expenses On-chain' : 'Net On-chain',
-            !isMobile ? 'Net Expenses Off-chain' : 'Net Off-chain',
+            {
+              label: 'Budget',
+              value: 'Budget',
+            },
+            {
+              label: 'Actuals',
+              value: 'Actuals',
+            },
+            {
+              label: 'Forecast',
+              value: 'Forecast',
+            },
+            {
+              label: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',
+              value: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',
+              labelWhenSelected: 'Net On-chain',
+            },
+            {
+              label: !isMobile ? 'Net Expenses Off-chain' : 'Net Exp. Off-Chain Incl.',
+              value: !isMobile ? 'Net Expenses Off-chain' : 'Net Exp. Off-Chain Incl.',
+              labelWhenSelected: 'Net Off-chain',
+            },
           ]}
           PopperProps={{
             placement: 'bottom-end',

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -47,6 +47,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     () => getMetricByPeriod(periodFilter, isMobile, isTable, isDesk1024, isDesk1280, isDesk1440, isDesk1920),
     [isDesk1024, isDesk1280, isDesk1440, isDesk1920, isMobile, isTable, periodFilter]
   );
+  const [numberMetrics, setNumberMetrics] = useState(val);
   const [activeMetrics, setActiveMetrics] = useState<string[]>(metricsFilter.slice(0, val));
   const maxItems = val;
   const minItems = 1;
@@ -220,33 +221,58 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
   useEffect(() => {
     if (periodFilter === 'Quarterly') {
       if (isTable) {
-        setActiveMetrics(metricsFilter.slice(0, val));
+        if (numberMetrics !== val) {
+          setActiveMetrics(metricsFilter.slice(0, val));
+        }
       }
       if (isDesk1024 || isDesk1280 || isDesk1440) {
-        setActiveMetrics(metricsFilter.slice(0, val));
+        if (numberMetrics !== val) {
+          setActiveMetrics(metricsFilter.slice(0, val));
+        }
       }
       if (isDesk1920) {
-        setActiveMetrics(metricsFilter.slice(0, val));
+        if (numberMetrics !== val) {
+          setActiveMetrics(metricsFilter.slice(0, val));
+        }
       }
     }
     if (periodFilter === 'Monthly') {
-      setActiveMetrics(metricsFilter.slice(0, val));
+      if (numberMetrics !== val) {
+        setActiveMetrics(metricsFilter.slice(0, val));
+      }
     }
     if (periodFilter === 'Annually') {
       if (isMobile) {
-        setActiveMetrics(metricsFilter.slice(0, val));
+        if (numberMetrics !== val) {
+          setActiveMetrics(metricsFilter.slice(0, val));
+        }
       } else {
-        setActiveMetrics(metricsFilter.slice(0, val));
+        if (numberMetrics !== val) {
+          setActiveMetrics(metricsFilter.slice(0, val));
+        }
       }
     }
     if (periodFilter === 'Semi-annual') {
       setActiveMetrics(metricsFilter.slice(0, val));
     }
-  }, [isDesk1024, isDesk1280, isDesk1440, isDesk1920, isMobile, isTable, metricsFilter, periodFilter, val]);
+  }, [
+    activeMetrics.length,
+    isDesk1024,
+    isDesk1280,
+    isDesk1440,
+    isDesk1920,
+    isMobile,
+    isTable,
+    metricsFilter,
+    numberMetrics,
+    periodFilter,
+    val,
+  ]);
 
   // Only show monthly filter in dimension bigger than isDesk1440
   useEffect(() => {
     const handleResize = () => {
+      setNumberMetrics(val);
       if (periodFilter === 'Monthly' && (isMobile || isDesk1024 || isDesk1280)) {
         setPeriodFilter('Quarterly');
       }
@@ -255,9 +281,10 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [isDesk1024, isDesk1280, isDesk1440, isMobile, periodFilter]);
+  }, [isDesk1024, isDesk1280, isDesk1440, isMobile, periodFilter, val]);
 
   const handleSelectChangeMetrics = (value: string[]) => {
+    setNumberMetrics(val);
     setActiveMetrics(value);
   };
   const handleResetMetrics = () => {

--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/ExpenseReportsFilters.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/ExpenseReportsFilters.tsx
@@ -48,14 +48,29 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
 
       <SelectContainer>
         <MetricSelect
+          isMobile={isMobile}
           useSelectedAsLabel
           selected={selectedMetric}
           onChange={onMetricChange}
           items={[
-            'Actuals',
-            'Forecast',
-            !isMobile ? 'Net Expenses On-chain' : 'Net On-chain',
-            !isMobile ? 'Net Expenses Off-chain' : 'Net Off-chain',
+            {
+              label: 'Actual',
+              value: 'Actual',
+            },
+            {
+              label: 'Forecast',
+              value: 'Forecast',
+            },
+            {
+              label: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',
+              value: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',
+              labelWhenSelected: 'Net On-chain',
+            },
+            {
+              label: !isMobile ? 'Net Expenses Off-chain' : 'Net Exp. Off-Chain Incl.',
+              value: !isMobile ? 'Net Off-chain' : 'Net Exp. Off-Chain Incl.',
+              labelWhenSelected: 'Net Off-chain',
+            },
           ]}
           PopperProps={{
             placement: 'bottom-end',

--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/ExpenseReportsFilters.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/ExpenseReportsFilters.tsx
@@ -54,8 +54,8 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
           onChange={onMetricChange}
           items={[
             {
-              label: 'Actual',
-              value: 'Actual',
+              label: 'Actuals',
+              value: 'Actuals',
             },
             {
               label: 'Forecast',

--- a/src/stories/containers/Finances/utils/types.ts
+++ b/src/stories/containers/Finances/utils/types.ts
@@ -62,8 +62,8 @@ export type Metric =
   | 'Forecast'
   | 'Net Expenses On-chain'
   | 'Net Expenses Off-chain'
-  | 'Net On-chain'
-  | 'Net Off-chain';
+  | 'Net Exp. On-Chain'
+  | 'Net Exp. Off-Chain Incl.';
 export interface MetricValues {
   Budget: number;
   Actuals: number;

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -858,13 +858,13 @@ export const getCorrectMetric = (budgetMetric: BudgetMetric, selectedMetric: Met
     case 'Net Expenses On-chain':
       metricKey = 'paymentsOnChain';
       break;
-    case 'Net On-chain':
+    case 'Net Exp. On-Chain':
       metricKey = 'paymentsOnChain';
       break;
     case 'Net Expenses Off-chain':
       metricKey = 'paymentsOffChainIncluded';
       break;
-    case 'Net Off-chain':
+    case 'Net Exp. Off-Chain Incl.':
       metricKey = 'paymentsOffChainIncluded';
       break;
     default:


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix issues

## What solved
- [X] The filter should display Net Exp. On-Chain and Net Exp. Off-Chain incl.  When are selected they should display as filter labels Net On-Chain and Net Off-Chain. 

