### PR TITLE
fix:Fix the percent in mobile show diferent value

### DIFF
--- a/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
+++ b/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
@@ -59,7 +59,7 @@ const CardNavigationMobile: React.FC<Props> = ({ image, title, totalDai, valueDa
                         isLight={isLight}
                       />
                     </ContainerBar>
-                    <Percent isLight={isLight}>{Math.floor(percent)}%</Percent>
+                    <Percent isLight={isLight}>{Math.round(percent)}%</Percent>
                   </ContainerBarPercent>
                 </CardInformation>
               </ContainerData>


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
 Fix the  percent value in mobile that show incorrect percent for the same values.
 The percent in mobile is different that the one that is show in  desktop even although, values to calculate it are the same

## What solved
- [X] - The percent reflected in each budget/category should be the same in all resolutions.**Current Output:**  In the desktop resolution, the core units category displays correctly 99% but in mobile is displayed 98% for this category. 

