### PR TITLE
Fix the colors line in dark mode

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterFallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterFallChartSection/utils.ts
@@ -281,7 +281,8 @@ export const generateLineSeries = (lineSeriesData: number[], isLight: boolean) =
 
   for (let i = 1; i < newLineSeries.length; i++) {
     const isAscending = positiveNegativeLine[i - 1];
-    const color = isLight ? (isAscending ? '#06554C' : '#A83815') : isAscending ? '#06554C' : '#A83815';
+    // const color = 'green';
+    const color = isLight ? (isAscending ? '#06554C' : '#A83815') : isAscending ? '#06554C' : '#641E08';
     const seriesData = new Array(newLineSeries.length).fill('-');
     seriesData[i - 1] = newLineSeries[i - 1];
     seriesData[i] = newLineSeries[i];


### PR DESCRIPTION
## Ticket
https://trello.com/c/qmqD8fNL/311-rc-1-reserves-chart

## Description
Fix colors line decrease amount in the dark mode

## What solved
- [X]  Lines connecting the bars. **Expected Output:** The lines should be slim and positioned as defined in the design. Change the red color to #641E08. Part of the line is visible on the top/bottom of the bar no as part of it.

