### PR TITLE
fix: finances icon title width

### DIFF
--- a/src/stories/components/IconTitle/IconTitle.tsx
+++ b/src/stories/components/IconTitle/IconTitle.tsx
@@ -1,10 +1,8 @@
-import styled from '@emotion/styled';
+import { styled } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import Image from 'next/image';
 import React from 'react';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   title: string;
@@ -13,7 +11,6 @@ interface Props {
 }
 
 const IconTitle: React.FC<Props> = ({ icon, title, className }) => {
-  const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
 
   return (
@@ -21,32 +18,35 @@ const IconTitle: React.FC<Props> = ({ icon, title, className }) => {
       <Icon>
         <ImageStyle src={icon} width={isMobile ? 29 : 32} height={isMobile ? 29 : 32} alt="Picture" unoptimized />
       </Icon>
-      <Title isLight={isLight}>{title}</Title>
+      <Title>{title}</Title>
     </Container>
   );
 };
 
 export default IconTitle;
 
-const Container = styled.div({
+const Container = styled('div')({
   display: 'flex',
   flexDirection: 'row',
   gap: 8,
   alignItems: 'center',
 });
-const Title = styled.div<WithIsLight>(({ isLight }) => ({
+
+const Title = styled('div')(({ theme }) => ({
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
   fontWeight: 600,
   fontSize: 20,
   letterSpacing: '0.4px',
-  color: isLight ? '#231536' : '#D2D4EF',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
+
   [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 32,
     lineHeight: 'normal',
   },
 }));
-const Icon = styled.div({
+
+const Icon = styled('div')({
   overflow: 'hidden',
   display: 'flex',
   justifyContent: 'center',
@@ -67,6 +67,11 @@ const Icon = styled.div({
   },
 });
 
-const ImageStyle = styled(Image)({
+const ImageStyle = styled(Image)(({ theme }) => ({
   borderRadius: 22,
-});
+  minWidth: 29,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    minWidth: 32,
+  },
+}));


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix icon width on mobile when the title is too long

## What solved
- [X] Finances->Scope Frameworks Budget->Support Scope->EAE. Icon.- ** **Expected Output:**  The icon should be displayed with the proper size.  **Current Output:**  The name is longer causing the icon to look ovalad.
