### PR TITLE
[BSN-1] Remove "Others" link

### DIFF
--- a/src/stories/containers/Finances/components/FinacesTable/CellTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/CellTable.tsx
@@ -12,14 +12,15 @@ interface Props {
   metrics: string[];
   value: MetricValues;
   href: string;
+  isSummaryRow?: boolean;
 }
 
-const CellTable: React.FC<Props> = ({ metrics, value, href }) => {
+const CellTable: React.FC<Props> = ({ metrics, value, href, isSummaryRow }) => {
   const element = filterMetricValues(value, metrics as (keyof MetricValues)[]);
   const { isLight } = useThemeContext();
   return (
     <Cell isLight={isLight}>
-      <LinkCellComponent href={href}>
+      <LinkCellComponent href={href} isSummaryRow={isSummaryRow}>
         <SpacedValues>
           {metrics.map((metric, index) => (
             <Span key={index} isLight={isLight}>

--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -54,9 +54,13 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
               return (
                 <TableRow key={index} isLight={isLight} isMain={row.isMain}>
                   <Headed isLight={isLight} period={period}>
-                    <Link href={href} scroll={false}>
-                      {row.name}
-                    </Link>
+                    {row.isSummaryRow ? (
+                      row.name
+                    ) : (
+                      <Link href={href} scroll={false}>
+                        {row.name}
+                      </Link>
+                    )}
                   </Headed>
 
                   {showAnnual &&
@@ -66,13 +70,15 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
                       if (!value) {
                         return (
                           <Cell key={index} isLight={isLight}>
-                            <LinkCellComponent href={href}>0</LinkCellComponent>
+                            <LinkCellComponent href={href} isSummaryRow={row.isSummaryRow}>
+                              0
+                            </LinkCellComponent>
                           </Cell>
                         );
                       }
                       return (
                         <Cell key={index} isLight={isLight}>
-                          <LinkCellComponent href={href}>
+                          <LinkCellComponent href={href} isSummaryRow={row.isSummaryRow}>
                             {usLocalizedNumber(row.columns[0][metric as keyof MetricValues], 0)}
                           </LinkCellComponent>
                         </Cell>
@@ -81,15 +87,33 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
 
                   {showQuarterly &&
                     arrayMetrics.map((_, index) => (
-                      <CellTable key={index} metrics={newMetrics} value={row.columns[index]} href={href} />
+                      <CellTable
+                        key={index}
+                        metrics={newMetrics}
+                        value={row.columns[index]}
+                        href={href}
+                        isSummaryRow={row.isSummaryRow}
+                      />
                     ))}
                   {showSemiAnnual &&
                     arrayMetrics.map((_, index) => (
-                      <CellTable key={index} metrics={newMetrics} value={row.columns[index]} href={href} />
+                      <CellTable
+                        key={index}
+                        metrics={newMetrics}
+                        value={row.columns[index]}
+                        href={href}
+                        isSummaryRow={row.isSummaryRow}
+                      />
                     ))}
                   {showMonthly &&
                     arrayMetrics.map((_, index) => (
-                      <CellTable key={index} metrics={newMetrics} value={row.columns[index]} href={href} />
+                      <CellTable
+                        key={index}
+                        metrics={newMetrics}
+                        value={row.columns[index]}
+                        href={href}
+                        isSummaryRow={row.isSummaryRow}
+                      />
                     ))}
                 </TableRow>
               );

--- a/src/stories/containers/Finances/components/LinkCellComponent/LinkCellComponent.tsx
+++ b/src/stories/containers/Finances/components/LinkCellComponent/LinkCellComponent.tsx
@@ -1,18 +1,37 @@
-import styled from '@emotion/styled';
+import { styled } from '@mui/material';
 import Link from 'next/link';
 import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 interface Props {
   href: string;
+  isSummaryRow?: boolean;
 }
 
-const LinkCellComponent: React.FC<Props & PropsWithChildren> = ({ href, children }) => (
-  <StyledLink href={href} scroll={false}>
-    {children}
-  </StyledLink>
-);
+const LinkCellComponent: React.FC<Props & PropsWithChildren> = ({ href, children, isSummaryRow }) =>
+  isSummaryRow ? (
+    <Span>{children}</Span>
+  ) : (
+    <StyledLink href={href} scroll={false}>
+      {children}
+    </StyledLink>
+  );
 export default LinkCellComponent;
+
+const Span = styled('span')({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textDecoration: 'none',
+  color: 'inherit',
+  zIndex: 1,
+});
+
 const StyledLink = styled(Link)({
   position: 'absolute',
   top: 0,

--- a/src/stories/containers/Finances/utils/types.ts
+++ b/src/stories/containers/Finances/utils/types.ts
@@ -119,6 +119,7 @@ export interface LineChartSeriesData {
 export interface ItemRow {
   name: string;
   isMain?: boolean;
+  isSummaryRow?: boolean;
   codePath?: string;
   columns: MetricValues[];
 }

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -579,6 +579,7 @@ export const showOnlySixteenRowsWithOthers = (data: TableFinances[]) => {
           },
           {
             name: 'Others',
+            isSummaryRow: true,
             columns: subTable.rows[0].columns.map(() => ({
               Actuals: 0,
               Budget: 0,


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Remove the link of the "Others" row as it is a summary and not a budget

## What solved
- [X] Finances->Scope Frameworks Budget. Breakdown table section, The "Others" row .- ** **Expected Output:** It should be a summary of the subcategories not displayed and should not be defined as a link .**Current Output:**  The row is defined as a link. 
