### PR TITLE
Add function to close the modal

### DIFF
--- a/src/stories/components/Pagination/BreadCrumbWithIcons.tsx
+++ b/src/stories/components/Pagination/BreadCrumbWithIcons.tsx
@@ -125,7 +125,7 @@ const BreadCrumbWithIcons = ({ title, items = [], className, marginRightSeparato
               }}
               legacyBehavior
             >
-              <ItemMenu>{item.label}</ItemMenu>
+              <ItemMenu onClick={handleClose}>{item.label}</ItemMenu>
             </Link>
           </MenuItem>
         ))}


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Close the modal when some item are selecting

## What solved
- [X] MakerDAO Legacy Budget. Selecting the option to go back.  A modal with the breadcrumb elements should be listed and the modal should disappear when an element is selected. Selecting an element the modal is still visible and overlaps the breadcrumb. 
