### PR TITLE
[BSN-1] Fix negative zero

### DIFF
--- a/src/core/utils/humanization.ts
+++ b/src/core/utils/humanization.ts
@@ -27,12 +27,13 @@ export const threeDigitsPrecisionHumanization = (num = 0, isHasAbsoluteValue = f
 export const usLocalizedNumber = (num: number, decimalPlace = 0): string => {
   num = num === 0 ? 0 : num; // avoid "-0"
 
-  return num?.toLocaleString('en-US', {
+  const value = num?.toLocaleString('en-US', {
     currency: 'USD',
     currencyDisplay: 'symbol',
     minimumFractionDigits: decimalPlace,
     maximumFractionDigits: decimalPlace,
   });
+  return value === '-0' ? '0' : value;
 };
 
 export const deleteTwoDecimalPLace = (formattedNumber: string) => {

--- a/src/core/utils/humanization.ts
+++ b/src/core/utils/humanization.ts
@@ -25,14 +25,13 @@ export const threeDigitsPrecisionHumanization = (num = 0, isHasAbsoluteValue = f
 };
 
 export const usLocalizedNumber = (num: number, decimalPlace = 0): string => {
-  num = num === 0 ? 0 : num; // avoid "-0"
-
   const value = num?.toLocaleString('en-US', {
     currency: 'USD',
     currencyDisplay: 'symbol',
     minimumFractionDigits: decimalPlace,
     maximumFractionDigits: decimalPlace,
   });
+
   return value === '-0' ? '0' : value;
 };
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix negative zeros on the breakdown table

## What solved
- [X] **- Finances->MakerDAO Legacy Budget, Breakdown Table section. Year: 2023. Metric: Net Protocol Outflow - ** **Expected Output:** When the value is 0 the minus sign should not be displayed. **Current Output:** In the metric selected the PE-001 core unit displays -0. 
