### PR TITLE
fix: Fix the loading state in breakdow chart

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeleton.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeleton.tsx
@@ -1,188 +1,52 @@
-import { Box, Skeleton, styled, useMediaQuery } from '@mui/material';
+import { Skeleton, styled } from '@mui/material';
 import React from 'react';
-import type { Theme } from '@mui/material';
+import BarSkeletonItems from './BreakdownChartSkeletonUtils/BarSkeletonItem';
+import ItemLegendValues from './BreakdownChartSkeletonUtils/ItemLegendValues';
+import LegendAxisYItems from './BreakdownChartSkeletonUtils/LegendAxisYComponent';
 
 const BreakdownChartSkeleton = () => {
   const arrayLegendAxisX = Array.from({ length: 12 }, () => 0);
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
-  const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
-  const isDesktop1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
-  const isDesk1280 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1280'));
-
-  const barSkeleton = (height: number, percentFilled: number) => (
-    <WrapperBox
-      display="flex"
-      flexDirection="column"
-      justifyContent="flex-end"
-      width={isMobile ? 16 : isTablet || isDesktop1024 ? 40 : isDesk1280 ? 56 : 56}
-      height={`${height}px`}
-      position="relative"
-      sx={{
-        borderTopLeftRadius: isMobile ? 4 : isTablet ? 6 : 6,
-        borderTopRightRadius: isMobile ? 4 : isTablet ? 6 : 6,
-        overflow: 'hidden',
-        borderBottomLeftRadius: isMobile ? 4 : isTablet ? 6 : 6,
-        borderBottomRightRadius: isMobile ? 4 : isTablet ? 6 : 6,
-      }}
-    >
-      <InsideBox
-        width={isMobile ? 16 : isTablet || isDesktop1024 ? 40 : isDesk1280 ? 56 : 56}
-        height={percentFilled}
-        sx={{
-          position: 'absolute',
-          borderBottomLeftRadius: isMobile ? 4 : isTablet ? 6 : 6,
-          borderBottomRightRadius: isMobile ? 4 : isTablet ? 6 : 6,
-        }}
-      />
-    </WrapperBox>
-  );
-
-  const ItemLegendValues = (circleDimension: number, itemWith: number) => (
-    <ContainerItem>
-      <Skeleton variant="circular" width={circleDimension} height={circleDimension} />
-      <Skeleton
-        variant="rectangular"
-        width={itemWith}
-        height={isMobile ? 10.5 : isTablet ? 14 : 14}
-        sx={{ borderRadius: 15 }}
-      />
-    </ContainerItem>
-  );
-
-  const ItemLegendAxisValues = (width: number, height: number) => (
-    <Skeleton
-      variant="rectangular"
-      width={width}
-      height={height}
-      sx={{ borderRadius: isMobile ? 12.5 : isTablet ? 17.5 : 17.5 }}
-    />
-  );
-
-  const legendAxisXMobile = (width = 7) => (
-    <Skeleton variant="circular" width={width} height={7.75} sx={{ borderRadius: 11.25 }} />
-  );
-
-  const lineMobile = (
-    <LineContainer>
-      <SkeletonLineMobileLeft variant="rectangular" width={170} height={11} sx={{}} />
-      <CircleElementStyled variant="circular" width={28} height={13} />
-
-      <SkeletonLineMobileRight variant="rectangular" width={170} height={11} sx={{}} />
-    </LineContainer>
-  );
-
-  const axisXNotMobile = (monthWith: number, yearWidth: number) => (
-    <ContainerAxisXNotMobile>
-      <Skeleton variant="rectangular" width={monthWith} height={10.5} sx={{ borderRadius: 15 }} />
-      <Skeleton variant="rectangular" width={yearWidth} height={10.5} sx={{ borderRadius: 15 }} />
-    </ContainerAxisXNotMobile>
-  );
 
   return (
     <Container>
       <ContainerLegendY>
-        <LegendAxisY>
-          <LegendAxisYItemContainer>
-            {ItemLegendAxisValues(isMobile ? 13 : isTablet ? 32 : 32, isMobile ? 8.75 : isTablet ? 12.5 : 12.5)}
-          </LegendAxisYItemContainer>
-
-          <LegendAxisYItemContainer>
-            {ItemLegendAxisValues(isMobile ? 26 : isTablet ? 32 : 32, isMobile ? 8.75 : isTablet ? 12.5 : 12.5)}
-          </LegendAxisYItemContainer>
-
-          <LegendAxisYItemContainer>
-            {ItemLegendAxisValues(isMobile ? 16 : isTablet ? 32 : 32, isMobile ? 8.75 : isTablet ? 12.5 : 12.5)}
-          </LegendAxisYItemContainer>
-
-          <LegendAxisYItemContainer>
-            {ItemLegendAxisValues(isMobile ? 25 : isTablet ? 32 : 32, isMobile ? 8.75 : isTablet ? 12.5 : 12.5)}
-          </LegendAxisYItemContainer>
-
-          <LegendAxisYItemContainer>
-            {ItemLegendAxisValues(isMobile ? 16 : isTablet ? 32 : 32, isMobile ? 8.75 : isTablet ? 12.5 : 12.5)}
-          </LegendAxisYItemContainer>
-
-          <LegendAxisYItemContainer>
-            {ItemLegendAxisValues(isMobile ? 25 : isTablet ? 32 : 32, isMobile ? 8.75 : isTablet ? 12.5 : 12.5)}
-          </LegendAxisYItemContainer>
-
-          <LegendAxisYItemContainer>
-            {ItemLegendAxisValues(isMobile ? 16 : isTablet ? 32 : 32, isMobile ? 8.75 : isTablet ? 12.5 : 12.5)}
-          </LegendAxisYItemContainer>
-
-          <LegendAxisYItemContainer>
-            {ItemLegendAxisValues(isMobile ? 25 : isTablet ? 32 : 32, isMobile ? 8.75 : isTablet ? 12.5 : 12.5)}
-          </LegendAxisYItemContainer>
-
-          <LegendAxisYItemContainer>
-            {ItemLegendAxisValues(isMobile ? 16 : isTablet ? 32 : 32, isMobile ? 8.75 : isTablet ? 12.5 : 12.5)}
-          </LegendAxisYItemContainer>
-        </LegendAxisY>
-        <ContainerBars>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 148 : isTablet ? 297 : 297, isMobile ? 148 : isTablet ? 297 : 297)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 150 : isTablet ? 296 : 296, isMobile ? 150 : isTablet ? 296 : 296)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 155 : isTablet ? 299 : 299, isMobile ? 155 : isTablet ? 299 : 299)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 139 : isTablet ? 274 : 274, isMobile ? 139 : isTablet ? 274 : 274)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 150 : isTablet ? 296 : 296, isMobile ? 98 : isTablet ? 192 : 192)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 156 : isTablet ? 306 : 306, isMobile ? 82 : isTablet ? 160 : 160)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 162 : isTablet ? 316 : 316, isMobile ? 62 : isTablet ? 124 : 124)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 166 : isTablet ? 332 : 332, isMobile ? 45 : isTablet ? 101 : 101)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 164 : isTablet ? 338 : 338, isMobile ? 36 : isTablet ? 70 : 70)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 162 : isTablet ? 345 : 345, isMobile ? 23 : isTablet ? 50 : 50)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 169 : isTablet ? 353 : 353, isMobile ? 15 : isTablet ? 30 : 30)}
-          </ContainerBar>
-          <ContainerBar>
-            {barSkeleton(isMobile ? 168 : isTablet ? 376 : 367, isMobile ? 7 : isTablet ? 16 : 16)}
-          </ContainerBar>
-        </ContainerBars>
+        <LegendAxisYItems />
+        <BarSkeletonItems />
       </ContainerLegendY>
