### PR TITLE
[BSN-1] Fix finances issues

### DIFF
--- a/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
+++ b/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
@@ -3,6 +3,7 @@ import { ClickAwayListener, Grow, MenuItem, MenuList, Paper, Popper } from '@mui
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import merge from 'deepmerge';
 import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import SimpleBar from 'simplebar-react';
 import { SelectChevronDown } from '../svg/select-chevron-down';
 import type { PaperProps, PopperProps } from '@mui/material';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -171,19 +172,26 @@ const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
             <CustomPaper isLight={isLight} {...paperProps}>
               <ClickAwayListener onClickAway={handleClose}>
                 <MenuList autoFocusItem={open} id={menuListId} aria-labelledby={inputId} onKeyDown={handleListKeyDown}>
-                  {items.map((item, index) => (
-                    <CustomMenuItem
-                      selected={compareItemWithValue(item, selected)}
-                      isLight={isLight}
-                      key={index}
-                      onClick={(event: Event | React.SyntheticEvent) => {
-                        handleClose(event);
-                        onChange?.(typeof item === 'string' ? item : item.value);
-                      }}
-                    >
-                      {typeof item === 'string' ? item : item.label}
-                    </CustomMenuItem>
-                  ))}
+                  <SimpleBar
+                    style={{
+                      maxHeight: 175,
+                    }}
+                    className="filter-popup-scroll"
+                  >
+                    {items.map((item, index) => (
+                      <CustomMenuItem
+                        selected={compareItemWithValue(item, selected)}
+                        isLight={isLight}
+                        key={index}
+                        onClick={(event: Event | React.SyntheticEvent) => {
+                          handleClose(event);
+                          onChange?.(typeof item === 'string' ? item : item.value);
+                        }}
+                      >
+                        {typeof item === 'string' ? item : item.label}
+                      </CustomMenuItem>
+                    ))}
+                  </SimpleBar>
                 </MenuList>
               </ClickAwayListener>
             </CustomPaper>

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import { styled } from '@mui/material';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import SectionTitle from '../SectionTitle/SectionTitle';
@@ -72,11 +72,15 @@ const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
 
 export default BreakdownChartSection;
 
