### PR TITLE
fix: transition status chart yeras on mobile

### DIFF
--- a/pages/endgame/index.tsx
+++ b/pages/endgame/index.tsx
@@ -1,5 +1,6 @@
 import EndgameContainer from '@ses/containers/Endgame/EndgameContainer';
 import { fetchAnalytics } from '@ses/containers/Finances/api/queries';
+import { DateTime } from 'luxon';
 import React from 'react';
 import type { Analytic } from '@ses/core/models/interfaces/analytic';
 
@@ -18,8 +19,10 @@ const EndgamePage: React.FC<EndgamePageProps> = ({ budgetStructureAnalytics, bud
 export default EndgamePage;
 
 export async function getServerSideProps() {
-  const budgetStructureAnalytics = await fetchAnalytics('total', [2021, 2024], 'atlas', 2);
-  const budgetTransitionAnalytics = await fetchAnalytics('quarterly', [2021, 2024], 'atlas', 2);
+  const [budgetStructureAnalytics, budgetTransitionAnalytics] = await Promise.all([
+    fetchAnalytics('total', [2021, 2025], 'atlas', 2),
+    fetchAnalytics('quarterly', ['2021-01-01', DateTime.now().toFormat('yyyy-LL-dd')], 'atlas', 2),
+  ]);
 
   return {
     props: {

--- a/src/stories/containers/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
+++ b/src/stories/containers/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
@@ -62,6 +62,14 @@ const BudgetTransitionChart: React.FC<BudgetTransitionChartProps> = ({ data, sel
     };
   }, [data, isMobile, selected]);
 
+  const years = useMemo(
+    () =>
+      Object.keys(data)
+        .filter((period) => period.endsWith('Q1'))
+        .map((period) => period.substring(0, 4)),
+    [data]
+  );
+
   const options: EChartsOption = {
     grid: {
       height: isMobile ? 222 : isTablet ? 312 : isDesktop1024 ? 392 : 392,
@@ -184,11 +192,12 @@ const BudgetTransitionChart: React.FC<BudgetTransitionChartProps> = ({ data, sel
           }}
           opts={{ renderer: 'svg' }}
         />
-        <YearsContainer>
-          <Year isLight={isLight}>2021</Year>
-          <Year isLight={isLight}>2022</Year>
-          <Year isLight={isLight}>2023</Year>
-          <Year isLight={isLight}>2024</Year>
+        <YearsContainer barsAmount={Object.keys(data).length}>
+          {years.map((year) => (
+            <Year isLight={isLight} key={year}>
+              {year}
+            </Year>
+          ))}
         </YearsContainer>
       </ChartContainer>
       <LegendContainer>
@@ -237,18 +246,18 @@ const ChartContainer = styled.div({
   },
 });
 
-const YearsContainer = styled.div({
+const YearsContainer = styled.div<{ barsAmount: number }>(({ barsAmount }) => ({
   position: 'absolute',
   display: 'flex',
   flexDirection: 'row',
-  gap: 40,
+  gap: (281 / barsAmount) * 4 - 30,
   bottom: -20,
   left: 45,
 
   [lightTheme.breakpoints.up('tablet_768')]: {
     display: 'none',
   },
-});
+}));
 
 const Year = styled.div<WithIsLight>(({ isLight }) => ({
   color: isLight ? '#139D8D' : '#2DC1B1',

--- a/src/stories/containers/Finances/api/queries.ts
+++ b/src/stories/containers/Finances/api/queries.ts
@@ -30,7 +30,7 @@ export const fetchBudgets = async (): Promise<Budget[]> => {
 
 export const fetchAnalytics = async (
   granularity: AnalyticGranularity,
-  year: string | [number, number],
+  year: string | [number, number] | [string, string],
   select: string,
   lod: number
 ): Promise<Analytic> => {
@@ -56,13 +56,17 @@ export const fetchAnalytics = async (
     }
   `;
 
-  const initialYear = Array.isArray(year) ? year[0] : year;
-  const endYear = Array.isArray(year) ? year[1] : Number(initialYear) + 1;
+  let initialYear = `${(Array.isArray(year) ? year[0] : year).toString()}-01-01`;
+  let endYear = `${(Array.isArray(year) ? year[1] : Number(initialYear) + 1).toString()}-01-01`;
+  if (Array.isArray(year) && typeof year[0] === 'string') {
+    initialYear = year[0];
+    endYear = year[1].toString();
+  }
   const filter: AnalyticFilter = {
     filter: {
       granularity,
-      start: `${initialYear}-01-01`,
-      end: `${Number(endYear)}-01-01`,
+      start: initialYear,
+      end: endYear,
       metrics: ['Actuals', 'Budget', 'Forecast', 'PaymentsOnChain', 'ProtocolNetOutflow'],
       currency: 'DAI',
       dimensions: [


### PR DESCRIPTION
## Ticket
https://trello.com/c/K6BCBa9u/293-met-14-visualization-of-budget-transition-status

## Description
The years are not correctly aligned with the x-axis Q1 items

## What solved
- [X] The number of years reflected should match the number of years quarterly displayed. **Current Output:** Four years are displayed but only three years quarterly are reflected.
