### PR TITLE
Fix the name in relation with the api

### DIFF
--- a/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/CellAnnually.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/CellAnnually.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { getShortNameForMetric } from '@ses/containers/Finances/utils/utils';
+import { getKeyMetric, getShortNameForMetric } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
@@ -20,7 +20,9 @@ export const CellAnnually: React.FC<Props> = ({ metrics, activeMetrics }) => {
       {activeMetrics?.map((metric, index) => (
         <Metrics isLight={isLight} key={index}>
           <Name isLight={isLight}>{getShortNameForMetric(metric)}</Name>
-          <Amount isLight={isLight}>{usLocalizedNumber(metrics[metric as keyof MetricValues] ?? 0)}</Amount>
+          <Amount isLight={isLight}>
+            {usLocalizedNumber(metrics[getKeyMetric(metric) as keyof MetricValues] ?? 0)}
+          </Amount>
         </Metrics>
       ))}
     </ContainerCell>

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { getShortNameForMetric } from '@ses/containers/Finances/utils/utils';
+import { getKeyMetric, getShortNameForMetric } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
@@ -23,7 +23,9 @@ export const CellMonthly: React.FC<Props> = ({ metrics, title, isTotal = false, 
       {activeMetrics?.map((metric, index) => (
         <Metrics key={index}>
           <Name isLight={isLight}>{getShortNameForMetric(metric)}</Name>
-          <Amount isLight={isLight}>{usLocalizedNumber(metrics[metric as keyof MetricValues] ?? 0)}</Amount>
+          <Amount isLight={isLight}>
+            {usLocalizedNumber(metrics[getKeyMetric(metric) as keyof MetricValues] ?? 0)}
+          </Amount>
         </Metrics>
       ))}
     </ContainerCell>

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/CellQuarterly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/CellQuarterly.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { getShortNameForMetric } from '@ses/containers/Finances/utils/utils';
+import { getKeyMetric, getShortNameForMetric } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
@@ -25,7 +25,9 @@ export const CellQuarterly: React.FC<Props> = ({ metrics, activeMetrics, quarter
           {activeMetrics?.map((metric, index) => (
             <Metrics key={index}>
               <Name isLight={isLight}>{getShortNameForMetric(metric)}</Name>
-              <Amount isLight={isLight}>{usLocalizedNumber(metrics?.[metric as keyof MetricValues] ?? 0)}</Amount>
+              <Amount isLight={isLight}>
+                {usLocalizedNumber(metrics?.[getKeyMetric(metric) as keyof MetricValues] ?? 0)}
+              </Amount>
             </Metrics>
           ))}
         </ContainerMetricsData>

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/CellSemiAnnual.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/CellSemiAnnual.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { getShortNameForMetric } from '@ses/containers/Finances/utils/utils';
+import { getKeyMetric, getShortNameForMetric } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import React from 'react';
@@ -25,7 +25,9 @@ export const CellSemiAnnual: React.FC<Props> = ({ metrics, semiannual, isTotal =
           {activeMetrics?.map((metric, index) => (
             <Metrics key={index}>
               <Name isLight={isLight}>{getShortNameForMetric(metric)}</Name>
-              <Amount isLight={isLight}>{usLocalizedNumber(metrics[metric as keyof MetricValues] ?? 0)}</Amount>
+              <Amount isLight={isLight}>
+                {usLocalizedNumber(metrics[getKeyMetric(metric) as keyof MetricValues] ?? 0)}
+              </Amount>
             </Metrics>
           ))}
         </ContainerMetricsData>

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -1012,9 +1012,11 @@ export const getShortNameForMetric = (metric: string): string => {
 // Remove this when API return correct data
 export const nameChanged = (name: string) => {
   const newName = removePrefix(name, prefixToRemove);
-  return newName === 'Atlas Immutable AA Budgets'
+  return newName === 'Atlas Immutable'
     ? 'Atlas Immutable Budget'
     : newName === 'Alignment Scope Budgets'
     ? 'Scope Frameworks Budget'
+    : newName === 'MakerDAO Legacy Budgets'
+    ? 'MakerDAO Legacy Budget'
     : newName;
 };

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -992,8 +992,9 @@ export const filterActiveMetrics = (activeMetrics: string[], headerTable: Metric
     const filteredMetrics: Partial<MetricValues> = {};
 
     activeMetrics.forEach((metric) => {
-      if (metric in header) {
-        filteredMetrics[metric as keyof MetricValues] = header[metric as keyof MetricValues];
+      const matchKey = getKeyMetric(metric);
+      if (matchKey in header) {
+        filteredMetrics[matchKey as keyof MetricValues] = header[matchKey as keyof MetricValues];
       }
     });
 
@@ -1019,4 +1020,14 @@ export const nameChanged = (name: string) => {
     : newName === 'MakerDAO Legacy Budgets'
     ? 'MakerDAO Legacy Budget'
     : newName;
+};
+
+export const getKeyMetric = (metric: string) => {
+  if (metric === 'Net Expenses On-chain') {
+    return 'PaymentsOnChain';
+  }
+  if (metric === 'Net Expenses Off-chain') {
+    return 'PaymentsOffChainIncluded';
+  }
+  return metric;
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix issues relate with the values in the header

## What solved
- [X] **HP**- Finances, Breakdown Table (2023 year, On-chain and Off-chain selected). - ** **Expected Output:**  The header of both metrics should show the total of the category.  **Current Output:** The metrics are displayed with a 0 value and the category is displayed with a value different to 0. 

