### PR TITLE
[BSN-1] Remove prediction from overview card

### DIFF
--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -87,7 +87,6 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
               handleSelectedMetric={cardOverViewSectionData.handleSelectedMetric}
               actuals={cardOverViewSectionData.actuals}
               budgetCap={cardOverViewSectionData.budgetCap}
-              prediction={cardOverViewSectionData.prediction}
               doughnutSeriesData={cardOverViewSectionData.doughnutSeriesData}
               isCoreThirdLevel={levelNumber >= 3}
               changeAlignment={cardOverViewSectionData.changeAlignment}
@@ -100,7 +99,6 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
             <OverviewCardMobile
               actuals={cardOverViewSectionData.actuals}
               budgetCap={cardOverViewSectionData.budgetCap}
-              prediction={cardOverViewSectionData.prediction}
             />
           </WrapperMobile>
           <CardsNavigation

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/InformationBudgetCapOverView/InformationBudgetCapOverView.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/InformationBudgetCapOverView/InformationBudgetCapOverView.tsx
@@ -9,13 +9,12 @@ import lightTheme from 'styles/theme/light';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 export type QuarterCardProps = {
-  prediction: number;
   actuals: number;
   budgetCap: number;
   className?: string;
 };
 
-const InformationBudgetCapOverview: React.FC<QuarterCardProps> = ({ prediction, actuals, budgetCap, className }) => {
+const InformationBudgetCapOverview: React.FC<QuarterCardProps> = ({ actuals, budgetCap, className }) => {
   const { isLight } = useThemeContext();
 
   const humanizedActuals = threeDigitsPrecisionHumanization(actuals);
@@ -45,7 +44,7 @@ const InformationBudgetCapOverview: React.FC<QuarterCardProps> = ({ prediction, 
       <DividerCardChart isLight={isLight} />
       <Percent isLight={isLight}>{percent}%</Percent>
       <BarWrapper>
-        <HorizontalBudgetBarStyled actuals={actuals} prediction={prediction} budgetCap={budgetCap} />
+        <HorizontalBudgetBarStyled actuals={actuals} prediction={0} budgetCap={budgetCap} />
       </BarWrapper>
       <Legend>
         <LegendItem isLight={isLight} dotColor={isLight ? '#2DC1B1' : '#1AAB9B'}>

--- a/src/stories/containers/Finances/components/OverviewCardMobile/OverviewCardMobile.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardMobile/OverviewCardMobile.tsx
@@ -7,19 +7,12 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 interface Props {
   actuals: number;
   budgetCap: number;
-  prediction: number;
 }
 
-const OverviewCardMobile: React.FC<Props> = ({ actuals, budgetCap, prediction }) => {
+const OverviewCardMobile: React.FC<Props> = ({ actuals, budgetCap }) => {
   const { isLight } = useThemeContext();
-  return (
-    <InformationBudgetCapOverviewStyled
-      isLight={isLight}
-      actuals={actuals}
-      budgetCap={budgetCap}
-      prediction={prediction}
-    />
-  );
+
+  return <InformationBudgetCapOverviewStyled isLight={isLight} actuals={actuals} budgetCap={budgetCap} />;
 };
 
 export default OverviewCardMobile;

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/CardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/CardChartOverview.tsx
@@ -13,7 +13,6 @@ interface Props {
   handleSelectedMetric: (selectedMetric: AnalyticMetric) => void;
   actuals: number;
   budgetCap: number;
-  prediction: number;
   doughnutSeriesData: DoughnutSeries[];
   isCoreThirdLevel: boolean;
   changeAlignment: boolean;
@@ -53,7 +52,6 @@ const CardChartOverview: React.FC<Props> = ({
   handleSelectedMetric,
   actuals,
   budgetCap,
-  prediction,
   doughnutSeriesData,
   isCoreThirdLevel,
   changeAlignment,
@@ -96,7 +94,7 @@ const CardChartOverview: React.FC<Props> = ({
             <ContainerCardChart>
               <ContainerCardAndLine>
                 <ContainerCardInformation>
-                  <InformationBudgetCapOverview actuals={actuals} budgetCap={budgetCap} prediction={prediction} />
+                  <InformationBudgetCapOverview actuals={actuals} budgetCap={budgetCap} />
                 </ContainerCardInformation>
                 <Divider isLight={isLight} />
               </ContainerCardAndLine>

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -208,7 +208,6 @@ export const useCardChartOverview = (
 
   return {
     actuals: isHasSubLevels ? metric.actuals : budgetWithNotChildren.actuals,
-    prediction: isHasSubLevels ? metric.forecast : budgetWithNotChildren.forecast,
     budgetCap: isHasSubLevels ? metric.budget : budgetWithNotChildren.budget,
     selectedMetric,
     handleSelectedMetric,


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
The card overview was showing the prediction/forecast

## What solved
- [X] Finances->MakerDAO Legacy Budget. The first section (right). Year: 2024. - ** **Expected Output:** If we don't have any values for budgets and actuals and the percent is 0, the progress bar shouldn't be represented with a green color.  **Current Output:**  The progress bar is displayed with a green color, representing values.
