### PR TITLE
[BSN-1] Fix year select default scroll bar

### DIFF
--- a/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
+++ b/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
@@ -174,7 +174,7 @@ const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
                 <MenuList autoFocusItem={open} id={menuListId} aria-labelledby={inputId} onKeyDown={handleListKeyDown}>
                   <SimpleBar
                     style={{
-                      maxHeight: 175,
+                      maxHeight: 178,
                     }}
                     className="filter-popup-scroll"
                   >


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Hide scroll bar in the year picker of the finances breadcrumb

## What solved
- [X] **- Finances view. Year dropdown and Metrics dropdown on Expense Reports section.- ** **Expected Output:** The scroll bar should be shown when there are more elements to display in the list. **Current Output:**  The scroll bar is displayed even if there are no more elements on the list.
