### PR TITLE
[RMV-1] Milestones dark mode

### DIFF
--- a/src/stories/containers/RoadmapMilestones/components/MilestoneCard/MilestoneCard.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneCard/MilestoneCard.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import { styled } from '@mui/system';
 import { CustomButton } from '@ses/components/CustomButton/CustomButton';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
@@ -68,7 +68,7 @@ const MilestoneCard: React.FC = () => {
 
 export default MilestoneCard;
 
-const Card = styled.div<WithIsLight>(({ isLight }) => ({
+const Card = styled('div')<WithIsLight>(({ isLight }) => ({
   background: isLight ? '#FFF' : '#1E2C37',
   borderRadius: 6,
   boxShadow: isLight ? '0px 4px 6px 0px rgba(195, 195, 195, 0.25)' : '10px 15px 20px 6px rgba(20, 0, 141, 0.10)',
@@ -91,7 +91,7 @@ const Card = styled.div<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const TitleBox = styled.div({
+const TitleBox = styled('div')({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
@@ -103,7 +103,7 @@ const TitleBox = styled.div({
   },
 });
 
-const TitleContainer = styled.div({
+const TitleContainer = styled('div')({
   display: 'flex',
   alignItems: 'center',
   gap: 8,
@@ -111,7 +111,7 @@ const TitleContainer = styled.div({
   width: '100%',
 });
 
-const CodeBox = styled.div({
+const CodeBox = styled('div')({
   display: 'flex',
   alignItems: 'center',
   gap: 4,
@@ -121,7 +121,7 @@ const CodeBox = styled.div({
   },
 });
 
-const MilestoneNumber = styled.span({
+const MilestoneNumber = styled('span')({
   color: '#B6BCC2',
   fontSize: 14,
   fontWeight: 700,
@@ -136,7 +136,7 @@ const MilestoneNumber = styled.span({
   },
 });
 
-const Code = styled.span<WithIsLight>(({ isLight }) => ({
+const Code = styled('span')<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#231536' : '#D2D4EF',
   fontSize: 14,
   fontWeight: 600,
@@ -148,23 +148,23 @@ const Code = styled.span<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const NameBox = styled.div({
+const NameBox = styled('div')(({ theme }) => ({
   display: 'flex',
   padding: '0 4px',
   justifyContent: 'space-between',
   alignItems: 'center',
   width: '100%',
   borderRadius: 4,
-  background: 'rgba(236, 239, 249, 0.50)',
+  background: theme.palette.mode === 'light' ? 'rgba(236, 239, 249, 0.50)' : '#1F2537',
 
   [lightTheme.breakpoints.up('tablet_768')]: {
     background: 'none',
     justifyContent: 'flex-end',
     padding: 0,
   },
-});
+}));
 
-const Name = styled.span<WithIsLight>(({ isLight }) => ({
+const Name = styled('span')<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#231536' : '#D2D4EF',
   fontSize: 16,
   fontWeight: 600,
@@ -175,7 +175,7 @@ const Name = styled.span<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const Quarter = styled.span(() => ({
+const Quarter = styled('span')(() => ({
   color: '#B6BCC2',
   fontSize: 16,
   fontWeight: 700,
@@ -192,7 +192,7 @@ const Quarter = styled.span(() => ({
   },
 }));
 
-const MobileOnlyBox = styled.div({
+const MobileOnlyBox = styled('div')({
   display: 'flex',
   alignSelf: 'stretch',
   gap: 8,
@@ -202,7 +202,7 @@ const MobileOnlyBox = styled.div({
   },
 });
 
-const TabletAndDesktopOnlyBox = styled.div({
+const TabletAndDesktopOnlyBox = styled('div')({
   display: 'none',
 
   [lightTheme.breakpoints.up('tablet_768')]: {
@@ -217,7 +217,7 @@ const TabletAndDesktopOnlyBox = styled.div({
   },
 });
 
-const MobileProgressBox = styled.div({
+const MobileProgressBox = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
@@ -226,12 +226,12 @@ const MobileProgressBox = styled.div({
   gap: 8,
 });
 
-const ProgressContainer = styled.div({
+const ProgressContainer = styled('div')({
   display: 'flex',
   justifyContent: 'center',
 });
 
-const BottomBox = styled.div({
+const BottomBox = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   alignSelf: 'stretch',
@@ -246,14 +246,14 @@ const BottomBox = styled.div({
   },
 });
 
-const XBox = styled.div({
+const XBox = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   gap: 16,
 });
 
-const ProgressBox = styled.div({
+const ProgressBox = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
@@ -273,7 +273,7 @@ const ProgressBox = styled.div({
   },
 });
 
-const Label = styled.div<WithIsLight>(({ isLight }) => ({
+const Label = styled('div')<WithIsLight>(({ isLight }) => ({
   color: '#708390',
   fontSize: 11,
   fontWeight: 600,
@@ -304,7 +304,7 @@ const ViewButton = styled(CustomButton)<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const ProgressBarBox = styled.div({
+const ProgressBarBox = styled('div')({
   display: 'flex',
   alignItems: 'center',
   alignSelf: 'stretch',
@@ -315,7 +315,7 @@ const ProgressBarBox = styled.div({
   },
 });
 
-const ProgressBar = styled.div<WithIsLight & { progress: number }>(({ isLight, progress }) => ({
+const ProgressBar = styled('div')<WithIsLight & { progress: number }>(({ isLight, progress }) => ({
   position: 'relative',
   borderRadius: 6,
   background: isLight ? '#ECF1F3' : '#10191F',
@@ -343,7 +343,7 @@ const ProgressBar = styled.div<WithIsLight & { progress: number }>(({ isLight, p
   },
 }));
 
-const ProgressLabel = styled.span<WithIsLight>(({ isLight }) => ({
+const ProgressLabel = styled('span')<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#231536' : '#D2D4EF',
   fontSize: 12,
   lineHeight: 'normal',
@@ -353,7 +353,7 @@ const ProgressLabel = styled.span<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const DescriptionBox = styled.div<WithIsLight>(({ isLight }) => ({
+const DescriptionBox = styled('div')<WithIsLight>(({ isLight }) => ({
   flexDirection: 'column',
   alignItems: 'center',
   alignSelf: 'stretch',
@@ -369,7 +369,7 @@ const DescriptionBox = styled.div<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const DescriptionTitle = styled.div<WithIsLight>(({ isLight }) => ({
+const DescriptionTitle = styled('div')<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#434358' : '#D2D4EF',
   fontSize: 14,
   fontWeight: 600,
@@ -383,7 +383,7 @@ const DescriptionTitle = styled.div<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const Description = styled.div<WithIsLight>(({ isLight }) => ({
+const Description = styled('div')<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#546978' : '#D2D4EF',
   fontSize: 14,
   lineHeight: 'normal',

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneCard/MobileProgressBar.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneCard/MobileProgressBar.tsx
@@ -20,13 +20,14 @@ const BarContainer = styled('div')(() => ({
 }));
 
 const CircularBarBase = styled(CircularProgress)(({ theme }) => ({
-  color: theme.palette.mode === 'light' ? '#ECF1F3' : 'red',
+  color: theme.palette.mode === 'light' ? '#ECF1F3' : '#31424E',
 }));
 
 const CircularBarProgress = styled(CircularProgress)(() => ({
   animationDuration: '550ms',
   position: 'absolute',
   left: 0,
+  color: '#1AAB9B',
 
   [`& .${circularProgressClasses.circle}`]: {
     strokeLinecap: 'round',
@@ -42,7 +43,7 @@ const LabelContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  color: theme.palette.mode === 'light' ? '#405361' : 'red',
+  color: theme.palette.mode === 'light' ? '#405361' : '#D2D4EF',
   fontWeight: 700,
   fontSize: 12,
 }));

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/Coordinators.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/Coordinators.tsx
@@ -36,7 +36,7 @@ const Title = styled('div')(({ theme }) => ({
   lineHeight: 'normal',
   letterSpacing: 1,
   textTransform: 'uppercase',
-  color: theme.palette.mode === 'light' ? '#434358' : 'red',
+  color: theme.palette.mode === 'light' ? '#434358' : '#B6BCC2',
 }));
 
 const CoordinatorsList = styled('div')(() => ({
@@ -56,5 +56,5 @@ const CoordinatorName = styled('div')(({ theme }) => ({
   fontSize: 16,
   fontWeight: 700,
   lineHeight: 'normal',
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
 }));

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/DeliverablesSection.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/DeliverablesSection.tsx
@@ -197,7 +197,7 @@ const Title = styled('h3')(({ theme }) => ({
   fontSize: 16,
   fontWeight: 700,
   lineHeight: 'normal',
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
   margin: 0,
 
   [theme.breakpoints.up('tablet_768')]: {
@@ -211,7 +211,7 @@ const Count = styled('div')(({ theme }) => ({
   fontSize: 16,
   fontWeight: 700,
   lineHeight: 'normal',
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
 
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 20,
@@ -278,7 +278,9 @@ const BackgroundContainer = styled('div')(({ theme }) => ({
   flexDirection: 'column',
   gap: 16,
   background:
-    theme.palette.mode === 'light' ? 'linear-gradient(0deg, #F6F8F9 85.04%, rgba(246, 248, 249, 0.00) 121.04%)' : 'red',
+    theme.palette.mode === 'light'
+      ? 'linear-gradient(0deg, #F6F8F9 85.04%, rgba(246, 248, 249, 0.00) 121.04%)'
+      : 'linear-gradient(180deg, rgba(16, 30, 38, 0.60) 0%, #101E26 100%)',
   margin: '8px -16px -24px',
   padding: '8px 16px 24px',
   borderRadius: 6,

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/EcosystemActors.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/EcosystemActors.tsx
@@ -44,7 +44,7 @@ const Title = styled('div')(({ theme }) => ({
   lineHeight: 'normal',
   letterSpacing: 1,
   textTransform: 'uppercase',
-  color: theme.palette.mode === 'light' ? '#434358' : 'red',
+  color: theme.palette.mode === 'light' ? '#434358' : '#B6BCC2',
 }));
 
 const ActorList = styled('div')(() => ({
@@ -68,5 +68,5 @@ const ActorAvatar = styled(Avatar)({
 const ActorName = styled('div')(({ theme }) => ({
   fontSize: 14,
   lineHeight: 'normal',
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
 }));

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
@@ -104,18 +104,19 @@ export default MilestoneDetailsCard;
 
 const Card = styled('article')(({ theme }) => ({
   position: 'relative',
-  background: theme.palette.mode === 'light' ? '#fff' : 'red',
-  border: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'red'}`,
+  background:
+    theme.palette.mode === 'light' ? '#fff' : 'linear-gradient(180deg, #1E2C37 0%, #1E2C37 24.48%, #101E26 100%)',
+  border: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : '#31424E'}`,
   borderRadius: 6,
   padding: '16px 16px 24px 16px',
 
   [theme.breakpoints.up('tablet_768')]: {
     padding: 24,
-    border: `1px solid ${theme.palette.mode === 'light' ? '#F6F8F9' : 'red'}`,
+    border: `1px solid ${theme.palette.mode === 'light' ? '#F6F8F9' : '#31424E'}`,
     boxShadow:
       theme.palette.mode === 'light'
         ? '1px 1px 5px 0px rgba(190, 190, 190, 0.25), 0px 12px 16px 0px rgba(219, 227, 237, 0.40)'
-        : '1px 1px 5px 0px red, 0px 12px 16px 0px red',
+        : 'none',
   },
 
   [theme.breakpoints.up('desktop_1024')]: {
@@ -167,7 +168,7 @@ const NameBox = styled('div')(() => ({
 }));
 
 const Code = styled('div')(({ theme }) => ({
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#B6BCC2',
   fontSize: 14,
   fontWeight: 700,
   lineHeight: 'normal',
@@ -180,7 +181,7 @@ const Code = styled('div')(({ theme }) => ({
 }));
 
 const Name = styled('div')(({ theme }) => ({
-  color: theme.palette.mode === 'light' ? '#25273D' : 'red',
+  color: theme.palette.mode === 'light' ? '#25273D' : '#D2D4EF',
   fontSize: 14,
   fontWeight: 500,
   lineHeight: '18px',
@@ -195,17 +196,17 @@ const Name = styled('div')(({ theme }) => ({
     fontWeight: 600,
     lineHeight: 'normal',
     letterSpacing: 0.4,
-    color: theme.palette.mode === 'light' ? '#231536' : 'red',
+    color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
   },
 }));
 
 const MilestoneNumber = styled('div')(({ theme }) => ({
-  color: theme.palette.mode === 'light' ? '#708390' : 'red',
+  color: theme.palette.mode === 'light' ? '#708390' : '#B6BCC2',
   fontSize: 11,
   lineHeight: 'normal',
   padding: '3px 7px',
   borderRadius: 3,
-  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : 'red'}`,
+  border: '1px solid #D4D9E1',
 
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
@@ -240,7 +241,7 @@ const Aside = styled('aside')(({ theme }) => ({
     alignItems: 'flex-start',
     alignSelf: 'stretch',
     borderRadius: '0 0 6px 6px',
-    background: theme.palette.mode === 'light' ? '#F6F8F9' : 'red',
+    background: theme.palette.mode === 'light' ? '#F6F8F9' : '#1E2C37',
     position: 'sticky',
     top: 140,
   },
@@ -292,7 +293,7 @@ const Divider = styled('div')(({ theme }) => ({
       position: 'absolute',
       width: 'calc(100% - 32px)',
       height: 1,
-      background: theme.palette.mode === 'light' ? '#D4D9E1' : 'red',
+      background: theme.palette.mode === 'light' ? '#D4D9E1' : '#31424E',
       top: 8,
       left: 16,
     },
@@ -317,7 +318,7 @@ const Paragraph = styled('p')(({ theme }) => ({
   margin: 0,
   fontSize: 16,
   lineHeight: '22px',
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
 }));
 
 const MilestoneContent = styled('div')(({ theme }) => ({

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
@@ -28,7 +28,7 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   alignSelf: 'stretch',
   padding: '16px 0',
   borderRadius: 6,
-  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : 'red'}`,
+  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : '#31424E'}`,
 
   [theme.breakpoints.up('tablet_768')]: {
     borderRadius: 16,
@@ -55,14 +55,14 @@ const TextProgress = styled('span')(({ theme }) => ({
   fontSize: 14,
   fontWeight: 500,
   lineHeight: '18px',
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
 
   '& span:nth-child(1)': {
-    color: theme.palette.mode === 'light' ? '#1AAB9B' : 'red',
+    color: '#1AAB9B',
   },
 
   '& span:nth-child(2)': {
-    color: theme.palette.mode === 'light' ? '#708390' : 'red',
+    color: theme.palette.mode === 'light' ? '#708390' : '#B6BCC2',
     fontWeight: 700,
   },
 }));

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/PercentageProgressBar.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/PercentageProgressBar.tsx
@@ -31,13 +31,14 @@ const BarContainer = styled('div')(() => ({
 }));
 
 const CircularBarBase = styled(CircularProgress)(({ theme }) => ({
-  color: theme.palette.mode === 'light' ? '#ECF1F3' : 'red',
+  color: theme.palette.mode === 'light' ? '#ECF1F3' : '#31424E',
 }));
 
 const CircularBarProgress = styled(CircularProgress)(() => ({
   animationDuration: '550ms',
   position: 'absolute',
   left: 0,
+  color: '#1AAB9B',
 
   [`& .${circularProgressClasses.circle}`]: {
     strokeLinecap: 'round',
@@ -53,7 +54,7 @@ const LabelContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
   fontWeight: 700,
 
   [theme.breakpoints.up('desktop_1024')]: {

--- a/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
+++ b/src/stories/containers/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
@@ -57,7 +57,7 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   alignSelf: 'stretch',
   padding: 15,
   borderRadius: 6,
-  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : 'red'}`,
+  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : '#31424E'}`,
 
   [theme.breakpoints.up('tablet_768')]: {
     borderRadius: 16,
@@ -84,7 +84,7 @@ const Label = styled('div')(({ theme }) => ({
   fontWeight: 600,
   letterSpacing: 1,
   textTransform: 'uppercase',
-  color: theme.palette.mode === 'light' ? '#434358' : 'red',
+  color: theme.palette.mode === 'light' ? '#434358' : '#B6BCC2',
   alignSelf: 'normal',
 }));
 
@@ -96,7 +96,7 @@ const Value = styled('div')(({ theme }) => ({
   gap: 4,
   fontSize: 14,
   fontWeight: 700,
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
 
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
@@ -105,7 +105,7 @@ const Value = styled('div')(({ theme }) => ({
   '& span': {
     fontSize: 16,
     fontWeight: 700,
-    color: theme.palette.mode === 'light' ? '#9FAFB9' : 'red',
+    color: theme.palette.mode === 'light' ? '#9FAFB9' : '#B6BCC2',
   },
 }));
 
@@ -122,7 +122,7 @@ const Percentage = styled('div')(({ theme }) => ({
   fontWeight: 600,
   lineHeight: 'normal',
   letterSpacing: 0.4,
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
   fontVariantNumeric: 'lining-nums tabular-nums',
 
   [theme.breakpoints.up('desktop_1024')]: {

--- a/styles/theme/dark.ts
+++ b/styles/theme/dark.ts
@@ -1,4 +1,5 @@
 import { createTheme, responsiveFontSizes } from '@mui/material/styles';
+import { breakpoints } from './light';
 
 const darkTheme = responsiveFontSizes(
   createTheme({
@@ -13,6 +14,11 @@ const darkTheme = responsiveFontSizes(
     },
     typography: {
       fontFamily: 'Inter, sans-serif',
+    },
+    breakpoints: {
+      values: {
+        ...breakpoints,
+      },
     },
   })
 );


### PR DESCRIPTION
## Ticket
https://trello.com/c/HIe66Yme/297-rmv-1-roadmaps-and-milestones-view

## Description
Fixed the dark mode on the milestones cards

## What solved
- [X]  Dark Mode. Milestones Roadmap Overview section. **Expected Output:** Background that involves the milestone's name and quarterly period should have color #1F2537. **Current Output:** The background color displayed is #eceff980.
- [X] Dark Mode. Milestones Roadmap Overview section. Progress bar cylinder. **Expected Output:** The Cylinder should use the colors: #1AAB9B, #31424E and the number in the middle of the cilinder with color #D2D4EF