### PR TITLE
[BSN-1] Protocol Outflow on mobile in the breakdown chart section

### DIFF
--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -155,6 +155,8 @@ const dictionary = [
   'nums',
   'customizable',
   'cancelled',
+  'Prtcol',
+  'Outfl',
 ];
 
 module.exports = dictionary;

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -61,7 +61,8 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
             {
               label: 'Net Protocol Outflow',
               value: 'ProtocolNetOutflow',
-              labelWhenSelected: 'Protocol Outflow',
+              // eslint-disable-next-line spellcheck/spell-checker
+              labelWhenSelected: isMobile ? 'Prtcol Outfl' : 'Protocol Outflow',
             },
             {
               label: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -61,7 +61,6 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
             {
               label: 'Net Protocol Outflow',
               value: 'ProtocolNetOutflow',
-              // eslint-disable-next-line spellcheck/spell-checker
               labelWhenSelected: isMobile ? 'Prtcol Outfl' : 'Protocol Outflow',
             },
             {


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Shorten the Protocol Outflow label on mobile in the breakdown chart section

## What solved
- [X] Breakdown Chart, Metric: Protocol Outflow selected.- ** **Expected Output:** The component should keep its size as it is displayed in the Expense Reports section.  **Current Output:** The component modified its height to show the metric text
