### PR TITLE
[BS-1] Add min height for the title

### DIFF
--- a/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
@@ -86,7 +86,7 @@ const TitleContainer = styled.div<WithIsLight>(({ isLight }) => ({
   flexDirection: 'row',
   justifyContent: 'flex-start',
   alignItems: 'center',
-  height: 48,
+  minHeight: 48,
   borderRight: `1px solid ${isLight ? '#D1DEE6' : '#546978'}`,
   width: 145,
   padding: '16px 8px 16px 8px',

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -204,7 +204,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
       subBudgets.forEach((subBudget) => {
         if (!rows.some((row) => row.name === subBudget.codePath)) {
           rows.push({
-            name: subBudget.codePath,
+            name: isMobile ? subBudget.code : subBudget.codePath,
             codePath: subBudget.codePath,
             columns: Array.from({ length: columnsCount }, () => ({ ...EMPTY_METRIC_VALUE })),
           });
@@ -213,13 +213,20 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
 
       // add correct rows name
       rows.forEach((row) => {
-        row.name =
-          subBudgets.filter((item) => item.codePath === row.name)[0]?.name ?? `${removePatternAfterSlash(row.name)}`;
+        const nameOrCode = subBudgets.filter((item) => item.codePath === row.name)[0];
+        if (!nameOrCode) {
+          row.name = `${removePatternAfterSlash(row.name)}`;
+        } else {
+          row.name = isMobile ? nameOrCode.code : nameOrCode.name;
+        }
       });
+
+      console.log('lod', lod);
 
       // sub-table header
       const header: ItemRow = {
-        name: formatBudgetName(budget.name),
+        name: isMobile ? (lod === 3 ? formatBudgetName(budget.name) : budget.code) : formatBudgetName(budget.name),
+
         isMain: true,
         codePath: budget.codePath,
         columns: rows
@@ -261,7 +268,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     }, Array.from({ length: columnsCount }, () => ({ ...EMPTY_METRIC_VALUE })) as MetricValues[]);
 
     return [tableHeader, tables];
-  }, [allBudgets, analytics, budgets, error, selectedGranularity]);
+  }, [allBudgets, analytics, budgets, error, isMobile, lod, selectedGranularity]);
 
   const isLoading = !analytics && !error && (tableHeader === null || tableBody === null);
 

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -221,8 +221,6 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
         }
       });
 
-      console.log('lod', lod);
-
       // sub-table header
       const header: ItemRow = {
         name: isMobile ? (lod === 3 ? formatBudgetName(budget.name) : budget.code) : formatBudgetName(budget.name),


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix when the text its to long, then a scroll add in the title of the header in the table

## What solved
- [X] From 375 to 1024. Finances->Atlas Immutable Budget-> AllocatorDAO Genesis Emissions, Distribution and Farming rate. Breakdown Table section, Header. -** **Expected Output:** The column's name should be displayed properly in the header area.  **Current Output :**The longer name is displayed cut off.  

