### PR TITLE
[BSN-1] Fix mobile breadcrumb long names

### DIFF
--- a/src/stories/components/Pagination/BreadCrumbWithIcons.tsx
+++ b/src/stories/components/Pagination/BreadCrumbWithIcons.tsx
@@ -158,6 +158,9 @@ const StyleTitle = styled(Typography, { shouldForwardProp: (prop) => prop !== 'i
 
 const ItemMenu = styled.a({
   textDecoration: 'none',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
 });
 
 const Container = styled.div({


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix long names with an ellipsis on mobile

## What solved
- [X] Finances->Atlas Immutable Budget->AllocatorDAO Genesis Emissions, Distribution and Farming rate->Allocator tokens for Genesis Farming.- ** **Expected Output:** When selecting the back option, the longest name should appear with three dots.  **Current Output:** The names are cut off. 
