### PR TITLE
[BSN-1] Fix table header long titles

### DIFF
--- a/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
@@ -94,6 +94,10 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
   fontWeight: 700,
   lineHeight: 'normal',
   whiteSpace: 'break-spaces',
+  maxWidth: '100%',
+  wordWrap: 'break-word',
+  paddingRight: 8,
+
   [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
   },

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/HeaderMonthly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/HeaderMonthly.tsx
@@ -90,7 +90,9 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
   fontWeight: 700,
   lineHeight: 'normal',
   whiteSpace: 'normal',
+  maxWidth: '100%',
   wordWrap: 'break-word',
+  paddingRight: 8,
 }));
 
 const ContainerTitle = styled.div({

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
@@ -71,6 +71,10 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
   fontWeight: 600,
   lineHeight: 'normal',
   whiteSpace: 'break-spaces',
+  maxWidth: '100%',
+  wordWrap: 'break-word',
+  paddingRight: 8,
+
   [lightTheme.breakpoints.up('desktop_1280')]: {
     whiteSpace: 'normal',
     wordWrap: 'break-word',

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
@@ -73,8 +73,11 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
   fontStyle: 'normal',
   fontWeight: 600,
   lineHeight: 'normal',
-
   whiteSpace: 'break-spaces',
+  maxWidth: '100%',
+  wordWrap: 'break-word',
+  paddingRight: 8,
+
   [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
   },


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
When the table header titles has a very long title it was out of its container

## What solved
- [X] Finances->Scope Frameworks Budget-> Stability Scope->Steakhouse/Strategic Finance->atlas/scopes/STA/STEAKHOUSE/*. Breakdown Table.-** **Expected Output:** When the column name is longer, it should be displayed in two lines. **Current Output:** The column name overlaps the rest of the columns.
