### PR TITLE
[BSN-1] Show only one row of navigation cards

### DIFF
--- a/src/stories/containers/Finances/components/CardNavigationFinance/CardNavigationFinance.tsx
+++ b/src/stories/containers/Finances/components/CardNavigationFinance/CardNavigationFinance.tsx
@@ -26,6 +26,7 @@ const CardNavigationFinance: React.FC<Props> = ({ image, title, description, hre
   const isHasSubLevels = hasSubLevels(codePath, allBudgets);
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const truncatedDescription = truncateDescription(description);
+
   return (
     <StyleCardNavigationGeneric>
       <ContainerImage>
@@ -52,6 +53,7 @@ const CardNavigationFinance: React.FC<Props> = ({ image, title, description, hre
 };
 
 export default CardNavigationFinance;
+
 const StyleCardNavigationGeneric = styled(CardNavigationGeneric)({
   flexDirection: 'column',
   alignItems: 'center',
@@ -61,18 +63,15 @@ const StyleCardNavigationGeneric = styled(CardNavigationGeneric)({
   [lightTheme.breakpoints.up('tablet_768')]: {
     padding: '16px 8px 24px',
     flex: 1,
-    width: 224,
-  },
-  [lightTheme.breakpoints.up('desktop_1024')]: {
-    padding: '16px 8px 24px',
-    width: 309.33,
-  },
-  [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: 373.33,
   },
 
-  [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: 416,
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    padding: '16px 8px 24px',
+    minWidth: 'calc(20% - 13px)',
+  },
+
+  [lightTheme.breakpoints.up('desktop_1280')]: {
+    minWidth: 'calc(20% - 20px)',
   },
 });
 
@@ -99,13 +98,15 @@ const Description = styled.div<WithIsLight>(({ isLight }) => ({
   fontStyle: 'normal',
   fontWeight: 400,
   lineHeight: 'normal',
-  width: 208,
+  maxWidth: 208,
   color: isLight ? '#708390' : '#708390',
+
   [lightTheme.breakpoints.up('desktop_1024')]: {
-    width: 293.3,
+    maxWidth: 293.3,
   },
+
   [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: 236,
+    maxWidth: 236,
   },
 }));
 

--- a/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
 import BigButton from '@ses/components/Button/BigButton/BigButton';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
@@ -8,6 +9,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import CardCoreUnitThirdLevelBudget from '../../CardCoreUnitThirdLevelBudget/CardCoreUnitThirdLevelBudget';
 import CardNavigationFinance from '../../CardNavigationFinance/CardNavigationFinance';
 import CardNavigationMobile from '../../CardNavigationMobile/CardNavigationMobile';
+import type { Theme } from '@mui/material';
 import type { NavigationCard } from '@ses/containers/Finances/utils/types';
 import type { Budget } from '@ses/core/models/interfaces/budget';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -28,6 +30,8 @@ const CardsNavigation: React.FC<Props> = ({
 }) => {
   const { isLight } = useThemeContext();
   const ref = useRef<SwiperRef>(null);
+  const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
+  const MAX_ITEMS = isTablet ? 3 : 5;
 
   // Options of Swiper
   const swiperOptions = {
@@ -63,7 +67,7 @@ const CardsNavigation: React.FC<Props> = ({
   return (
     <ContainerCardsNavigation>
       <WrapperDesk>
-        {cardsNavigationInformation.length > 6 ? (
+        {cardsNavigationInformation.length > MAX_ITEMS ? (
           <SwiperWrapper isLight={isLight}>
             <Swiper
               direction="horizontal"
@@ -153,7 +157,7 @@ const WrapperDesk = styled.div({
     display: 'flex',
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 32,
+    gap: 24,
   },
 });
 
@@ -165,6 +169,7 @@ const SwiperWrapper = styled.div<WithIsLight>(({ isLight }) => ({
     marginBottom: 32,
     display: 'block',
     maxWidth: '100%',
+    width: '100%',
   },
 
   '& .swiper-slide': {


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Show 5 navigation cards on desktop and 3 in tablet, if there are more, then show a carrousel to avoid having multiple rows

## What solved
- [X] The navigation cards should be displayed in one row. More than 5, carousels should be introduced.  **Current Output:**  The cards are displayed in two rows and the second one displays a card across the width of the view. 
