### PR TITLE
[MET-1] Update budget structure legend name

### DIFF
--- a/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
+++ b/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
@@ -32,7 +32,7 @@ const BudgetStructureSection: React.FC<BudgetCompositionProps> = ({
 
   const doughnutSeriesData: DoughnutSeries[] = [
     {
-      name: 'End-game Alignment Scope Budgets',
+      name: 'Scope Frameworks Budget',
       value: scopes,
       percent: (scopes * 100) / totalBudgetCap,
       actuals: 0,
@@ -40,7 +40,7 @@ const BudgetStructureSection: React.FC<BudgetCompositionProps> = ({
       color: '#D2D4EF',
     },
     {
-      name: 'End-game Atlas Immutable AA Budgets',
+      name: 'Atlas Immutable Budget',
       value: immutable,
       percent: (immutable * 100) / totalBudgetCap,
       actuals: 0,


### PR DESCRIPTION
## Ticket
https://trello.com/c/ERuAdkUG/292-met-13-detailed-insight-into-endgame-budget-structure

## Description
Updated the budget structure legend name to match the finances budgets names

## What solved
- [X] Change the budget names
