### PR TITLE
[RMV-1] Update deliverables title on expand

### DIFF
--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/DeliverablesSection.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/DeliverablesSection.tsx
@@ -129,7 +129,7 @@ const DeliverablesSection: React.FC = () => {
     <DeliverablesContainer>
       <Header>
         <TitleBox>
-          <Title>Highlighted Deliverables</Title>
+          <Title>{showAllDeliverables ? 'All' : 'Highlighted'} Deliverables</Title>
           <Count>{deliverables.length}</Count>
         </TitleBox>
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/HIe66Yme/297-rmv-1-roadmaps-and-milestones-view

## Description
Update the deliverables title when they are expanded/collapsed

## What solved
- [X] Should be displayed as the title of the section "All Deliverables"  when clicking "view all deliverables", otherwise should be "Highlighted Deliverables".
