### PR TITLE
[BS-1] Add component for not result in expense report

### DIFF
--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -181,22 +181,21 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
             />
           </ContainerReservesWaterfallChart>
         )}
-        {expenseReportSection.hasExpenseReports && (
-          <ContainerLastReport>
-            <DelegateExpenseTrendFinances
-              selectedMetric={expenseReportSection.selectedMetric}
-              onMetricChange={expenseReportSection.onMetricChange}
-              selectedStatuses={expenseReportSection.selectedStatuses}
-              onStatusSelectChange={expenseReportSection.onStatusSelectChange}
-              handleResetFilter={expenseReportSection.handleResetFilter}
-              statusesItems={expenseReportSection.statusesItems}
-              columns={expenseReportSection.headersExpenseReport}
-              sortClick={expenseReportSection.onSortClick}
-              expenseReportResponse={expenseReportSection.expenseReportResponse}
-              isDisabled={expenseReportSection.isDisabled}
-            />
-          </ContainerLastReport>
-        )}
+        <ContainerLastReport>
+          <DelegateExpenseTrendFinances
+            selectedMetric={expenseReportSection.selectedMetric}
+            onMetricChange={expenseReportSection.onMetricChange}
+            selectedStatuses={expenseReportSection.selectedStatuses}
+            onStatusSelectChange={expenseReportSection.onStatusSelectChange}
+            handleResetFilter={expenseReportSection.handleResetFilter}
+            statusesItems={expenseReportSection.statusesItems}
+            columns={expenseReportSection.headersExpenseReport}
+            sortClick={expenseReportSection.onSortClick}
+            expenseReportResponse={expenseReportSection.expenseReportResponse}
+            isDisabled={expenseReportSection.isDisabled}
+            hasExpenseReport={expenseReportSection.hasExpenseReports}
+          />
+        </ContainerLastReport>
       </Container>
     </PageContainer>
   );

--- a/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReports.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReports.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import BigButton from '@ses/components/Button/BigButton/BigButton';
+import { TablePlaceholder } from '@ses/components/CustomTable/TablePlaceholder';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
@@ -18,12 +19,14 @@ interface Props extends ExpenseReportsFiltersProps {
   columns: DelegateExpenseTableHeader[];
   sortClick: (index: number) => void;
   expenseReportResponse: SWRInfiniteResponse<BudgetStatement[], unknown>;
+  hasExpenseReport: boolean;
 }
 
 const ExpenseReports: React.FC<Props> = ({
   columns,
   sortClick,
   expenseReportResponse,
+  hasExpenseReport,
   ...filterProps // props from ExpenseReportsFiltersProps
 }) => {
   const { isLight } = useThemeContext();
@@ -33,6 +36,7 @@ const ExpenseReports: React.FC<Props> = ({
       expenseReportResponse.data &&
       typeof expenseReportResponse.data[expenseReportResponse.size - 1] === 'undefined');
 
+  console.log('hasExpenseReport', hasExpenseReport);
   return (
     <Container>
       <HeaderContainer>
@@ -43,9 +47,11 @@ const ExpenseReports: React.FC<Props> = ({
         <ExpenseReportsFilters {...filterProps} />
       </HeaderContainer>
 
-      <Header>
-        <HeaderDelegateExpense columns={columns} sortClick={sortClick} />
-      </Header>
+      {hasExpenseReport && (
+        <Header>
+          <HeaderDelegateExpense columns={columns} sortClick={sortClick} />
+        </Header>
+      )}
       <ItemSection>
         {expenseReportResponse.data?.map((page, index) => (
           <React.Fragment key={`page-${index}`}>
@@ -55,7 +61,11 @@ const ExpenseReports: React.FC<Props> = ({
           </React.Fragment>
         ))}
         {isLoading && <ExpenseReportsItemsSkeleton />}
+        {!hasExpenseReport && (
+          <TablePlaceholder description="There are no contributors available with this combination of filters" />
+        )}
       </ItemSection>
+
       {!isLoading &&
         !((expenseReportResponse.data?.[(expenseReportResponse.data?.length ?? 0) - 1]?.length ?? 0) < 10) && (
           <ContainerButton>


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Add component of not result when there its not result 

## What solved
- [X]- Finances view. Expenses Report section. Selecting a status with 0 elements. -** **Expected Output:** A message indicating no results should be displayed. **Current Output:** The section disappears of the view.
