### PR TITLE
[BS-1] Add CSS breakpoint to avoid render container before loading

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/BreakdownTableBodySkeleton.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/BreakdownTableBodySkeleton.tsx
@@ -1,4 +1,4 @@
-import { useMediaQuery, type Theme, styled, useTheme } from '@mui/material';
+import { styled, useTheme } from '@mui/material';
 import React from 'react';
 import { HeaderRowSkeleton } from './HeaderRowSkeleton';
 import RowSkeleton from './RowSkeleton';
@@ -10,11 +10,7 @@ interface Props {
 const BreakdownTableBodySkeleton: React.FC<Props> = ({ differentNumberOfRows = true }) => {
   const theme = useTheme();
   const isLight = theme.palette.mode === 'light';
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
-  const isTable = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
-  const isDesk1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
-  const isDesk1280 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1280', 'desktop_1440'));
-  const isDesk1440 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1440'));
+
   return (
     <Container>
       <Header>
@@ -22,249 +18,237 @@ const BreakdownTableBodySkeleton: React.FC<Props> = ({ differentNumberOfRows = t
       </Header>
       {differentNumberOfRows ? (
         <Body>
-          {isMobile && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[52, 39]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[59, 67]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[49]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
-          {isTable && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[67, 94]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[104]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[54]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
-          {isDesk1024 && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[67, 94]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[104]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[54]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
-          {isDesk1280 && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[67, 94]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[104]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[54]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
-          {isDesk1440 && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[67, 94]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[104]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[54]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
+          <Mobile>
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[52, 39]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[59, 67]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[49]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Mobile>
+
+          <Tablet>
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[67, 94]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[104]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[54]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Tablet>
+
+          <Desk1024>
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[67, 94]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[104]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[54]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Desk1024>
+
+          <Desk1280>
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[67, 94]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[104]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[54]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Desk1280>
+
+          <Desk1440>
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[67, 94]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[104]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[54]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Desk1440>
         </Body>
       ) : (
         <Body>
-          {isMobile && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[37, 53]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[54, 53]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[54, 53]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[40, 61]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[65, 46]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
-          {isTable && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[122]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[120]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[127, 76]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[123]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[94, 114]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
-          {isDesk1024 && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[122]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[120]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[109, 73]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[123]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={2}
-                numberWith={[94, 114]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
-          {isDesk1280 && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[122]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[120]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[146]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[123]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[148]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
-          {isDesk1440 && (
-            <>
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[122]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[120]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[146]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[123]}
-                backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
-              />
-              <RowSkeleton
-                numberItemsHeader={1}
-                numberWith={[148]}
-                backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
-              />
-            </>
-          )}
+          <Mobile>
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[37, 53]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[54, 53]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[54, 53]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[40, 61]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[65, 46]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Mobile>
+
+          <Tablet>
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[122]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[120]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[127, 76]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[123]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[94, 114]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Tablet>
+
+          <Desk1024>
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[122]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[120]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[109, 73]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[123]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={2}
+              numberWith={[94, 114]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Desk1024>
+
+          <Desk1280>
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[122]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[120]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[146]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[123]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[148]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Desk1280>
+
+          <Desk1440>
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[122]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[120]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[146]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[123]}
+              backgroundRow={isLight ? '#F5F5F5' : 'rgb(24, 37, 46, 0.3)'}
+            />
+            <RowSkeleton
+              numberItemsHeader={1}
+              numberWith={[148]}
+              backgroundRow={isLight ? 'white' : 'rgb(31, 45, 55, 0.4)'}
+            />
+          </Desk1440>
         </Body>
       )}
     </Container>
@@ -287,3 +271,42 @@ const Header = styled('div')({
   borderBottomLeftRadius: 6,
 });
 const Body = styled('div')({});
+
+const Mobile = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
+const Tablet = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+}));
+
+const Desk1024 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1024', 'desktop_1280')]: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+}));
+
+const Desk1280 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+}));
+const Desk1440 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1440')]: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+}));

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/HeaderRowSkeleton.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/HeaderRowSkeleton.tsx
@@ -1,14 +1,8 @@
-import { Skeleton, styled, useMediaQuery } from '@mui/material';
+import { Skeleton, styled } from '@mui/material';
 import React from 'react';
-import type { Theme } from '@mui/material';
+import HeaderRowSkeletonTitle from './HeaderRowSkeletonTitle';
 
 export const HeaderRowSkeleton = () => {
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
-  const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
-  const isDesk1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
-  const isDesk1280 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1280', 'desktop_1440'));
-  const isDesk1440 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1440'));
-
   const TwoItemsSkeleton = () => (
     <TwoItemsSkeletonContainer>
       <ItemStyledSkeleton
@@ -33,248 +27,144 @@ export const HeaderRowSkeleton = () => {
   return (
     <Container>
       <TitleBox>
-        {isMobile && (
-          <>
-            <ItemStyledSkeleton
-              variant="rectangular"
-              width={38}
-              height={9.62}
-              sx={{
-                borderRadius: 13.5,
-              }}
-            />
-            <ItemStyledSkeleton
-              variant="rectangular"
-              width={51}
-              height={9.62}
-              sx={{
-                borderRadius: 13.5,
-              }}
-            />
-            <ItemStyledSkeleton
-              variant="rectangular"
-              width={39}
-              height={9.62}
-              sx={{
-                borderRadius: 13.5,
-              }}
-            />
-          </>
-        )}
-        {isTablet && (
-          <>
-            <ItemStyledSkeleton
-              variant="rectangular"
-              width={119}
-              height={12.15}
-              sx={{
-                borderRadius: 13.5,
-              }}
-            />
-            <ItemStyledSkeleton
-              variant="rectangular"
-              width={90}
-              height={12.15}
-              sx={{
-                borderRadius: 13.5,
-              }}
-            />
-          </>
-        )}
-        {isDesk1024 && (
-          <>
-            <ItemStyledSkeleton
-              variant="rectangular"
-              width={90}
-              height={12.15}
-              sx={{
-                borderRadius: 13.5,
-              }}
-            />
-
-            <ItemStyledSkeleton
-              variant="rectangular"
-              width={119}
-              height={12.15}
-              sx={{
-                borderRadius: 13.5,
-              }}
-            />
-          </>
-        )}
-        {isDesk1280 && (
-          <>
-            <ItemStyledSkeleton
-              variant="rectangular"
-              width={190}
-              height={12.15}
-              sx={{
-                borderRadius: 13.5,
-              }}
-            />
-          </>
-        )}
-        {isDesk1440 && (
-          <>
-            <ItemStyledSkeleton
-              variant="rectangular"
-              width={160}
-              height={12.51}
-              sx={{
-                borderRadius: 13.5,
-              }}
-            />
-          </>
-        )}
+        <HeaderRowSkeletonTitle />
       </TitleBox>
+      <Mobile>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+      </Mobile>
 
-      <>
-        {isMobile && (
-          <ItemsBox>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-          </ItemsBox>
-        )}
-        {isTablet && (
-          <ItemsBox>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={61}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={61}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={61}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={61}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={61}
-                height={10.5}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-          </ItemsBox>
-        )}
-        {isDesk1024 && (
-          <ItemsBox>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-          </ItemsBox>
-        )}
-        {isDesk1280 && (
-          <ItemsBox>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-          </ItemsBox>
-        )}
-        {isDesk1440 && (
-          <ItemsBox>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-          </ItemsBox>
-        )}
-      </>
+      <Tablet>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={61}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={61}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={61}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={61}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={61}
+            height={10.5}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+      </Tablet>
+      <Desk1024>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+      </Desk1024>
+      <Desk1280>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+      </Desk1280>
+      <Desk1440>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+      </Desk1440>
     </Container>
   );
 };
@@ -286,7 +176,9 @@ const Container = styled('div')(({ theme }) => ({
   width: '100%',
   padding: '16px 8px',
   borderRadius: 6,
+  minHeight: 48,
   overflow: 'hidden',
+  alignItems: 'center',
   background: theme.palette.mode === 'light' ? 'rgba(236, 239, 249, 0.50)' : 'rgb(64, 83, 97, 0.30)',
   [theme.breakpoints.up('tablet_768')]: {
     padding: '16px 0px 16px 8px',
@@ -328,40 +220,20 @@ const ContainerItem = styled('div')(({ theme }) => ({
   flexDirection: 'row',
   justifyContent: 'center',
   alignItems: 'center',
-  minWidth: 76,
-  flex: 1,
-  [theme.breakpoints.up('tablet_768')]: {
-    minWidth: 78,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    minWidth: 130,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    minWidth: 130,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    minWidth: 130,
-  },
-}));
 
-const ItemsBox = styled('div')(({ theme }) => ({
-  flex: 3 / 4,
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  justifyContent: 'space-between',
+  width: 76,
+
   [theme.breakpoints.up('tablet_768')]: {
-    minWidth: 'calc(100%-145px)',
-    flex: 5 / 6,
+    minWidth: 100,
   },
   [theme.breakpoints.up('desktop_1024')]: {
-    minWidth: 'calc(100%-142px)',
+    minWidth: 130,
   },
   [theme.breakpoints.up('desktop_1280')]: {
-    minWidth: 'calc(100%-228px)',
+    minWidth: 180,
   },
   [theme.breakpoints.up('desktop_1440')]: {
-    minWidth: 'calc(100%-228px)',
+    minWidth: 180,
   },
 }));
 
@@ -376,4 +248,62 @@ const TwoItemsSkeletonContainer = styled('div')(({ theme }) => ({
 
 const ItemStyledSkeleton = styled(Skeleton)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'light' ? '#D1DEE6' : '#31424E',
+}));
+
+const Mobile = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flex: 3 / 4,
+
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
+const Tablet = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    display: 'flex',
+    flex: 5 / 6,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minWidth: 'calc(100%-145px)',
+  },
+}));
+
+const Desk1024 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1024', 'desktop_1280')]: {
+    display: 'flex',
+    flex: 5 / 6,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minWidth: 'calc(100%-142px)',
+  },
+}));
+
+const Desk1280 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
+    display: 'flex',
+    flex: 5 / 6,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minWidth: 'calc(100%-180px)',
+  },
+}));
+const Desk1440 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1440')]: {
+    display: 'flex',
+    flex: 5 / 6,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minWidth: 'calc(100%-228px)',
+  },
 }));

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/HeaderRowSkeletonTitle.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/HeaderRowSkeletonTitle.tsx
@@ -1,0 +1,161 @@
+import { Skeleton, styled } from '@mui/material';
+import React from 'react';
+
+const HeaderRowSkeletonTitle = () => (
+  <Container>
+    <Mobile>
+      <ItemStyledSkeleton
+        variant="rectangular"
+        width={38}
+        height={9.62}
+        sx={{
+          borderRadius: 13.5,
+        }}
+      />
+      <ItemStyledSkeleton
+        variant="rectangular"
+        width={51}
+        height={9.62}
+        sx={{
+          borderRadius: 13.5,
+        }}
+      />
+      <ItemStyledSkeleton
+        variant="rectangular"
+        width={39}
+        height={9.62}
+        sx={{
+          borderRadius: 13.5,
+        }}
+      />
+    </Mobile>
+
+    <Tablet>
+      <ItemStyledSkeleton
+        variant="rectangular"
+        width={119}
+        height={12.15}
+        sx={{
+          borderRadius: 13.5,
+        }}
+      />
+      <ItemStyledSkeleton
+        variant="rectangular"
+        width={90}
+        height={12.15}
+        sx={{
+          borderRadius: 13.5,
+        }}
+      />
+    </Tablet>
+
+    <Desk1024>
+      <ItemStyledSkeleton
+        variant="rectangular"
+        width={90}
+        height={12.15}
+        sx={{
+          borderRadius: 13.5,
+        }}
+      />
+
+      <ItemStyledSkeleton
+        variant="rectangular"
+        width={119}
+        height={12.15}
+        sx={{
+          borderRadius: 13.5,
+        }}
+      />
+    </Desk1024>
+
+    <Desk1280>
+      <ItemStyledSkeleton
+        variant="rectangular"
+        width={190}
+        height={12.15}
+        sx={{
+          borderRadius: 13.5,
+        }}
+      />
+    </Desk1280>
+
+    <Desk1440>
+      <ItemStyledSkeleton
+        variant="rectangular"
+        width={160}
+        height={12.51}
+        sx={{
+          borderRadius: 13.5,
+        }}
+      />
+    </Desk1440>
+  </Container>
+);
+
+export default HeaderRowSkeletonTitle;
+
+const Container = styled('div')({
+  display: 'flex',
+});
+
+const Mobile = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  gap: 4,
+  height: 48,
+  width: 78,
+  border: '1px solid red',
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
+const Tablet = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    display: 'flex',
+    width: 136,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    gap: 16,
+  },
+}));
+
+const Desk1024 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1024', 'desktop_1280')]: {
+    display: 'flex',
+    width: 136,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    gap: 16,
+  },
+}));
+
+const Desk1280 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
+    display: 'flex',
+    minWidth: 130,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    position: 'relative',
+    gap: 16,
+  },
+}));
+const Desk1440 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1440')]: {
+    display: 'flex',
+    width: 136,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    position: 'relative',
+    gap: 16,
+  },
+}));
+
+const ItemStyledSkeleton = styled(Skeleton)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'light' ? '#D1DEE6' : '#31424E',
+}));

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/RowSkeleton.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/RowSkeleton.tsx
@@ -1,6 +1,5 @@
-import { Skeleton, styled, useMediaQuery } from '@mui/material';
+import { Skeleton, styled } from '@mui/material';
 import React from 'react';