-const Section = styled.section({
+const Section = styled('section')(({ theme }) => ({
   marginTop: 40,
-});
 
-const HeaderContainer = styled.div({
+  [theme.breakpoints.up('desktop_1280')]: {
+    marginTop: 64,
+  },
+}));
+
+const HeaderContainer = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   gap: 24,
@@ -87,6 +91,6 @@ const HeaderContainer = styled.div({
   },
 });
 
-const Wrapper = styled.div({
+const Wrapper = styled('div')({
   marginTop: 32,
 });

--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -53,7 +53,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
 
               return (
                 <TableRow key={index} isLight={isLight} isMain={row.isMain}>
-                  <Headed isLight={isLight} period={period}>
+                  <Headed isLight={isLight} period={period} isHeader={!!row.isMain}>
                     {row.isSummaryRow ? (
                       row.name
                     ) : (
@@ -139,71 +139,70 @@ const TableContainer = styled.table<WithIsLight>(({ isLight }) => ({
   overflow: 'hidden',
 }));
 
-const Headed = styled.th<WithIsLight & { period?: PeriodicSelectionFilter }>(({ isLight, period }) => ({
-  borderRight: `1px solid ${isLight ? '#D8E0E3' : '#405361'}`,
-  fontSize: 11,
-  color: isLight ? '#231536' : '#D2D4EF',
-  width: 87,
-  textAlign: 'center',
-  verticalAlign: 'center',
-  padding: '16px 4px 16px 8px',
-  whiteSpace: 'normal',
-  overflowWrap: 'break-word',
-  wordBreak: 'break-word',
-  position: 'relative',
+const Headed = styled.th<WithIsLight & { period?: PeriodicSelectionFilter; isHeader: boolean }>(
+  ({ isLight, period, isHeader }) => ({
+    borderRight: `1px solid ${isLight ? '#D8E0E3' : '#405361'}`,
+    fontSize: 11,
+    color: isLight ? '#231536' : '#D2D4EF',
+    width: 87,
+    textAlign: 'center',
+    verticalAlign: 'center',
+    padding: '16px 4px 16px 8px',
+    whiteSpace: 'normal',
+    overflowWrap: 'break-word',
+    wordBreak: 'break-word',
+    position: 'relative',
 
-  '& .link': {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    textDecoration: 'none',
-    color: 'inherit',
-    zIndex: 1,
-  },
+    '& .link': {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      textDecoration: 'none',
+      color: 'inherit',
+      zIndex: 1,
+    },
 
-  [lightTheme.breakpoints.up('tablet_768')]: {
-    fontSize: 14,
-    ...(period === 'Monthly' && {
-      fontSize: 12,
-    }),
-    width: 150,
-  },
+    [lightTheme.breakpoints.up('tablet_768')]: {
+      fontSize: isHeader ? 14 : 12,
+      width: 150,
+    },
 
-  [lightTheme.breakpoints.up('desktop_1024')]: {
-    width: 150,
-  },
+    [lightTheme.breakpoints.up('desktop_1024')]: {
+      width: 150,
+    },
 
-  [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: 220,
-    padding: '16px 0px 16px 32px',
-  },
+    [lightTheme.breakpoints.up('desktop_1280')]: {
+      width: 220,
+      padding: '16px 0px 16px 32px',
+    },
 
-  [lightTheme.breakpoints.up('desktop_1440')]: {
-    width: period === 'Quarterly' ? 261 : period === 'Annually' ? 200 : 188,
-    padding: '16px 0px 16px 32px',
-    textOverflow: period === 'Monthly' ? 'ellipsis' : 'revert',
-    ...(period === 'Monthly' && {
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-    }),
-    ...(period === 'Annually' && {
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-    }),
-  },
+    [lightTheme.breakpoints.up('desktop_1440')]: {
+      width: period === 'Quarterly' ? 261 : period === 'Annually' ? 200 : 188,
+      padding: '16px 0px 16px 32px',
+      textOverflow: period === 'Monthly' ? 'ellipsis' : 'revert',
+      ...(period === 'Monthly' && {
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+      }),
+      ...(period === 'Annually' && {
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+      }),
+    },
 
-  [lightTheme.breakpoints.up('desktop_1920')]: {
-    width: period === 'Annually' ? 212 : 230,
-    padding: period === 'Quarterly' ? '16px 0px 16px 16px' : '16px 0px 16px 32px',
-  },
-}));
+    [lightTheme.breakpoints.up('desktop_1920')]: {
+      width: period === 'Annually' ? 212 : 230,
+      padding: period === 'Quarterly' ? '16px 0px 16px 16px' : '16px 0px 16px 32px',
+    },
+  })
+);
 
 const TableRow = styled.tr<WithIsLight & { isMain?: boolean }>(({ isMain = false, isLight }) => ({
   '& th': {

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -44,6 +44,8 @@ const DoughnutChartFinances: React.FC<Props> = ({
   useEffect(() => {
     setVisibleSeries(doughnutSeriesData);
     setLegends(doughnutSeriesData);
+    // avoid to cut off the chart on page load
+    chartRef.current?.getEchartsInstance()?.resize();
   }, [doughnutSeriesData]);
   const isTable = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
   const isDesktop1024 = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
@@ -383,6 +385,10 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean }>(({ isCoreThirdLe
     flexGrow: 1,
     flexShrink: 1,
     height: 'calc(100% + 16px)',
+  },
+
+  '& .swiper-wrapper': {
+    paddingBottom: 24,
   },
 
   '& .swiper-slide': {},


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
<!--- What is new in this PR -->

## What solved
- [X] Finances view. Breakdown Table section. Period: Quarterly, Annually. - ** **Expected Output:** The subcategories should have font-size: 12px. **Current Output:**  The font-size displayed for the subcategories is 14px.
- [X] The space between the sections should be 64px. **Current Output:** The space between the navigation cards and the breakdown chart section is 40px. To check the space between the expense metric line chart and the reserves chart.
- [X] Finances view. Year component- ** **Expected Output:** It should be prepared to display more years without affecting the size of the list area. **Current Output:**  Once a new year is added, the list area grows up.
- [X] Finances->AScope Frameworks Budget. Pie chart legend.-** **Expected Output:** A space should be visible between the legend and the navigation elements. **Current Output:** The navigation elements are displayed closer to the bottom of the legend.
