### PR TITLE
[BSN-1] Fix first sections charts

### DIFF
--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -114,6 +114,7 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
 
         {isEnabled('FEATURE_FINANCES_BREAKDOWN_CHART_SECTION') && (
           <BreakdownChartSection
+            isLoading={breakdownChartSectionData.isLoading}
             year={year}
             selectedMetric={breakdownChartSectionData.selectedBreakdownMetric}
             selectedGranularity={breakdownChartSectionData.selectedBreakdownGranularity}

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -6,7 +6,7 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import ReactECharts from 'echarts-for-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import type { BreakdownChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -33,106 +33,117 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
   const isTablet = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
   const upTable = useMediaQuery(lightTheme.breakpoints.up('tablet_768'));
   const isDesktop1024 = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
-
-  const [visibleSeries, setVisibleSeries] = useState<BreakdownChartSeriesData[]>(series);
-  const [legends, setLegends] = useState<BreakdownChartSeriesData[]>(series);
   const showLineYear =
     isMobile && (selectedGranularity as string) !== 'Quarterly' && (selectedGranularity as string) !== 'Annually';
-  useEffect(() => {
-    setVisibleSeries(series);
-    setLegends(series);
-  }, [series]);
 
-  const xAxisStyles = {
-    fontFamily: 'Inter, sans-serif',
-    textAlign: 'center',
-    color: '#708390',
-    fontWeight: 600,
-    fontSize: upTable ? 12 : 9,
-    verticalAlign: 'top',
-    interval: 0,
-  };
-  const options: EChartsOption = {
-    tooltip: createChartTooltip(selectedGranularity, year, isLight, isMobile),
-    grid: {
-      height: isMobile ? 192 : isTablet ? 390 : isDesktop1024 ? 392 : isDesktop1280 ? 392 : 392,
-      width: isMobile ? 304 : isTablet ? 630 : isDesktop1024 ? 678 : isDesktop1280 ? 955 : 955,
-      top: isMobile ? 10 : isTablet ? 10 : isDesktop1024 ? 6 : isDesktop1280 ? 11 : 11,
-      right: isMobile ? 2 : isTablet ? 7 : isDesktop1024 ? 50 : isDesktop1280 ? 4 : 4,
-    },
-    xAxis: {
-      show: true,
-      type: 'category',
-      data: getGranularity(selectedGranularity, isMobile),
-      splitLine: {
-        show: false,
+  const xAxisStyles = useMemo(
+    () => ({
+      fontFamily: 'Inter, sans-serif',
+      textAlign: 'center',
+      color: '#708390',
+      fontWeight: 600,
+      fontSize: upTable ? 12 : 9,
+      verticalAlign: 'top',
+      interval: 0,
+    }),
+    [upTable]
+  );
+
+  const options: EChartsOption = useMemo(
+    () => ({
+      tooltip: createChartTooltip(selectedGranularity, year, isLight, isMobile),
+      grid: {
+        height: isMobile ? 192 : isTablet ? 390 : isDesktop1024 ? 392 : isDesktop1280 ? 392 : 392,
+        width: isMobile ? 304 : isTablet ? 630 : isDesktop1024 ? 678 : isDesktop1280 ? 955 : 955,
+        top: isMobile ? 10 : isTablet ? 10 : isDesktop1024 ? 6 : isDesktop1280 ? 11 : 11,
+        right: isMobile ? 2 : isTablet ? 7 : isDesktop1024 ? 50 : isDesktop1280 ? 4 : 4,
       },
-      axisLine: {
-        show: false,
-        symbolOffset: 'left',
-        lineStyle: {
-          color: 'transparent',
-        },
-      },
-      axisTick: {
-        show: false,
-      },
-      axisLabel: {
-        margin: isMobile ? 12 : isTablet ? 18 : isDesktop1024 ? 20 : isDesktop1280 ? 16 : 16,
-        color: isLight ? '#434358' : '#708390',
-        align: 'center',
-        fontFamily: 'Inter,san-serif',
-        fontWeight: 400,
-        fontSize: upTable ? 12 : 9,
-        height: upTable ? 15 : 11,
-        baseline: 'top',
-        interval: 0,
-        formatter: function (value: string) {
-          const formatted = formatterBreakDownChart(selectedGranularity as AnalyticGranularity, isMobile, year, value);
-          return formatted;
-        },
-        rich: {
-          month: xAxisStyles,
-          year: xAxisStyles,
-        },
-      },
-    },
-    yAxis: {
-      min: visibleSeries.length === 0 ? 0 : null,
-      max: visibleSeries.length === 0 ? 1 : null,
-      show: true,
-      axisLabel: {
+      xAxis: {
         show: true,
-        margin: isMobile ? 10 : isTablet ? 22 : isDesktop1024 ? 32 : isDesktop1280 ? 20 : 20,
-        formatter: function (value: number, index: number) {
-          if (value === 0 && index === 0) {
-            return value.toString();
-          }
+        type: 'category',
+        data: getGranularity(selectedGranularity, isMobile),
+        splitLine: {
+          show: false,
+        },
+        axisLine: {
+          show: false,
+          symbolOffset: 'left',
+          lineStyle: {
+            color: 'transparent',
+          },
+        },
+        axisTick: {
+          show: false,
+        },
+        axisLabel: {
+          margin: isMobile ? 12 : isTablet ? 18 : isDesktop1024 ? 20 : isDesktop1280 ? 16 : 16,
+          color: isLight ? '#434358' : '#708390',
+          align: 'center',
+          fontFamily: 'Inter,san-serif',
+          fontWeight: 400,
+          fontSize: upTable ? 12 : 9,
+          height: upTable ? 15 : 11,
+          baseline: 'top',
+          interval: 0,
+          formatter: function (value: string) {
+            const formatted = formatterBreakDownChart(
+              selectedGranularity as AnalyticGranularity,
+              isMobile,
+              year,
+              value
+            );
+            return formatted;
+          },
+          rich: {
+            month: xAxisStyles,
+            year: xAxisStyles,
+          },
+        },
+      },
+      yAxis: {
+        min: series.length === 0 ? 0 : null,
+        max: series.length === 0 ? 1 : null,
+        show: true,
+        axisLabel: {
+          show: true,
+          margin: isMobile ? 10 : isTablet ? 22 : isDesktop1024 ? 32 : isDesktop1280 ? 20 : 20,
+          formatter: function (value: number, index: number) {
+            if (value === 0 && index === 0) {
+              return value.toString();
+            }
 
-          return replaceAllNumberLetOneBeforeDot(value);
+            return replaceAllNumberLetOneBeforeDot(value);
+          },
+          color: isLight ? '#231536' : '#EDEFFF',
+          fontSize: isMobile ? 10 : isTablet ? 14 : 14,
+          height: upTable ? 15 : 12,
+          fontFamily: 'Inter, sans-serif',
+          fontWeight: upTable ? 600 : 400,
         },
-        color: isLight ? '#231536' : '#EDEFFF',
-        fontSize: isMobile ? 10 : isTablet ? 14 : 14,
+        verticalAlign: 'middle',
         height: upTable ? 15 : 12,
-        fontFamily: 'Inter, sans-serif',
-        fontWeight: upTable ? 600 : 400,
-      },
-      verticalAlign: 'middle',
-      height: upTable ? 15 : 12,
-      type: 'value',
-      zlevel: 1,
-      axisLine: {
-        show: false,
-      },
-      splitLine: {
-        lineStyle: {
-          color: isLight ? '#31424E' : '#D8E0E3',
-          width: 0.25,
+        type: 'value',
+        zlevel: 1,
+        axisLine: {
+          show: false,
+        },
+        splitLine: {
+          lineStyle: {
+            color: isLight ? '#31424E' : '#D8E0E3',
+            width: 0.25,
+          },
         },
       },
-    },
-    series: visibleSeries,
-  };
+      series,
+    }),
+    [isDesktop1024, isDesktop1280, isLight, isMobile, isTablet, selectedGranularity, series, upTable, xAxisStyles, year]
+  );
+
+  useEffect(() => {
+    // avoid to merge data when moving between levels
+    const chartInstance = refBreakDownChart.current.getEchartsInstance();
+    chartInstance.setOption(options, { notMerge: true });
+  }, [options, refBreakDownChart]);
 
   const onLegendItemHover = (legendName: string) => {
     const chartInstance = refBreakDownChart.current.getEchartsInstance();
@@ -169,7 +180,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
         )}
       </ChartContainer>
       <LegendContainer>
-        {legends.map((element, index) => (
+        {series.map((element, index) => (
           <LegendItem
             key={index}
             isLight={isLight}

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
@@ -9,6 +9,7 @@ import type { AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
 import type { EChartsOption } from 'echarts-for-react';
 
 export interface BreakdownChartSectionProps {
+  isLoading: boolean;
   selectedMetric: string;
   onMetricChange: (value: string) => void;
   selectedGranularity: string;
@@ -22,6 +23,7 @@ export interface BreakdownChartSectionProps {
 }
 
 const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
+  isLoading,
   year,
   selectedMetric,
   onMetricChange,
@@ -49,13 +51,27 @@ const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
       />
     </HeaderContainer>
 
-    <BreakdownChart
-      year={year}
-      selectedGranularity={selectedGranularity as AnalyticGranularity}
-      series={series}
-      handleToggleSeries={handleToggleSeries}
-      refBreakDownChart={refBreakDownChart}
-    />
+    {isLoading ? (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: 300,
+          color: 'red',
+        }}
+      >
+        loading...
+      </div>
+    ) : (
+      <BreakdownChart
+        year={year}
+        selectedGranularity={selectedGranularity as AnalyticGranularity}
+        series={series}
+        handleToggleSeries={handleToggleSeries}
+        refBreakDownChart={refBreakDownChart}
+      />
+    )}
   </Section>
 );
 

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -4,7 +4,7 @@ import { calculateValuesByBreakpoint } from '@ses/containers/Finances/utils/util
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import ReactECharts from 'echarts-for-react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Navigation, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import CardLegend from './CardLegend';
@@ -54,24 +54,25 @@ const DoughnutChartFinances: React.FC<Props> = ({
 
   const doughnutSeriesChunks = chunkArray(doughnutSeriesData, numberSliderPerLevel);
   const numberSlider = doughnutSeriesChunks.size;
-  const options = {
-    color: visibleSeries.map((data) => data.color),
-    tooltip: {
-      show: true,
-      trigger: 'item',
-      label: {
-        show: false,
-        position: 'center',
-      },
-      emphasis: {
-        width: 40,
-      },
-      padding: 0,
-      borderWidth: 2,
-      formatter: function (params: DoughnutSeries) {
-        const index = visibleSeries.findIndex((data) => data.name === params.name);
-        const itemRender = visibleSeries[index];
-        const customTooltip = `
+  const options = useMemo(
+    () => ({
+      color: visibleSeries.map((data) => data.color),
+      tooltip: {
+        show: true,
+        trigger: 'item',
+        label: {
+          show: false,
+          position: 'center',
+        },
+        emphasis: {
+          width: 40,
+        },
+        padding: 0,
+        borderWidth: 2,
+        formatter: function (params: DoughnutSeries) {
+          const index = visibleSeries.findIndex((data) => data.name === params.name);
+          const itemRender = visibleSeries[index];
+          const customTooltip = `
         <div style="background-color:${
           isLight ? '#fff' : '#000A13'
         };padding:16px;min-width:194px;overflow:auto;border-radius:3px;">
@@ -82,8 +83,8 @@ const DoughnutChartFinances: React.FC<Props> = ({
           <div style="display:flex;flex-direction:row;gap:20px">
               <div style="display:flex;flex-direction:column">
                 <div style="margin-bottom:4;color:${isLight ? '#000' : '#EDEFFF'};">${itemRender.actuals.toLocaleString(
-          'es-US'
-        )}</div>
+            'es-US'
+          )}</div>
                 <div style="font-weight:bold;color:${isLight ? '#231536' : '#9FAFB9'};">Actuals</div>
              </div>
               <div style="display:flex;flex-direction:column">
@@ -96,30 +97,32 @@ const DoughnutChartFinances: React.FC<Props> = ({
         </div>
         `;
 
-        return customTooltip;
+          return customTooltip;
+        },
       },
-    },
 
-    series: [
-      {
-        name: 'Overview Card',
-        type: 'pie',
-        radius,
-        center,
-        label: {
-          normal: {
-            show: false,
+      series: [
+        {
+          name: 'Overview Card',
+          type: 'pie',
+          radius,
+          center,
+          label: {
+            normal: {
+              show: false,
+            },
           },
-        },
-        labelLine: {
-          normal: {
-            show: false,
+          labelLine: {
+            normal: {
+              show: false,
+            },
           },
+          data: visibleSeries,
         },
-        data: visibleSeries,
-      },
-    ],
-  };
+      ],
+    }),
+    [center, isLight, radius, visibleSeries]
+  );
 
   const toggleSeriesVisibility = (seriesName: string) => {
     const chartInstance = chartRef.current?.getEchartsInstance();
@@ -216,6 +219,12 @@ const DoughnutChartFinances: React.FC<Props> = ({
       },
     },
   } as SwiperProps;
+
+  useEffect(() => {
+    // avoid to merge data when moving between levels
+    const chartInstance = chartRef.current?.getEchartsInstance();
+    chartInstance?.setOption(options, { notMerge: true });
+  }, [options]);
 
   return (
     <Container className={className} isCoreThirdLevel={isCoreThirdLevel}>

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -53,19 +53,9 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
 
   // TODO: we should be using only one query and refetch the data depending on the selected granularity
   const { data: budgetsAnalytics } = useSWRImmutable(
-    'analytics/annual',
+    ['annual', year, codePath, levelOfDetail, budgets],
     async () =>
       getBudgetsAnalytics('annual', year, codePath, levelOfDetail, budgets) as Promise<BreakdownBudgetAnalytic>
-  );
-  const { data: budgetsAnalyticsQuarterly } = useSWRImmutable(
-    'analytics/quarterly',
-    async () =>
-      getBudgetsAnalytics('quarterly', year, codePath, levelOfDetail, budgets) as Promise<BreakdownBudgetAnalytic>
-  );
-  const { data: budgetsAnalyticsMonthly } = useSWRImmutable(
-    'analytics/monthly',
-    async () =>
-      getBudgetsAnalytics('monthly', year, codePath, levelOfDetail, budgets) as Promise<BreakdownBudgetAnalytic>
   );
 
   // generate the breadcrumb routes
@@ -114,6 +104,16 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
 
   const colorsDark = generateColorPalette(180, budgets.length, existingColorsDark);
 
+  // All the logic required by the CardChartOverview section
+  const cardOverViewSectionData = useCardChartOverview(
+    budgets,
+    budgetsAnalytics,
+    levelNumber,
+    allBudgets,
+    codePath,
+    year
+  );
+
   // All the logic required by the CardNavigation section
   const cardsNavigationInformation = budgets.map((item, index) => {
     const budgetMetric =
@@ -144,25 +144,10 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   const cardsToShow = loadMoreCards && isMobile ? cardsNavigationInformation.slice(0, 6) : cardsNavigationInformation;
 
   // All the logic required by the breakdown chart section
-  const breakdownChartSectionData = useBreakdownChart(
-    budgets,
-    budgetsAnalyticsMonthly,
-    budgetsAnalyticsQuarterly,
-    budgetsAnalytics
-  );
+  const breakdownChartSectionData = useBreakdownChart(budgets, year, codePath);
 
   // All the logic required by the Expense Reports
   const expenseTrendFinances = useExpenseReports(codePath);
-
-  // All the logic required by the CardChartOverview section
-  const cardOverViewSectionData = useCardChartOverview(
-    budgets,
-    budgetsAnalytics,
-    levelNumber,
-    allBudgets,
-    codePath,
-    year
-  );
 
   // All the logic required by the BreakdownTable section
   const breakdownTable = useBreakdownTable(year, budgets, allBudgets);


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix the breakdown chart and the Doughnut chart of the first section when the user browses in deeper levels and goes back to cached data

## What solved
- [X] The view should display all budgets coming from the API. **Current Output:**  The breakdown chart is displaying 2 new values but the rest of the sections don't. 
