### PR TITLE
fix: Fix the number of items show in the columns

### DIFF
--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
@@ -140,8 +140,7 @@ const ContainerLegend = styled.div<{ isCoreThirdLevel: boolean; changeAlignment:
     justifyContent: isCoreThirdLevel && changeAlignment ? 'flex-start' : changeAlignment ? 'flex-start' : 'center',
     gap: isCoreThirdLevel ? 16 : 14,
     maxWidth: '100%',
-    maxHeight: 210,
-
+    maxHeight: 180,
     overflow: 'hidden',
     ...(changeAlignment && {
       flex: 1,

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
@@ -140,7 +140,7 @@ const ContainerLegend = styled.div<{ isCoreThirdLevel: boolean; changeAlignment:
     justifyContent: isCoreThirdLevel && changeAlignment ? 'flex-start' : changeAlignment ? 'flex-start' : 'center',
     gap: isCoreThirdLevel ? 16 : 14,
     maxWidth: '100%',
-    maxHeight: 180,
+    maxHeight: isCoreThirdLevel ? 180 : 210,
     overflow: 'hidden',
     ...(changeAlignment && {
       flex: 1,

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -390,7 +390,7 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean; numberSliderPerLev
       height: 'calc(100% - 8px)',
       ...(numberSliderPerLevel === 10 && {
         minWidth: 340,
-        height: 'calc(100% + 8px)',
+        height: 'calc(100% - 10px)',
       }),
     },
 
@@ -401,7 +401,7 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean; numberSliderPerLev
       height: 'calc(100% - 8px)',
       ...(numberSliderPerLevel === 10 && {
         minWidth: 440,
-        height: 'calc(100% + 8px)',
+        height: 'calc(100% - 10px)',
       }),
     },
 


### PR DESCRIPTION

## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix the correct items in each columns when there are to many items .
Some columns have more items that the other column, when should be the same  number

## What solved
- [X]- Finances-> MakerDAO Legacy Budget->core-units. Legend- ** **Expected Output:** All elements of the legend should be displayed properly covering the space. **Current Output:** In the second column a space without elements even when there are more elements to display.  

## Screenshots (if apply)
