### PR TITLE
[BSN-1] Split the carousel into pages

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -34,7 +34,7 @@ const CardsNavigation: React.FC<Props> = ({
   const MAX_ITEMS = isTablet ? 3 : 5;
 
   // Options of Swiper
-  const swiperOptions = {
+  const swiperOptions: SwiperProps = {
     pagination: {
       type: 'bullets',
       enabled: true,
@@ -44,25 +44,30 @@ const CardsNavigation: React.FC<Props> = ({
       768: {
         slidesPerView: 'auto',
         spaceBetween: 16,
+        slidesPerGroup: 3,
       },
       1024: {
         slidesPerView: 'auto',
         spaceBetween: 8,
+        slidesPerGroup: 3,
       },
       1280: {
         slidesPerView: 'auto',
         spaceBetween: 8,
+        slidesPerGroup: 5,
       },
       1440: {
         slidesPerView: 'auto',
         spaceBetween: 8,
+        slidesPerGroup: 5,
       },
       1920: {
         slidesPerView: 'auto',
         spaceBetween: 8,
+        slidesPerGroup: 5,
       },
     },
-  } as SwiperProps;
+  };
 
   return (
     <ContainerCardsNavigation>


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Now the pages of the carousel change by half page instead of cards 1 by 1

## What solved
- [X]  Navigation cards (carousel). Selecting the navigation component- ** **Expected Output:** The cards should be displayed by pages. **Current Output:**  The cards are displayed of 1 to 1.
