### PR TITLE
[RC-1]Add all the budgets

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
@@ -31,8 +31,8 @@ export const useReservesWaterfallChart = (codePath: string, budgets: Budget[], a
   );
 
   const { summaryValues, totalToStart } = useMemo(
-    () => getAnalyticForWaterfall(selectedGranularity, analytics),
-    [analytics, selectedGranularity]
+    () => getAnalyticForWaterfall(budgets, selectedGranularity, analytics),
+    [budgets, analytics, selectedGranularity]
   );
   const selectAll = useMemo(() => Array.from(summaryValues.keys()), [summaryValues]);
 

--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -2,6 +2,7 @@ import { UMBRAL_CHART_WATERFALL } from '@ses/core/utils/const';
 import { threeDigitsPrecisionHumanization } from '@ses/core/utils/humanization';
 import type { LineWaterfall, MetricValues, WaterfallChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { Analytic, AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
+import type { Budget } from '@ses/core/models/interfaces/budget';
 import type { EChartsOption } from 'echarts-for-react';
 
 export const getArraysWaterfall = (data: number[]) => {
@@ -290,12 +291,23 @@ const EMPTY_METRIC_VALUE = {
   ProtocolNetOutflow: 0,
 } as WaterfallReserves;
 
-export const getAnalyticForWaterfall = (granularity: AnalyticGranularity, analytic: Analytic | undefined) => {
+export const getAnalyticForWaterfall = (
+  budgets: Budget[],
+  granularity: AnalyticGranularity,
+  analytic: Analytic | undefined
+) => {
   const budgetAnalyticMap = new Map<string, WaterfallReserves[]>();
   const arrayLength = getArrayLengthByGranularity(granularity);
   const summaryValues = new Map<string, number[]>();
   let netProtocolOutflow = 0;
   let paymentsOnChain = 0;
+
+  budgets.forEach((budget) => {
+    budgetAnalyticMap.set(
+      budget.codePath,
+      Array.from({ length: arrayLength }, () => ({ ...EMPTY_METRIC_VALUE }))
+    );
+  });
 
   if (!analytic || !analytic.series?.length) {
     return {


### PR DESCRIPTION
## Ticket
https://trello.com/c/qmqD8fNL/311-rc-1-reserves-chart

## Description
Fix the filter in waterfall chart

## What solved
- [X]  Finances view. Year: 2024. AllMakerdao filter. **Expected Output:** The filter should display by default all budgets selected and the number of the budgets. **Current Output:** It displays 5 elements selected but in the list are only 4 selected. **Visual Proof:** [image.png]

## Screenshots (if apply)
