### PR TITLE
[BSN-1] Fix on chain metric on the expense reports section

### DIFF
--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
@@ -60,8 +60,7 @@ const DelegateExpenseTrendItem: React.FC<Props> = ({ budget, selectedMetric, now
         return budget.actualExpenses ?? 0;
       case 'Forecast':
         return budget.forecastExpenses ?? 0;
-      case 'Net Expenses On-chain':
-      case 'Net On-chain':
+      case 'Net On-Chain':
         return budget.paymentsOnChain ?? 0;
       case 'Protocol Outflow':
         return budget.netProtocolOutflow ?? 0;

--- a/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReportsFilters.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReportsFilters.tsx
@@ -56,15 +56,15 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
               value: 'Forecast',
             },
             {
-              label: !isMobile ? 'Net Expenses Off-chain' : 'Net Exp. Off-Chain Incl.',
-              value: !isMobile ? 'Net Off-chain' : 'Net Exp. Off-Chain Incl.',
-              labelWhenSelected: 'Net Off-chain',
-            },
-            {
               label: 'Net Protocol Outflow',
               value: 'Protocol Outflow',
               // eslint-disable-next-line spellcheck/spell-checker
               labelWhenSelected: 'Prtcol Outfl',
+            },
+            {
+              label: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',
+              value: 'Net On-Chain',
+              labelWhenSelected: 'Net On-chain',
             },
             {
               label: 'Actuals',


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Remove off chain metric and set the on chain metric in the expense reports filter

## What solved
- [X]  **- Expense Reports section, Metrics filter.- ** **Expected Output:** Net Expenses On-chain should be listed in the metrics. **Current Output:**  The metric Net Expenses On-chain is missing and instead appears as Net Expenses Off-chain. 
