### PR TITLE
[BSN-1] Fix breakdown chart tooltip

### DIFF
--- a/src/stories/containers/Finances/utils/chartTooltip.ts
+++ b/src/stories/containers/Finances/utils/chartTooltip.ts
@@ -45,7 +45,9 @@ export const createChartTooltip = (
                 <circle cx="6.5" cy="6.5" r="5.5" stroke="${item.color}" />
                 <circle cx="6.5" cy="6.5" r="4" fill="${item.color}" />
               </svg>
-              <span style="font-size:14px;color:${isLight ? '#231536' : '#B6BCC2'};"> ${formatBudgetName(
+              <span style="font-size:14px;color:${
+                isLight ? '#231536' : '#B6BCC2'
+              };max-width:350px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"> ${formatBudgetName(
                   item.seriesName
                 )}:</span>
               <span style="font-size:16px;font-weight:700;color:${isLight ? '#231536' : '#EDEFFF'};">${formatNumber(


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix tooltip when the names are too long

## What solved
- [X] Finances-> MakerDAO Legacy Budget-> SFPs. Breakdown Chart section, Hovering over the bars.- ** **Expected Output:** The info displayed in the tooltip should be properly displayed. **Current Output:**  The longer name is cut off causing a lack of information. A horizontal scroll bar is displayed.