-      {
-        <ContainerAxisX>
-          {isMobile ? (
-            <>
-              {arrayLegendAxisX.map((_, index) => (
-                <ItemXAxis key={index}>
-                  {legendAxisXMobile(
-                    index === (0 || 1 || 8 || 13) ? 6 : index === (2 || 4) ? 9 : index === (5 || 6) ? 5 : 9
-                  )}
-                </ItemXAxis>
-              ))}
-            </>
-          ) : (
-            <>
-              {arrayLegendAxisX.map(() => (
-                <>{axisXNotMobile(44, 34)}</>
-              ))}
-            </>
-          )}
-        </ContainerAxisX>
-      }
-      {isMobile && <ContainerLine>{lineMobile}</ContainerLine>}
+
+      <ContainerAxisX>
+        <Mobile>
+          {arrayLegendAxisX.map((_, index) => (
+            <ItemXAxis key={index}>
+              <Skeleton
+                variant="circular"
+                width={index === (0 || 1 || 8 || 13) ? 6 : index === (2 || 4) ? 9 : index === (5 || 6) ? 5 : 9}
+                height={7.75}
+                sx={{ borderRadius: 11.25 }}
+              />
+            </ItemXAxis>
+          ))}
+        </Mobile>
+
+        <MobileHidden>
+          {arrayLegendAxisX.map(() => (
+            <ContainerAxisXNotMobile>
+              <Skeleton variant="rectangular" width={44} height={10.5} sx={{ borderRadius: 15 }} />
+              <Skeleton variant="rectangular" width={32} height={10.5} sx={{ borderRadius: 15 }} />
+            </ContainerAxisXNotMobile>
+          ))}
+        </MobileHidden>
+      </ContainerAxisX>
+
+      <LineContainer>
+        <SkeletonLineMobileLeft variant="rectangular" width={130} height={11} />
+        <CircleElementStyled variant="circular" width={28} height={13} />
+        <SkeletonLineMobileRight variant="rectangular" width={130} height={11} />
+      </LineContainer>
       <ContainerLegends>
