### PR TITLE
[BSN-1] Show rows and other if necessary in the subtables

### DIFF
--- a/src/core/utils/const.ts
+++ b/src/core/utils/const.ts
@@ -15,5 +15,5 @@ export const COOKIES_POLICY_PARAGRAPH_FOUR =
 
 export const LOCAL_STORAGE_AUTH_KEY = 'auth';
 export const DELEGATE_PAGE = 'https://vote.makerdao.com/delegates';
-export const NUMBER_ROWS_FINANCES_TABLE = 16;
+export const MAX_ROWS_FINANCES_TABLE = 16;
 export const UMBRAL_CHART_WATERFALL = 0.000001;


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
If a suitable in finances has sub budgets they should be shown as rows, but show up to 16 rows in total

## What solved
- [X] FInances->MakerDAO Legacy Budget. Breakdown table section.-**  **Expected Output:** The table should display the sub-categories per each budget category.  **Current Output:** The sub-categories are not displayed.
