### PR TITLE
fix:Fix the fontSize start and end bar of waterfall chart

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -107,7 +107,7 @@ export const builderWaterfallSeries = (
         rich: {
           colorful: {
             color: isLight ? '#83A7FF' : '#447AFB',
-            fontSize: isMobile ? 7 : 12,
+            fontSize: isMobile ? 8 : 12,
             fontFamily: 'Inter, sans-serif',
           },
           hidden: {


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix the font size in start and bar of the waterfall chart .
The actual font size of the waterfall es  to small so its need to be change

## What solved
- [X]  Finances,Reserves Chart section.- ** **Expected Output:** The numbers of each bar should be visible with a proper size.**Current Output:**  The numbers on the start and finish bars are barely visible.

## Screenshots (if apply)
