### PR TITLE
[BS-1] Fix/issues table number

### DIFF
--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -7,9 +7,10 @@ import lightTheme from '@ses/styles/theme/light';
 import Link from 'next/link';
 import React from 'react';
 import { showOnlySixteenRowsWithOthers, sortTablesByRows } from '../../utils/utils';
+import { defaultOrder, orderMetrics } from '../HeaderTable/utils';
 import LinkCellComponent from '../LinkCellComponent/LinkCellComponent';
 import CellTable from './CellTable';
-import type { MetricValues, PeriodicSelectionFilter, ItemRow, TableFinances } from '../../utils/types';
+import type { TableFinances, MetricValues, PeriodicSelectionFilter, ItemRow } from '../../utils/types';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
@@ -22,7 +23,6 @@ interface Props {
 
 const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, period, year }) => {
   const { isLight } = useThemeContext();
-
   const orderData = sortTablesByRows(breakdownTable);
   const showFooterAndCorrectNumber = showOnlySixteenRowsWithOthers(orderData);
   const iteration = period === 'Quarterly' ? 5 : period === 'Monthly' ? 13 : period === 'Annually' ? 1 : 3;
@@ -33,7 +33,8 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
   const showQuarterly = !isMobile && period === 'Quarterly';
   const showMonthly = desk1440 && period === 'Monthly';
   const arrayMetrics = new Array<number>(iteration).fill(0);
-  const newMetrics = metrics.map((metric) =>
+  const newMetricsOrdered = orderMetrics(defaultOrder, metrics);
+  const newMetrics = newMetricsOrdered.map((metric) =>
     metric === 'Net Expenses On-chain'
       ? 'PaymentsOnChain'
       : metric === 'Net Protocol Outflow'

--- a/src/stories/containers/Finances/components/HeaderTable/utils.ts
+++ b/src/stories/containers/Finances/components/HeaderTable/utils.ts
@@ -1,4 +1,4 @@
-const defaultOrder = ['Budget', 'Forecast', 'Net Protocol Outflow', 'Net Expenses On-chain', 'Actuals'];
+export const defaultOrder = ['Budget', 'Forecast', 'Net Protocol Outflow', 'Net Expenses On-chain', 'Actuals'];
 export const orderMetrics = (metricOrder = defaultOrder, metricsToOrder: string[]) => {
   const orderedMetrics: string[] = [];
 

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/HeaderRowSkeletonTitle.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTableSkeleton/BreakdownTableBodySkeleton/HeaderRowSkeletonTitle.tsx
@@ -106,7 +106,6 @@ const Mobile = styled('div')(({ theme }) => ({
   gap: 4,
   height: 48,
   width: 78,
-  border: '1px solid red',
   [theme.breakpoints.up('tablet_768')]: {
     display: 'none',
   },

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -205,6 +205,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
         if (!rows.some((row) => row.name === subBudget.codePath)) {
           rows.push({
             name: isMobile ? subBudget.code : subBudget.codePath,
+            // name: subBudget.codePath,
             codePath: subBudget.codePath,
             columns: Array.from({ length: columnsCount }, () => ({ ...EMPTY_METRIC_VALUE })),
           });


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix the order of of the metrics to match with the analiticys

## What solved
- [X] - Finances view. Breakdown Table section. Period: Annually. Year: 2024. - ** **Expected Output:** The total of each metric should match the sum of the value per each budget. **Current Output:**  The total of the Budget m metric is 20,138,275 but all the categories and subcategories have a value 0. All the totals displayed are wrong.

## Screenshots (if apply)
