### PR TITLE
[BSN-1] Change finances link in the navbar

### DIFF
--- a/src/stories/components/Header/menuItems.ts
+++ b/src/stories/components/Header/menuItems.ts
@@ -23,7 +23,9 @@ const menuItems = {} as Record<RouteOnHeader, MenuType>;
 if (featureFlags[CURRENT_ENVIRONMENT].FEATURE_FINANCES_OVERVIEW) {
   menuItems.finances = {
     title: 'Finances',
-    link: siteRoutes.financesOverview,
+    link: featureFlags[CURRENT_ENVIRONMENT].FEATURE_ECOSYSTEM_FINANCES_DASHBOARD_PAGE
+      ? siteRoutes.finances()
+      : siteRoutes.financesOverview,
     marginRight: '32px',
   };
 }


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Change the target of the Finances link in the navbar. This link now point to the new finances page (available thought feature flags)

## What solved
- [X] The system should direct to the new Finances page