-        {ItemLegendValues(isMobile ? 12 : 16, isMobile ? 85 : isTablet ? 109 : isDesktop1024 ? 106 : 106)}
-        {ItemLegendValues(isMobile ? 12 : 16, isMobile ? 93 : isTablet ? 91 : isDesktop1024 ? 114 : 114)}
-        {ItemLegendValues(isMobile ? 12 : 16, isMobile ? 105 : isTablet ? 94 : isDesktop1024 ? 101 : 101)}
+        <ItemLegendValues />
+        <ItemLegendValues />
+        <ItemLegendValues />
       </ContainerLegends>
     </Container>
   );
@@ -197,6 +61,7 @@ const Container = styled('div')(({ theme }) => ({
   paddingLeft: 7,
   width: '100%',
   maxWidth: 343,
+
   minHeight: 275,
   marginLeft: 'auto',
   marginRight: 'auto',
@@ -223,6 +88,7 @@ const ContainerLegendY = styled('div')(({ theme }) => ({
   flexDirection: 'row',
   position: 'relative',
   justifyContent: 'flex-start',
+  alignItems: 'flex-end',
   gap: 8,
   width: '100%',
   [theme.breakpoints.up('tablet_768')]: {
@@ -236,56 +102,10 @@ const ContainerLegendY = styled('div')(({ theme }) => ({
   },
 }));
 
-const ContainerBar = styled('div')(() => ({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'flex-end',
-  alignItems: 'center',
-}));
-
-const LegendAxisY = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 16,
-  [theme.breakpoints.up('tablet_768')]: {
-    gap: 24,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    gap: 36.75,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    gap: 32,
-  },
-}));
-
-const ContainerBars = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  gap: 10,
-  border: '1px soldid red',
-  [theme.breakpoints.up('tablet_768')]: {
-    gap: 13,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    gap: 16,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    gap: 24,
-  },
-}));
-
 const ContainerAxisX = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  gap: 10,
   paddingLeft: 35,
   [theme.breakpoints.up('tablet_768')]: {
     paddingLeft: 50,
-    gap: 13,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    gap: 16,
-    justifyContent: 'center',
   },
   [theme.breakpoints.up('desktop_1280')]: {
     gap: 24,
@@ -312,17 +132,15 @@ const ItemXAxis = styled('div')({
   textAlign: 'center',
 });
 
-const LineContainer = styled('div')({
+const LineContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
-});
-
-const ContainerItem = styled('div')({
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  gap: 4,
-});
+  overflow: 'hidden',
+  marginLeft: 16,
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
 
 const ContainerLegends = styled('div')(({ theme }) => ({
   display: 'flex',
@@ -340,14 +158,9 @@ const ContainerLegends = styled('div')(({ theme }) => ({
   },
 }));
 
-const ContainerLine = styled('div')({
-  marginLeft: 32,
-});
-
-const LegendAxisYItemContainer = styled('div')({});
-
 const SkeletonLineMobileLeft = styled(Skeleton)(({ theme }) => ({
   borderLeft: `1px solid ${theme.palette.mode === 'light' ? '#ECF1F3' : '#31424E'}`,
+
   borderBottom: `1px solid ${theme.palette.mode === 'light' ? '#ECF1F3' : '#31424E'}`,
   backgroundColor: 'transparent',
 }));
@@ -369,10 +182,26 @@ const SkeletonLineMobileRight = styled(Skeleton)(({ theme }) => ({
   backgroundColor: 'transparent',
 }));
 
-const WrapperBox = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'light' ? '#ECF1F3' : '#31424E',
+const Mobile = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: 10,
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
 }));
 
