### PR TITLE
[QC] Fix expense comparison percentage when there are not off chain data

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
@@ -225,7 +225,7 @@ export const buildExpensesComparisonRows = (
           formatExpenseMonth(comparison.month),
           formatExpenseWithCurrency(comparison.reportedActuals || 0, currency),
           formatExpenseWithCurrency(comparison.netExpenses.onChainOnly.amount || 0, currency),
-          formatExpenseDifference(comparison.netExpenses.onChainOnly.difference || 0),
+          formatExpenseDifference((comparison.netExpenses.onChainOnly.difference || 0) * 100),
         ],
         comparison.month === currentPeriod,
         false


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Show the percentage of the Expense comparison section of the account snapshots correctly when there are not offchain data

## What solved
- [X] SIDESTREAM ecosystem actor. Accounts Snapshot view, Reported Expenses Comparison section. **Expected Output:** The percent should be displayed properly. **Current Output:** When there is no Off- Chain the percent is displayed -0.10% instead of 10%. 