-import type { Theme } from '@mui/material';
 
 interface Props {
   numberItemsHeader: number;
@@ -10,11 +9,6 @@ interface Props {
 
 const RowSkeleton: React.FC<Props> = ({ numberItemsHeader, numberWith, backgroundRow }) => {
   const itemsHeader = Array.from({ length: numberItemsHeader }, () => 0);
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
-  const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
-  const isDesk1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
-  const isDesk1280 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1280', 'desktop_1440'));
-  const isDesk1440 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1440'));
 
   const TwoItemsSkeleton = () => (
     <TwoItemsSkeletonContainer>
@@ -52,153 +46,146 @@ const RowSkeleton: React.FC<Props> = ({ numberItemsHeader, numberWith, backgroun
           ))}
         </ContainerItemsHeader>
       </TitleBox>
-      <ItemsBox>
-        {isMobile && (
-          <>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-          </>
-        )}
-        {isTablet && (
-          <>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-            <ContainerItem>
-              <ItemStyledSkeleton
-                variant="rectangular"
-                width={56}
-                height={9.62}
-                sx={{
-                  borderRadius: 13.5,
-                }}
-              />
-            </ContainerItem>
-          </>
-        )}
-        {isDesk1024 && (
-          <>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-          </>
-        )}
-        {isDesk1280 && (
-          <>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-          </>
-        )}
-        {isDesk1440 && (
-          <>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-            <ContainerItem>
-              <TwoItemsSkeleton />
-            </ContainerItem>
-          </>
-        )}
-      </ItemsBox>
+
+      <Mobile>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+      </Mobile>
+
+      <Tablet>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+        <ContainerItem>
+          <ItemStyledSkeleton
+            variant="rectangular"
+            width={56}
+            height={9.62}
+            sx={{
+              borderRadius: 13.5,
+            }}
+          />
+        </ContainerItem>
+      </Tablet>
+
+      <Desk1024>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+      </Desk1024>
+
+      <Desk1280>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+      </Desk1280>
+
+      <Desk1440>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+        <ContainerItem>
+          <TwoItemsSkeleton />
+        </ContainerItem>
+      </Desk1440>
     </Container>
   );
 };
@@ -211,7 +198,6 @@ const Container = styled('div')<{ background: string }>(({ theme, background }) 
   justifyContent: 'space-between',
   width: '100%',
   padding: '16px 8px',
-
   background,
   [theme.breakpoints.up('tablet_768')]: {
     padding: '16px 0px 16px 8px',
@@ -244,44 +230,21 @@ const TitleBox = styled('div')(({ theme }) => ({
   },
 }));
 
-const ItemsBox = styled('div')(({ theme }) => ({
-  flex: 3 / 4,
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  [theme.breakpoints.up('tablet_768')]: {
-    minWidth: 'calc(100%-145px)',
-    flex: 5 / 6,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    minWidth: 'calc(100%-142px)',
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    minWidth: 'calc(100%-228px)',
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    minWidth: 'calc(100%-228px)',
-  },
-}));
 const ContainerItem = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
   alignItems: 'center',
   minWidth: 76,
-  flex: 1,
+
   [theme.breakpoints.up('tablet_768')]: {
-    minWidth: 78,
+    minWidth: 100,
   },
   [theme.breakpoints.up('desktop_1024')]: {
     minWidth: 130,
   },
   [theme.breakpoints.up('desktop_1280')]: {
-    minWidth: 130,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    minWidth: 130,
+    minWidth: 180,
   },
 }));
 