-const InsideBox = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'light' ? '#D1DEE6' : '#47616f80',
+const MobileHidden = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+    gap: 13,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 16,
+    justifyContent: 'center',
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    gap: 24,
+  },
 }));

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeletonUtils/BarSkeletonItem.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeletonUtils/BarSkeletonItem.tsx
@@ -1,0 +1,214 @@
+import { styled } from '@mui/material';
+import React from 'react';
+
+const mobileBarsValues = [
+  {
+    height: 148,
+    percentFilled: 148,
+  },
+  {
+    height: 150,
+    percentFilled: 150,
+  },
+  {
+    height: 155,
+    percentFilled: 155,
+  },
+  {
+    height: 139,
+    percentFilled: 139,
+  },
+  {
+    height: 150,
+    percentFilled: 98,
+  },
+  {
+    height: 156,
+    percentFilled: 82,
+  },
+  {
+    height: 162,
+    percentFilled: 62,
+  },
+  {
+    height: 166,
+    percentFilled: 45,
+  },
+  {
+    height: 164,
+    percentFilled: 36,
+  },
+  {
+    height: 162,
+    percentFilled: 23,
+  },
+  {
+    height: 169,
+    percentFilled: 15,
+  },
+  {
+    height: 168,
+    percentFilled: 7,
+  },
+];
+const tabletBarsValues = [
+  {
+    height: 297,
+    percentFilled: 297,
+  },
+  {
+    height: 296,
+    percentFilled: 296,
+  },
+  {
+    height: 299,
+    percentFilled: 299,
+  },
+  {
+    height: 274,
+    percentFilled: 274,
+  },
+  {
+    height: 296,
+    percentFilled: 192,
+  },
+  {
+    height: 306,
+    percentFilled: 160,
+  },
+  {
+    height: 316,
+    percentFilled: 124,
+  },
+  {
+    height: 332,
+    percentFilled: 101,
+  },
+  {
+    height: 338,
+    percentFilled: 70,
+  },
+  {
+    height: 345,
+    percentFilled: 50,
+  },
+  {
+    height: 353,
+    percentFilled: 30,
+  },
+  {
+    height: 376,
+    percentFilled: 16,
+  },
+];
+
+const BarSkeletonItems: React.FC = () => (
+  <ContainerBars>
+    <Mobile>
+      {mobileBarsValues.map((item, index) => (
+        <WrapperBox height={item.height} key={index}>
+          <InsideBox height={item.percentFilled} />
+        </WrapperBox>
+      ))}
+    </Mobile>
+    <Table>
+      {tabletBarsValues.map((item, index) => (
+        <WrapperBox height={item.height} key={index}>
+          <InsideBox height={item.percentFilled} />
+        </WrapperBox>
+      ))}
+    </Table>
+  </ContainerBars>
+);
+export default BarSkeletonItems;
+
+const ContainerBars = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'flex-end',
+  gap: 10,
+  [theme.breakpoints.up('tablet_768')]: {
+    gap: 13,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 16,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    gap: 24,
+  },
+}));
+const WrapperBox = styled('div')<{ height: number }>(({ theme, height }) => ({
+  display: 'flex',
+  position: 'relative',
+  flexDirection: 'column',
+  justifyContent: 'flex-end',
+  backgroundColor: theme.palette.mode === 'light' ? '#ECF1F3' : '#31424E',
+  width: 16,
+  borderBottomLeftRadius: 4,
+  borderBottomRightRadius: 4,
+  borderTopLeftRadius: 4,
+  borderTopRightRadius: 4,
+  overflow: 'hidden',
+  height,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 40,
+    borderBottomLeftRadius: 6,
+    borderBottomRightRadius: 6,
+    borderTopLeftRadius: 6,
+    borderTopRightRadius: 6,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    width: 56,
+  },
+}));
+
+const InsideBox = styled('div')<{ height: number }>(({ theme, height }) => ({
+  backgroundColor: theme.palette.mode === 'light' ? '#D1DEE6' : '#47616f80',
+  width: 16,
+  borderBottomLeftRadius: 4,
+  borderBottomRightRadius: 4,
+  position: 'absolute',
+  height,
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 40,
+    borderBottomLeftRadius: 6,
+    borderBottomRightRadius: 6,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    width: 56,
+  },
+}));
+
+const Mobile = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'flex-end',
+  gap: 10,
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
+
+const Table = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 13,
+  },
+
+  [theme.breakpoints.between('desktop_1024', 'desktop_1280')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 16,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 24,
+  },
+}));

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeletonUtils/ItemLegendAxisValues.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeletonUtils/ItemLegendAxisValues.tsx
@@ -1,0 +1,19 @@
+import { Skeleton, styled } from '@mui/material';
+import React from 'react';
+
+interface Props {
+  width: number;
+}
+
+const ItemLegendAxisValues: React.FC<Props> = ({ width }) => <ContainerSkeleton variant="rectangular" width={width} />;
+
+export default ItemLegendAxisValues;
+
+const ContainerSkeleton = styled(Skeleton)(({ theme }) => ({
+  borderRadius: 12.5,
+  height: 8.75,
+  [theme.breakpoints.up('tablet_768')]: {
+    borderRadius: 17.5,
+    height: 12.5,
+  },
+}));

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeletonUtils/ItemLegendValues.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeletonUtils/ItemLegendValues.tsx
@@ -1,0 +1,41 @@
+import { Skeleton, styled } from '@mui/material';
+import React from 'react';
+
+const ItemLegendValues: React.FC = () => (
+  <ContainerItem>
+    <ItemLegendCircle variant="circular" />
+    <SkeletonItemRectangular variant="rectangular" />
+  </ContainerItem>
+);
+
+export default ItemLegendValues;
+
+const ContainerItem = styled('div')({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: 4,
+});
+
+const SkeletonItemRectangular = styled(Skeleton)(({ theme }) => ({
+  height: 10.5,
+  borderRadius: 15,
+  width: 85,
+  [theme.breakpoints.up('tablet_768')]: {
+    height: 14,
+    width: 109,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    height: 14,
+    width: 106,
+  },
+}));
+
+const ItemLegendCircle = styled(Skeleton)(({ theme }) => ({
+  width: 12,
+  height: 12,
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 16,
+    height: 16,
+  },
+}));

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeletonUtils/LegendAxisYComponent.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChartSkeletonUtils/LegendAxisYComponent.tsx
@@ -1,0 +1,86 @@
+import { styled } from '@mui/material';
+import React from 'react';
+import ItemLegendAxisValues from './ItemLegendAxisValues';
+
+const mobileAxisYValues = [
+  {
+    width: 13,
+  },
+  {
+    width: 26,
+  },
+  {
+    width: 16,
+  },
+  {
+    width: 25,
+  },
+  {
+    width: 16,
+  },
+  {
+    width: 25,
+  },
+  {
+    width: 16,
+  },
+  {
+    width: 25,
+  },
+  {
+    width: 16,
+  },
+];
+
+const LegendAxisYItems: React.FC = () => (
+  <LegendAxisY>
+    <Mobile>
+      {mobileAxisYValues.map((dim, index) => (
+        <LegendAxisYItemContainer key={index}>
+          <ItemLegendAxisValues width={dim.width} />
+        </LegendAxisYItemContainer>
+      ))}
+    </Mobile>
+    <Table>
+      {mobileAxisYValues.map((dim, index) => (
+        <LegendAxisYItemContainer key={index}>
+          <ItemLegendAxisValues width={32} />
+        </LegendAxisYItemContainer>
+      ))}
+    </Table>
+  </LegendAxisY>
+);
+
+export default LegendAxisYItems;
+
+const LegendAxisY = styled('div')({
+  display: 'flex',
+});
+const LegendAxisYItemContainer = styled('div')({
+  display: 'flex',
+});
+
+const Mobile = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  justifyContent: 'flex-end',
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
+const Table = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 32,
+    justifyContent: 'flex-end',
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 36.75,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    gap: 32,
+  },
+}));


### PR DESCRIPTION


## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix the loading state in the breakdown chart in the Finances page .
The loading state got the wrong size in their bars, because the media query take time get correct value.
 The fix pass the items to Css to fix the problem

## What solved
- [X]  The loading state should be visible as the design shows for mobile resolution. **Current Output:**  It displays the loading state for the desktop and later changes to the proper resolution.   

