### PR TITLE
[BSN-1] Fix annually metric update

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -351,11 +351,13 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     updateUrl(periodFilter, METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics));
   };
   const handlePeriodChange = (value: string) => {
+    let metrics = activeMetrics;
     if (value === 'Annually') {
-      setActiveMetrics(METRIC_FILTER_OPTIONS.slice(0, isMobile ? 3 : 5));
+      metrics = METRIC_FILTER_OPTIONS.slice(0, isMobile ? 3 : 5);
+      setActiveMetrics(metrics);
     }
     setPeriodFilter(value as PeriodicSelectionFilter);
-    updateUrl(value as PeriodicSelectionFilter, activeMetrics);
+    updateUrl(value as PeriodicSelectionFilter, metrics);
   };
 
   const selectMetrics = useMemo(


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
When the granularity was changed from monthly or quarterly to annually, the wrong amount of metrics were selected

## What solved
- [X] Finances view. Breakdown Table section. Annually period and 5 metrics selected. Sharing link-** **Expected Output:** The link should direct to the Breakdown Table section keeping the filters selected (Annually with 5 metrics selected). **Current Output:** The link shared is directing properly but shows the Annually period with 3 metrics selected. 