@@ -302,4 +265,62 @@ const ContainerItemsHeader = styled('div')({
 
 const ItemStyledSkeleton = styled(Skeleton)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'light' ? '#D1DEE6' : '#31424E',
+}));
+
+const Mobile = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flex: 3 / 4,
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
+const Tablet = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minWidth: 'calc(100%-145px)',
+    flex: 5 / 6,
+  },
+}));
+
+const Desk1024 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1024', 'desktop_1280')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flex: 5 / 6,
+    minWidth: 'calc(100%-228px)',
+  },
+}));
+
+const Desk1280 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flex: 5 / 6,
+    minWidth: 'calc(100%-228px)',
+  },
+}));
+const Desk1440 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1440')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flex: 5 / 6,
+    minWidth: 'calc(100%-228px)',
+  },
 }));

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/HeaderBreakdownTableSkeleton.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/HeaderBreakdownTableSkeleton.tsx
@@ -1,58 +1,46 @@
-import { styled, useMediaQuery } from '@mui/material';
+import { styled } from '@mui/material';
 import React from 'react';
 import HeaderTitleSkeleton from './HeaderTitleSkeleton';
 import ItemHeaderSkeleton from './ItemHeaderSkeleton';
-import type { Theme } from '@mui/material';
 
-const HeaderBreakdownTableSkeleton = () => {
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
-  const isTable = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
-  const isDesk1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
-  const isDesk1028 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1280'));
-  return (
-    <Container>
-      <TitleBox>
-        <HeaderTitleSkeleton />
-      </TitleBox>
-      <>
-        {isMobile && (
-          <ItemsBox>
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton isLast={true} />
-          </ItemsBox>
-        )}
-        {isTable && (
-          <ItemsBox>
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton isLast={true} />
-          </ItemsBox>
-        )}
-        {isDesk1024 && (
-          <ItemsBox>
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton isLast={true} />
-          </ItemsBox>
-        )}
-        {isDesk1028 && (
-          <ItemsBox>
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton />
-            <ItemHeaderSkeleton isLast={true} />
-          </ItemsBox>
-        )}
-      </>
-    </Container>
-  );
-};
+const HeaderBreakdownTableSkeleton = () => (
+  <Container>
+    <TitleBox>
+      <HeaderTitleSkeleton />
+    </TitleBox>
+    <>
+      <Mobile>
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton isLast={true} />
+      </Mobile>
+
+      <Table>
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton isLast={true} />
+      </Table>
+
+      <Desk1024>
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton isLast={true} />
+      </Desk1024>
+
+      <Desk10280>
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton />
+        <ItemHeaderSkeleton isLast={true} />
+      </Desk10280>
+    </>
+  </Container>
+);
 
 export default HeaderBreakdownTableSkeleton;
 const Container = styled('div')(({ theme }) => ({
@@ -76,6 +64,7 @@ const Container = styled('div')(({ theme }) => ({
 
 const TitleBox = styled('div')(({ theme }) => ({
   minWidth: 76,
+  display: 'flex',
   flex: 1 / 4,
   [theme.breakpoints.up('tablet_768')]: {
     minWidth: 136,
@@ -91,9 +80,10 @@ const TitleBox = styled('div')(({ theme }) => ({
   },
 }));
 
-const ItemsBox = styled('div')(({ theme }) => ({
-  flex: 3 / 4,
+const Mobile = styled('div')(({ theme }) => ({
   display: 'flex',
+  width: '100%',
+  flex: 3 / 4,
   flexDirection: 'row',
   alignItems: 'center',
   minWidth: 'calc(100%-76px)',
@@ -101,13 +91,47 @@ const ItemsBox = styled('div')(({ theme }) => ({
 
   gap: 8,
   [theme.breakpoints.up('tablet_768')]: {
-    minWidth: 'calc(100%-136px)',
+    display: 'none',
+  },
+}));
+
+const Table = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    display: 'flex',
     flex: 5 / 6,
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    minWidth: 'calc(100%-136px)',
   },
-  [theme.breakpoints.up('desktop_1024')]: {
+}));
+const Desk1024 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1024', 'desktop_1280')]: {
+    display: 'flex',
     minWidth: 'calc(100%-142px)',
+    flex: 5 / 6,
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
   },
+}));
+
+const Desk10280 = styled('div')(({ theme }) => ({
+  display: 'none',
   [theme.breakpoints.up('desktop_1280')]: {
+    display: 'flex',
     minWidth: 'calc(100%-228px)',
+    flex: 5 / 6,
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
   },
 }));

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/HeaderTitleSkeleton.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/HeaderTitleSkeleton.tsx
@@ -1,34 +1,46 @@
-import { Skeleton, styled, useMediaQuery } from '@mui/material';
+import { Skeleton, styled } from '@mui/material';
 import React from 'react';
-import type { Theme } from '@mui/material';
 
-const HeaderTitleSkeleton = () => {
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
-  const isTable = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
-  const isDesk1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
-  const isDesk1028 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1280'));
-  return (
-    <Container>
-      {(isMobile || isTable) && (
-        <>
-          <ItemSkeleton variant="rectangular" />
-          <ItemSkeleton variant="rectangular" />
-        </>
-      )}
-      {isDesk1024 && (
-        <>
-          <ItemSkeleton variant="rectangular" width={84} />
-          <ItemSkeleton variant="rectangular" width={136} />
-        </>
-      )}
-      {isDesk1028 && <ItemSkeleton variant="rectangular" width={145} />}
-    </Container>
-  );
-};
+const HeaderTitleSkeleton = () => (
+  <Container>
+    <Mobile>
+      <ItemSkeleton variant="rectangular" />
+      <ItemSkeleton variant="rectangular" />
+    </Mobile>
+    <Table>
+      <ItemSkeleton variant="rectangular" />
+      <ItemSkeleton variant="rectangular" />
+    </Table>
 
+    <Desk1024>
+      <ItemSkeleton variant="rectangular" width={84} />
+      <ItemSkeleton variant="rectangular" width={136} />
+    </Desk1024>
+
+    <Desk1028>
+      <ItemSkeleton variant="rectangular" width={145} />
+    </Desk1028>
+  </Container>
+);
 export default HeaderTitleSkeleton;
 
-const Container = styled('div')(({ theme }) => ({
+const Container = styled('div')({
+  display: 'flex',
+});
+
+const ItemSkeleton = styled(Skeleton)(({ theme }) => ({
+  borderRadius: 15,
+  height: 10.5,
+  width: 50,
+  backgroundColor: theme.palette.mode === 'light' ? '#D1DEE6' : '#31424E',
+  [theme.breakpoints.up('tablet_768')]: {
+    borderRadius: 20,
+    height: 14,
+    width: 98,
+  },
+}));
+
+const Mobile = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
@@ -44,44 +56,68 @@ const Container = styled('div')(({ theme }) => ({
     borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
   },
   [theme.breakpoints.up('tablet_768')]: {
-    width: 136,
-    ':after': {
-      content: '""',
-      position: 'absolute',
-      height: 48,
-      right: 0,
-      borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
-    },
+    display: 'none',
   },
-  [theme.breakpoints.up('desktop_1024')]: {
-    ':after': {
-      content: '""',
-      position: 'absolute',
+}));
+const Table = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    gap: 16,
+    position: 'relative',
+    [theme.breakpoints.up('tablet_768')]: {
+      width: 136,
       height: 48,
-      right: -16,
-      borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
-    },
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    width: 228,
-    ':after': {
-      content: '""',
-      position: 'absolute',
-      height: 48,
-      right: 10,
-      borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
+      ':after': {
+        content: '""',
+        position: 'absolute',
+        height: 48,
+        right: 0,
+        borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
+      },
     },
   },
 }));
 
-const ItemSkeleton = styled(Skeleton)(({ theme }) => ({
-  borderRadius: 15,
-  height: 10.5,
-  width: 50,
-  backgroundColor: theme.palette.mode === 'light' ? '#D1DEE6' : '#31424E',
-  [theme.breakpoints.up('tablet_768')]: {
-    borderRadius: 20,
-    height: 14,
-    width: 98,
+const Desk1024 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1024', 'desktop_1280')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    gap: 16,
+    position: 'relative',
+    [theme.breakpoints.up('desktop_1024')]: {
+      ':after': {
+        content: '""',
+        position: 'absolute',
+        height: 48,
+        right: -16,
+        borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
+      },
+    },
+  },
+}));
+
+const Desk1028 = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1280')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    position: 'relative',
+    gap: 16,
+    [theme.breakpoints.up('desktop_1280')]: {
+      width: 228,
+      ':after': {
+        content: '""',
+        position: 'absolute',
+        height: 48,
+        right: 10,
+        borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
+      },
+    },
   },
 }));

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/ItemHeaderSkeleton.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/ItemHeaderSkeleton.tsx
@@ -1,118 +1,59 @@
-import { Skeleton, styled, useMediaQuery } from '@mui/material';
+import { Skeleton, styled } from '@mui/material';
 import React from 'react';
-import type { Theme } from '@mui/material';
 
 interface Props {
   isLast?: boolean;
   className?: string;
 }
 
-const ItemHeaderSkeleton: React.FC<Props> = ({ isLast, className }) => {
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
-  const isTable = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
-  const isDesk1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
-  const isDesk1028 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1280'));
-  return (
-    <Container isLast={isLast} className={className}>
-      {isMobile && (
-        <>
-          <ItemSkeleton variant="rectangular" height={10.5} width={38} />
-          <Values>
-            <ItemSkeleton variant="rectangular" height={10.5} width={50} />
-            <ItemSkeleton variant="rectangular" height={10.5} width={50} />
-          </Values>
-        </>
-      )}
-      {isTable && (
-        <>
-          <ItemSkeleton variant="rectangular" height={14} width={isLast ? 40 : 69} />
-          <Values>
-            <ItemSkeleton variant="rectangular" height={9.62} width={38} />
-            <ItemSkeleton variant="rectangular" height={10.5} width={66} />
-          </Values>
-        </>
-      )}
-      {isDesk1024 && (
-        <>
-          <ItemSkeleton variant="rectangular" height={14} width={isLast ? 40 : 66} />
-          <RowValues>
-            <ItemValueCell>
-              <ItemSkeleton variant="rectangular" height={9.62} width={40} />
-              <ItemSkeleton variant="rectangular" height={10.5} width={66} />
-            </ItemValueCell>
-            <ItemValueCell>
-              <ItemSkeleton variant="rectangular" height={9.62} width={40} />
-              <ItemSkeleton variant="rectangular" height={10.5} width={66} />
-            </ItemValueCell>
-          </RowValues>
-        </>
-      )}
-      {isDesk1028 && (
-        <>
-          <ItemSkeleton variant="rectangular" height={17.5} width={isLast ? 51 : 85} />
-          <RowValues>
-            <ItemValueCell>
-              <ItemSkeleton variant="rectangular" height={9.62} width={38} />
-              <ItemSkeleton variant="rectangular" height={10.5} width={66} />
-            </ItemValueCell>
-            <ItemValueCell>
-              <ItemSkeleton variant="rectangular" height={9.62} width={49} />
-              <ItemSkeleton variant="rectangular" height={10.5} width={66} />
-            </ItemValueCell>
-          </RowValues>
-        </>
-      )}
-    </Container>
-  );
-};
+const ItemHeaderSkeleton: React.FC<Props> = ({ isLast, className }) => (
+  <Container className={className}>
+    <Mobile isLast={isLast}>
+      <ItemSkeleton variant="rectangular" height={10.5} width={38} />
+      <Values>
+        <ItemSkeleton variant="rectangular" height={10.5} width={50} />
+        <ItemSkeleton variant="rectangular" height={10.5} width={50} />
+      </Values>
+    </Mobile>
 
+    <Table isLast={isLast}>
+      <ItemSkeleton variant="rectangular" height={14} width={isLast ? 40 : 69} />
+      <Values>
+        <ItemSkeleton variant="rectangular" height={9.62} width={38} />
+        <ItemSkeleton variant="rectangular" height={10.5} width={66} />
+      </Values>
+    </Table>
+    <Desk1024 isLast={isLast}>
+      <ItemSkeleton variant="rectangular" height={14} width={isLast ? 40 : 66} />
+      <RowValues>
+        <ItemValueCell>
+          <ItemSkeleton variant="rectangular" height={9.62} width={40} />
+          <ItemSkeleton variant="rectangular" height={10.5} width={66} />
+        </ItemValueCell>
+        <ItemValueCell>
+          <ItemSkeleton variant="rectangular" height={9.62} width={40} />
+          <ItemSkeleton variant="rectangular" height={10.5} width={66} />
+        </ItemValueCell>
+      </RowValues>
+    </Desk1024>
+    <Desk1028 isLast={isLast}>
+      <ItemSkeleton variant="rectangular" height={17.5} width={isLast ? 51 : 85} />
+      <RowValues>
+        <ItemValueCell>
+          <ItemSkeleton variant="rectangular" height={9.62} width={38} />
+          <ItemSkeleton variant="rectangular" height={10.5} width={66} />
+        </ItemValueCell>
+        <ItemValueCell>
+          <ItemSkeleton variant="rectangular" height={9.62} width={49} />
+          <ItemSkeleton variant="rectangular" height={10.5} width={66} />
+        </ItemValueCell>
+      </RowValues>
+    </Desk1028>
+  </Container>
+);
 export default ItemHeaderSkeleton;
 
-const Container = styled('div')<{ isLast?: boolean }>(({ theme, isLast = false }) => ({
-  display: 'flex',
-  position: 'relative',
-  flexDirection: 'column',
-  alignItems: 'center',
-  gap: 12.5,
-  minWidth: 78,
-
-  flex: 1,
-  ...(!isLast && {
-    ':after': {
-      content: '""',
-      position: 'absolute',
-      height: 48,
-      right: -6,
-      borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
-    },
-  }),
-
-  [theme.breakpoints.up('tablet_768')]: {
-    gap: 14,
-    minWidth: 103.5,
-    ...(!isLast && {
-      ':after': {
-        content: '""',
-        position: 'absolute',
-        height: 60,
-        right: -14,
-        borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
-      },
-    }),
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    minWidth: 130,
-    ...(!isLast && {
-      ':after': {
-        content: '""',
-        position: 'absolute',
-        height: 60,
-        right: -8,
-        borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
-      },
-    }),
-  },
-}));
+const Container = styled('div')({});
 
 const Values = styled('div')({
   display: 'flex',
@@ -142,5 +83,91 @@ const ItemValueCell = styled('div')(({ theme }) => ({
   width: 70.5,
   [theme.breakpoints.up('desktop_1280')]: {
     width: 90,
+  },
+}));
+
+const Mobile = styled('div')<{ isLast?: boolean }>(({ theme, isLast = false }) => ({
+  display: 'flex',
+  position: 'relative',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 12.5,
+  minWidth: 78,
+
+  flex: 1,
+  ...(!isLast && {
+    ':after': {
+      content: '""',
+      position: 'absolute',
+      height: 48,
+      right: -6,
+      borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
+    },
+  }),
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
+
+const Table = styled('div')<{ isLast?: boolean }>(({ theme, isLast = false }) => ({
+  display: 'none',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    gap: 14,
+    display: 'flex',
+    position: 'relative',
+    flexDirection: 'column',
+    alignItems: 'center',
+    minWidth: 103.5,
+    ...(!isLast && {
+      ':after': {
+        content: '""',
+        position: 'absolute',
+        height: 60,
+        right: -14,
+        borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
+      },
+    }),
+  },
+}));
+
+const Desk1024 = styled('div')<{ isLast?: boolean }>(({ theme, isLast = false }) => ({
+  display: 'none',
+  [theme.breakpoints.between('desktop_1024', 'desktop_1280')]: {
+    minWidth: 130,
+    gap: 14,
+    display: 'flex',
+    position: 'relative',
+    flexDirection: 'column',
+    alignItems: 'center',
+    ...(!isLast && {
+      ':after': {
+        content: '""',
+        position: 'absolute',
+        height: 60,
+        right: -8,
+        borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
+      },
+    }),
+  },
+}));
+
+const Desk1028 = styled('div')<{ isLast?: boolean }>(({ theme, isLast = false }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1280')]: {
+    minWidth: 130,
+    gap: 14,
+    display: 'flex',
+    position: 'relative',
+    flexDirection: 'column',
+    alignItems: 'center',
+    ...(!isLast && {
+      ':after': {
+        content: '""',
+        position: 'absolute',
+        height: 60,
+        right: -8,
+        borderRight: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : 'rgb(84, 105, 120, 0.30)'}`,
+      },
+    }),
   },
 }));


### PR DESCRIPTION
## Ticket
<!--- Your Ticket Link -->

## Description
<!--- What is new in this PR -->

## What solved
- [X] Finances view, Breakdown Table section. Loading state.- ** **Expected Output:** Once the view is loading, the skeleton of the section should be displayed as the design shows.**Current Output:** Firstly, a loading for several rows is displayed and later changes to the correct skeleton. 

