### PR TITLE
[SB-1] Fix/issues relate with doughnut chart

### DIFF
--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -380,14 +380,8 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean }>(({ isCoreThirdLe
     marginTop: !isCoreThirdLevel ? 10 : 10,
     display: 'flex',
     position: 'relative',
-    flexGrow: 1,
-    flexShrink: 1,
     height: 'calc(100% + 16px)',
   },
-
-  '& .swiper-slide': {},
-
-  '& .swiper-pagination': {},
 
   '& .swiper-pagination-horizontal': {
     display: 'flex',
@@ -407,9 +401,6 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean }>(({ isCoreThirdLe
   },
   '& .swiper-pagination-bullet-active': {
     backgroundColor: '#2DC1B1 !important',
-  },
-  '& .swiper-slide-active': {
-    [lightTheme.breakpoints.up('tablet_768')]: {},
   },
 }));
 

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -366,12 +366,12 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean }>(({ isCoreThirdLe
     display: 'flex',
     position: 'relative',
     width: 200,
-    height: isCoreThirdLevel ? 'calc(100% + 16px)' : 'calc(100% - 16px)',
+    height: isCoreThirdLevel ? 'calc(100% + 8px)' : 'calc(100% - 16px)',
   },
   [lightTheme.breakpoints.up('desktop_1024')]: {
     marginTop: isCoreThirdLevel ? 10 : 16,
     display: 'flex',
-    height: isCoreThirdLevel ? 'calc(100% + 16px)' : 'calc(100% - 16px)',
+    height: isCoreThirdLevel ? 'calc(100% + 8px)' : 'calc(100% - 16px)',
 
     width: 250,
     minWidth: 250,
@@ -380,7 +380,7 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean }>(({ isCoreThirdLe
     marginTop: !isCoreThirdLevel ? 10 : 10,
     display: 'flex',
     position: 'relative',
-    height: 'calc(100% + 16px)',
+    height: 'calc(100% - 8px)',
   },
 
   '& .swiper-pagination-horizontal': {

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -24,6 +24,7 @@ export const useCardChartOverview = (
 ) => {
   const isTable = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
   const isDesk1024 = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
+  const isDesk1280 = useMediaQuery(lightTheme.breakpoints.up('desktop_1280'));
 
   const isHasSubLevels = hasSubLevels(codePath, allBudgets);
 
@@ -203,7 +204,8 @@ export const useCardChartOverview = (
   });
   const changeAlignment = doughnutSeriesData.length > 4;
 
-  const showSwiper = !!((isTable || isDesk1024) && doughnutSeriesData.length >= 4);
+  const showSwiper =
+    !!((isTable || isDesk1024) && doughnutSeriesData.length >= 4) || (isDesk1280 && doughnutSeriesData.length >= 10);
   const numberSliderPerLevel = (isTable || isDesk1024) && levelNumber < 3 ? 3 : 5;
 
   return {


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Add Swiper when there is to many items

## What solved
- [X] Finances->MakerDAO Legacy Budget-> core-units. Legend-** **Expected Output:** The legend should display all the data required. ** Current Output:** The values of the third column are cut off. 

- [X] From 768 to 1280. - Finances->MakerDAO Legacy Budget-> core-units. Legend-. The navigation items should be displayed in the legend area.** Current Output:** The navigation items are displayed outside of the legend area. 
## Screenshots (if apply)
