### PR TITLE
[BSN-1] Keep the table filter status when navigating to a deeper level

### DIFF
--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -47,12 +47,16 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
         <TableContainer isLight={isLight} className={className} key={index} hasOthers={table.others || false}>
           <TableBody isLight={isLight}>
             {table.rows.map((row: ItemRow, index) => {
-              const href = `${siteRoutes.finances((row.codePath ?? '').replace('atlas/', ''))}?year=${year}`;
+              const href = `${siteRoutes.finances(
+                (row.codePath ?? '').replace('atlas/', '')
+              )}?year=${year}#breakdown-table`;
 
               return (
                 <TableRow key={index} isLight={isLight} isMain={row.isMain}>
                   <Headed isLight={isLight} period={period}>
-                    <Link href={href}>{row.name}</Link>
+                    <Link href={href} scroll={false}>
+                      {row.name}
+                    </Link>
                   </Headed>
 
                   {showAnnual &&

--- a/src/stories/containers/Finances/components/LinkCellComponent/LinkCellComponent.tsx
+++ b/src/stories/containers/Finances/components/LinkCellComponent/LinkCellComponent.tsx
@@ -8,7 +8,9 @@ interface Props {
 }
 
 const LinkCellComponent: React.FC<Props & PropsWithChildren> = ({ href, children }) => (
-  <StyledLink href={href}>{children}</StyledLink>
+  <StyledLink href={href} scroll={false}>
+    {children}
+  </StyledLink>
 );
 export default LinkCellComponent;
 const StyledLink = styled(Link)({


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
When navigating through the table items keep the table filter status

## What solved
- [X] The metrics and period should be added to the URL as parameters. When a section is shared the filters selected should remain. 