### PR TITLE
fix: reset filter hability

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -335,16 +335,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
       setActiveMetrics(METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics));
       setPeriodFilter('Semi-annual');
     }
-    if (isTable) {
-      setActiveMetrics(METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics));
-      setPeriodFilter('Quarterly');
-    }
-    if (isDesk1024 || isDesk1280 || isDesk1440) {
-      setActiveMetrics(METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics));
-      setPeriodFilter('Quarterly');
-    }
-
-    if (isDesk1920) {
+    if (isTable || isDesk1024 || isDesk1280 || isDesk1440 || isDesk1920) {
       setActiveMetrics(METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics));
       setPeriodFilter('Quarterly');
     }
@@ -368,11 +359,11 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
   );
 
   const metricsMatch =
-    JSON.stringify(activeMetrics) === JSON.stringify(METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics));
+    JSON.stringify(activeMetrics.sort()) ===
+    JSON.stringify(METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics).sort());
 
   const isDisabled =
-    (isMobile && selectedGranularity === 'semiAnnual' && metricsMatch) ||
-    ((isTable || isDesk1024 || isDesk1280 || isDesk1920) && selectedGranularity === 'quarterly' && metricsMatch);
+    metricsMatch && (isMobile ? selectedGranularity === 'semiAnnual' : selectedGranularity === 'quarterly');
 
   return {
     isMobile,


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
The reset filter button wasn't disabled sometimes when the default filters were selected

## What solved
- [X]  Finances view. Breakdown table section. Reset filters option. -** **Expected Output:** The reset filters option should be disabled by default, It should be active only when the filters are changed. **Current Output:** The option always has the active state.
