### PR TITLE
Put the default metric for granularity

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterFallChartSection/useReservesWaterFallChart.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterFallChartSection/useReservesWaterFallChart.tsx
@@ -36,6 +36,7 @@ export const useReservesWaterFallChart = (codePath: string, budgets: Budget[], a
   };
   const handleResetFilter = () => {
     setActiveElements(selectAll);
+    setSelectedGranularity('monthly');
   };
 
   // fetch actual data from the API


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix issues in the filter in the reserves chart

## What solved
- [X] Selecting the Reset option. The Reset option should reset the filter to the default state.  The AllMakerDao filter is reset and with that action, the chart displays only the lines. 

