### PR TITLE
Fix/percent in doughnut chart

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -205,7 +205,6 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
         if (!rows.some((row) => row.name === subBudget.codePath)) {
           rows.push({
             name: isMobile ? subBudget.code : subBudget.codePath,
-            // name: subBudget.codePath,
             codePath: subBudget.codePath,
             columns: Array.from({ length: columnsCount }, () => ({ ...EMPTY_METRIC_VALUE })),
           });

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -66,6 +66,7 @@ export const useCardChartOverview = (
     forecast: 0,
     budget: 0,
     paymentsOnChain: 0,
+    protocolNetOutflow: 0,
     paymentsOffChainIncluded: 0,
   };
 

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/utils.ts
@@ -25,11 +25,12 @@ export const getShortCode = (code: string) => (code.length > 8 ? code.substring(
 
 export const getCorrectMetricValuesOverViewChart = (metric: AnalyticMetric) => {
   if (metric === 'Forecast' || metric === 'Actuals' || metric === 'Budget') return metric.toLocaleLowerCase();
+
   switch (metric) {
     case 'PaymentsOnChain':
       return 'paymentsOnChain';
-    case 'PaymentsOffChainIncluded':
-      return 'paymentsOffChainIncluded';
+    case 'ProtocolNetOutflow':
+      return 'protocolNetOutflow';
     default:
       return 'budget';
   }


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix the % when the  Net Protocol Outflow is selected

## What solved
- [X] - Finances view, Legend section.Metric: Net Protocol Outflow- ** **Expected Output:** If the budgets have values, then the percent should be reflected. **Current Output:** MakerDao Legacy Budget displays a value of 36.5K which is reflected in the pie chart but the percent is 0
