### PR TITLE
[BSN-1] Fix expense metrics spacing

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics.stories.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics.stories.tsx
@@ -49,8 +49,7 @@ LightMode.parameters = {
   figma: {
     component: {
       375: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24365:95374&mode=dev',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=28966-337836',
         options: {
           componentStyle: {
             width: 343,
@@ -62,8 +61,7 @@ LightMode.parameters = {
         },
       },
       768: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24369:100308&mode=dev',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=28966-331810',
         options: {
           componentStyle: {
             width: 704,
@@ -75,8 +73,7 @@ LightMode.parameters = {
         },
       },
       1024: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=24542:202077&mode=dev',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=28966-330256',
         options: {
           componentStyle: {
             width: 960,
@@ -88,8 +85,7 @@ LightMode.parameters = {
         },
       },
       1280: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=28966:334923&mode=dev',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=28966-334923',
         options: {
           componentStyle: {
             width: 1184,
@@ -101,8 +97,7 @@ LightMode.parameters = {
         },
       },
       1440: {
-        component:
-          'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=28966:336453&mode=dev',
+        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=28966-336453',
         options: {
           componentStyle: {
             width: 1312,

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -196,24 +196,24 @@ const ChartContainer = styled.div({
   width: '100%',
 
   maxWidth: 343,
-  height: 347,
+  height: 319,
   marginLeft: 'auto',
   marginRight: 'auto',
   marginTop: -4,
 
   [lightTheme.breakpoints.up('tablet_768')]: {
     maxWidth: 756,
-    height: 510,
+    height: 560,
   },
 
   [lightTheme.breakpoints.up('desktop_1024')]: {
     maxWidth: 848,
-    height: 508,
+    height: 521,
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
     maxWidth: 1028,
-    height: 508,
+    height: 521,
   },
 });
 
@@ -222,7 +222,7 @@ const YearXAxis = styled.div<WithIsLight>(({ isLight }) => {
 
   return {
     position: 'absolute',
-    bottom: 107,
+    bottom: 80,
     left: 40,
     right: 5,
     height: 11,
@@ -255,7 +255,7 @@ const LegendContainer = styled.div({
   flex: 1,
   gap: 24,
   position: 'absolute',
-  bottom: 28,
+  bottom: 0,
   rowGap: 14,
 
   [lightTheme.breakpoints.up('tablet_768')]: {
@@ -263,27 +263,28 @@ const LegendContainer = styled.div({
     flexDirection: 'row',
     justifyContent: 'center',
     gap: 42,
-    bottom: -50,
     rowGap: 16,
   },
+
   [lightTheme.breakpoints.up('desktop_1024')]: {
     marginLeft: -6,
     gap: 40,
     minWidth: 940,
-    bottom: -12,
     justifyContent: 'center',
   },
+
   [lightTheme.breakpoints.up('desktop_1280')]: {
     gap: 65,
     marginLeft: -46,
     width: '100%',
-    bottom: -14,
     minWidth: 'revert',
   },
+
   [lightTheme.breakpoints.up('desktop_1440')]: {
     gap: 65,
     marginLeft: 2,
   },
+
   [lightTheme.breakpoints.up('desktop_1920')]: {
     marginLeft: -45,
   },


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix spacing between Expense Metrics and Reserves sections

## What solved
- [X] **- Finances view, Expense Metrics Line Chart/ Reserves Chart sections. ** **Expected Output:** The space between both sections should be 64px. **Current Output:** The 64 px between both sections is not defined correctly.
