### PR TITLE
fix: Fix the query analytics in the Finances

### DIFF
--- a/src/stories/containers/Finances/api/queries.ts
+++ b/src/stories/containers/Finances/api/queries.ts
@@ -55,9 +55,16 @@ export const fetchAnalytics = async (
       }
     }
   `;
+  let initialYear, endYear;
 
-  let initialYear = `${(Array.isArray(year) ? year[0] : year).toString()}-01-01`;
-  let endYear = `${(Array.isArray(year) ? year[1] : Number(initialYear) + 1).toString()}-01-01`;
+  if (Array.isArray(year)) {
+    initialYear = `${year[0]}-01-01`;
+    endYear = `${year[1]}-01-01`;
+  } else {
+    initialYear = `${year}-01-01`;
+    endYear = `${Number(year) + 1}-01-01`;
+  }
+
   if (Array.isArray(year) && typeof year[0] === 'string') {
     initialYear = year[0];
     endYear = year[1].toString();


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix the NAN value return by the endYear value in the finances page query 
Fix the way that end year is calculate to get a valid value for filter in the query


## What solved
- [X] **HP** All **Steps to Reproduce:** **- Query: Analytics- **  **Current Output:** In the filter, the end date displays the year as "NaN".   
- [X] **HP** Finances view- ** **Expected Output:** The values should be displayed in all sections. **Current Output:**  The sections are displayed with values = 0. The query doesn't display any result. **Visual Proof:** [image.png](). **Order Execution:** Please, fix it.
