### PR TITLE
[BSN-1] Fix the No-name with the code path

### DIFF
--- a/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
@@ -100,7 +100,7 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
 }));
 
 const ContainerTitle = styled.div<WithIsLight>({
-  width: 76,
+  minWidth: 76,
   display: 'flex',
   alignItems: 'center',
   whiteSpace: 'break-spaces',

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
@@ -90,7 +90,7 @@ const TitleContainer = styled.div<WithIsLight>(({ isLight }) => ({
   alignItems: 'center',
   height: 48,
   borderRight: `1px solid ${isLight ? '#D1DEE6' : '#546978'}`,
-  width: 85,
+  minWidth: 85,
   padding: '16px 16px 16px 8px',
 }));
 

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -41,7 +41,7 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   const levelOfDetail = levelNumber + 1;
   const currentBudget = allBudgets.find((budget) => budget.codePath === codePath);
   const icon = currentBudget?.image;
-  const title = nameChanged(currentBudget?.name || '');
+  const title = nameChanged((currentBudget?.name || codePath) ?? '');
   const handleChangeYears = (value: string) => {
     setYear(value);
     router.push(
@@ -84,7 +84,8 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
         // it is a deeper level
         trailingAddressDesktop.push({
           label: nameChanged(
-            allBudgets.find((budget) => budget.codePath === segmentedCodePath.slice(0, index + 1).join('/'))?.name || ''
+            allBudgets.find((budget) => budget.codePath === segmentedCodePath.slice(0, index + 1).join('/'))?.name ??
+              codePath
           ),
           url: `${siteRoutes.finances(segmentedCodePath.slice(1, index + 1).join('/'))}?year=${year}`,
         });


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Change the No-Name text for the code Path text

## What solved
- [X] :Breakdown Table, Selecting the category without name- ** **Expected Output:** The breadcrumb and the page should display the path as the name. **Current Output:**  The breadcrumb and the page display "No-Name"  as the name. 

