### PR TITLE
[BSN-1] Add the same behavior in mobile for monthly componente

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -37,8 +37,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
   const isTablet = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
   const upTable = useMediaQuery(lightTheme.breakpoints.up('tablet_768'));
   const isDesktop1024 = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
-  const showLineYear =
-    isMobile && (selectedGranularity as string) !== 'Quarterly' && (selectedGranularity as string) !== 'Annually';
+  const showLineYear = isMobile && selectedGranularity === 'monthly';
 
   const xAxisStyles = useMemo(
     () => ({

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
 import { createChartTooltip } from '@ses/containers/Finances/utils/chartTooltip';
-import { barChartAxisLabelsMonthly, barChartAxisLabelsQuarterly } from '@ses/containers/Finances/utils/utils';
+import { formatterBreakdownChart, getChartAxisLabelByGranularity } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
@@ -31,7 +31,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
   const isTablet = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
   const isDesktop1024 = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
   const isDesktop1280 = useMediaQuery(lightTheme.breakpoints.between('desktop_1280', 'desktop_1440'));
-
+  const showLineYear = isMobile && selectedGranularity === 'monthly';
   const xAxisStyles = {
     fontFamily: 'Inter, sans-serif',
     textAlign: 'center',
@@ -52,12 +52,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
     },
     xAxis: {
       type: 'category',
-      data:
-        selectedGranularity === 'monthly'
-          ? barChartAxisLabelsMonthly(isMobile)
-          : selectedGranularity === 'quarterly'
-          ? barChartAxisLabelsQuarterly(isMobile)
-          : [''],
+      data: getChartAxisLabelByGranularity(selectedGranularity, isMobile),
       splitLine: {
         show: false,
       },
@@ -81,21 +76,12 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
         height: upTable ? 15 : 11,
         baseline: 'top',
         interval: 0,
-
         formatter: function (value: string) {
-          if (isMobile) {
-            return value;
-          }
-          if (selectedGranularity === 'monthly') {
-            return `{value|${value}}\n{year|${year}}`;
-          }
-          if (selectedGranularity === 'quarterly') {
-            return `{value|${value}}\n{year|${year}}`;
-          }
-          return `{year|${year}}`;
+          const formatted = formatterBreakdownChart(selectedGranularity as AnalyticGranularity, isMobile, year, value);
+          return formatted;
         },
         rich: {
-          value: xAxisStyles,
+          month: xAxisStyles,
           year: xAxisStyles,
         },
       },
@@ -162,7 +148,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
           }}
           opts={{ renderer: 'svg' }}
         />
-        {isMobile && (
+        {showLineYear && (
           <YearXAxis isLight={isLight}>
             <YearText isLight={isLight}>{year}</YearText>
           </YearXAxis>

--- a/src/stories/containers/Finances/components/WaterfallChart/WaterfallChart.tsx
+++ b/src/stories/containers/Finances/components/WaterfallChart/WaterfallChart.tsx
@@ -6,7 +6,7 @@ import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/light';
 import ReactECharts from 'echarts-for-react';
 import { useEffect, useMemo, useRef } from 'react';
-import { getChartAxisLabelByGranularity } from '../../utils/utils';
+import { formatterWaterfallChart, getChartAxisLabelByGranularity } from '../../utils/utils';
 import LegendItemChart from '../LegendItemChart/LegendItemChart';
 import LineYearBorderBottomChart from '../LineYearBorderBottomChart/LineYearBorderBottomChart';
 import type { LegendItemsWaterfall, LineWaterfall, WaterfallChartSeriesData } from '../../utils/types';
@@ -29,6 +29,7 @@ const WaterfallChart: React.FC<Props> = ({ legends, year, selectedGranularity, s
   const isDesktop1024 = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
   const isDesktop1280 = useMediaQuery(lightTheme.breakpoints.between('desktop_1280', 'desktop_1440'));
   const isDesktop1440 = useMediaQuery(lightTheme.breakpoints.between('desktop_1440', 'desktop_1920'));
+  const showLineYear = isMobile && selectedGranularity === 'monthly';
 
   const xAxisStyles = useMemo(
     () => ({
@@ -101,34 +102,9 @@ const WaterfallChart: React.FC<Props> = ({ legends, year, selectedGranularity, s
           height: upTable ? 15 : 11,
           interval: 0,
           formatter: function (value: string, index: number) {
-            if (isMobile) {
-              if (selectedGranularity === 'monthly' && (index === 0 || index === 13)) {
-                return `{start|${value}}`;
-              }
-              return value;
-            }
-            if (selectedGranularity === 'monthly') {
-              if (index === 0 || index === 13) {
-                return `{start|${value}}\n{startYear|${year}}`;
-              }
-              return `{month|${value}}\n{year|${year}}`;
-            }
-
-            if (selectedGranularity === 'quarterly') {
-              if (index === 0 || index === 5) {
-                return `{start|${value}}\n{startYear|${year}}`;
-              }
-              return `{month|${value}}\n{year|${year}}`;
-            }
-            if (selectedGranularity === 'annual') {
-              if (index === 0 || index === 2) {
-                return `{start|${value}}\n{startYear|${year}}`;
-              }
-              return `{year|${year}}`;
-            }
-            return `{year|${year}}`;
+            const formatted = formatterWaterfallChart(selectedGranularity, isMobile, year, value, index);
+            return formatted;
           },
-
           rich: {
             month: xAxisStyles,
             year: xYearStyles,
@@ -216,7 +192,7 @@ const WaterfallChart: React.FC<Props> = ({ legends, year, selectedGranularity, s
           }}
           opts={{ renderer: 'svg' }}
         />
-        {isMobile && <LineYearBorderBottomChart year={year} />}
+        {showLineYear && <LineYearBorderBottomChart year={year} />}
       </ChartContainer>
       <LegendContainer>
         {legends?.map((legend, index) => (

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -776,6 +776,52 @@ export const formatterBreakdownChart = (
   }
 };
 
+export const formatterWaterfallChart = (
+  granularity: AnalyticGranularity,
+  isMobile: boolean,
+  year: string,
+  value: string,
+  index: number
+) => {
+  if (isMobile) {
+    switch (granularity) {
+      case 'monthly':
+        return `{start|${value}}`;
+      case 'quarterly':
+        if (index === 0 || index === 5) {
+          return '';
+        }
+        return `{month|${value}}\n{year|${year}}`;
+      case 'annual':
+        if (index === 0 || index === 2) {
+          return '';
+        }
+        return `{month|${year}}`;
+
+      default:
+        return `{start|${value}}`;
+    }
+  }
+  switch (granularity) {
+    case 'monthly':
+      if (index === 0 || index === 13) {
+        return `{start|${value}}\n{startYear|${year}}`;
+      }
+      return `{month|${value}}\n{year|${year}}`;
+    case 'quarterly':
+      if (index === 0 || index === 5) {
+        return `{start|${value}}\n{startYear|${year}}`;
+      }
+      return `{month|${value}}\n{year|${year}}`;
+    case 'annual':
+      if (index === 0 || index === 2) {
+        return `{start|${value}}\n{startYear|${year}}`;
+      }
+      return `{month|${value}}\n{year|${year}}`;
+    default:
+      return `{month|${value}}\n{year|${year}}`;
+  }
+};
 export const getCorrectMetric = (budgetMetric: BudgetMetric, selectedMetric: AnalyticMetric): ValuesDataWithBorder => {
   let metricKey: keyof BudgetMetric;
   switch (selectedMetric) {


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Made the legend of the chart for mobile and monthly homogeneous

## What solved
- [X] Breakdown chart, Expense Metrics Line chart, Reserves chart sections. Selecting Quarterly or Annually period.- 


## Screenshots (if apply)
