### PR TITLE
[BSN-1] Restore max amount of metric in annual when the granularity is changed to Annual

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -351,6 +351,9 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     updateUrl(periodFilter, METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics));
   };
   const handlePeriodChange = (value: string) => {
+    if (value === 'Annually') {
+      setActiveMetrics(METRIC_FILTER_OPTIONS.slice(0, isMobile ? 3 : 5));
+    }
     setPeriodFilter(value as PeriodicSelectionFilter);
     updateUrl(value as PeriodicSelectionFilter, activeMetrics);
   };


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
If the period was Monthly or Quarterly and then change to Annually the selected metrics was just 1-3 but they had to be the max amount of allowed metrics for the annually period

## What solved
- [X] Finances->Scope Frameworks Budget. Breakdown table, Changing the period filter. -** **Expected Output:** The metrics should change to the default state depending on the period selected. ** Current Output:** After selecting the Monthly period, the metrics filter remains only one metric selected in all the periods selected. 
