### PR TITLE
[QC] Fix CU reports month navigation

### DIFF
--- a/pages/core-unit/[code]/finances/reports/index.tsx
+++ b/pages/core-unit/[code]/finances/reports/index.tsx
@@ -45,8 +45,8 @@ const Transparency = ({ coreUnits, cu, expenseCategories, snapshotLimitPeriods }
           snapshotLimitPeriods
             ? {
                 // deserialize the ISO strings to date objects
-                earliest: DateTime.fromISO(snapshotLimitPeriods.earliest),
-                latest: DateTime.fromISO(snapshotLimitPeriods.latest),
+                earliest: DateTime.fromISO(snapshotLimitPeriods.earliest).toUTC(),
+                latest: DateTime.fromISO(snapshotLimitPeriods.latest).toUTC(),
               }
             : undefined
         }

--- a/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
+++ b/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
@@ -142,7 +142,11 @@ export const getLastSnapshotPeriod = async (
     return undefined;
   }
 
-  const periods = data.snapshots.map((snapshot) => DateTime.fromFormat(snapshot.period, 'yyyy/MM'));
+  const periods = data.snapshots.map((snapshot) =>
+    DateTime.fromFormat(snapshot.period, 'yyyy/MM', {
+      zone: 'UTC',
+    })
+  );
   return {
     earliest: DateTime.min(...periods),
     latest: DateTime.max(...periods),


### PR DESCRIPTION
## Ticket
https://trello.com/c/08Jl1Gns/310-qc-round-2-r

## Description
Fixed the navigation. The issue was related to differences between the timezones of the server and clients

## What solved
- [X] SES core unit, Expenses reports, Feb 2024. **Expected Output:** The snapshot query displays data for Feb 2024. **Current Output:** Feb 2024 is not available on the UI.
