### PR TITLE
[MER-1] Avoid query revalidation

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/useDelegateExpenseTrendFinances.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/DelegateExpenseTrendFinances/useDelegateExpenseTrendFinances.tsx
@@ -95,6 +95,12 @@ export const useDelegateExpenseTrendFinances = (budgetPath: string) => {
       }>(GRAPHQL_ENDPOINT, args.query, args.options);
 
       return res.budgetStatements;
+    },
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      revalidateAll: false,
+      revalidateFirstPage: false,
     }
   );
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/zera64wM/312-mer-1-monthly-expense-reports

## Description
Avoid query revalidation on the expense reports page as the data is immutable

## What solved
- [X] Request (paginator).  **Current Output:** Selecting the Load more option, the frontend requests twice the first 10 elements and then requests the second page
