### PR TITLE
[BSN-1] Fix protocol overflow metric in expense reports

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReportsFilters.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReportsFilters.tsx
@@ -63,9 +63,10 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
               labelWhenSelected: 'Net Off-chain',
             },
             {
-              label: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',
-              value: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',
-              labelWhenSelected: 'Net On-chain',
+              label: 'Net Protocol Outflow',
+              value: 'Protocol Outflow',
+              // eslint-disable-next-line spellcheck/spell-checker
+              labelWhenSelected: 'Prtcol Outfl',
             },
             {
               label: 'Actuals',


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Replace off chain with protocol overflow in expense report

## What solved
- [X] Monthly Expense reports section- ** **Expected Output:**  The filter should display Net Protocol Outflow. **Current Output:**  Net Expense Off-Chain is still visible.
