### PR TITLE
[BSN-1] Fix resize the windows was redirecting to finances

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -75,6 +75,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
         .replace(
           {
             query: {
+              path: router.query.path,
               year,
               metric: metrics,
               period: granularity,


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
When the windows are resized in the finances page it was redirecting to the finances root page when it should keep in the same page

## What solved
- [X] Finances->Scope Frameworks Budget->Support Scope->EAE. Changing the resolution.- ** **Expected Output:**  The current page should remain visible. **Current Output:**  The system resets and the MakerDao level is displayed or the current data is displayed but with the breadcrumb and page title as MakerDao level.
