### PR TITLE
[SB-1]  Fix the last level the doughnut and breakdown chart don't

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -13,7 +13,7 @@ import type {
 import type { Budget } from '@ses/core/models/interfaces/budget';
 import type { EChartsOption } from 'echarts-for-react';
 
-const useBreakdownChart = (budgets: Budget[], year: string, codePath: string) => {
+const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, allBudgets: Budget[]) => {
   const { isLight } = useThemeContext();
   const [selectedMetric, setSelectedMetric] = useState<AnalyticMetric>('Budget');
   const refBreakDownChart = useRef<EChartsOption | null>(null);
@@ -66,8 +66,9 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string) =>
   );
 
   const seriesWithoutBorder = useMemo(
-    () => parseAnalyticsToSeriesBreakDownChart(budgetsAnalytics, budgets, isLight, barWidth, selectedMetric),
-    [barWidth, budgets, budgetsAnalytics, isLight, selectedMetric]
+    () =>
+      parseAnalyticsToSeriesBreakDownChart(budgetsAnalytics, budgets, isLight, barWidth, selectedMetric, allBudgets),
+    [allBudgets, barWidth, budgets, budgetsAnalytics, isLight, selectedMetric]
   );
 
   const allSeries = setBorderRadiusForSeries(seriesWithoutBorder, barBorderRadius);

--- a/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
@@ -1,4 +1,5 @@
 import { existingColors, existingColorsDark, generateColorPalette, getCorrectMetric } from '../../utils/utils';
+import { removePatternAfterSlash } from '../SectionPages/BreakdownTable/utils';
 import type { BreakdownChartSeriesData } from '../../utils/types';
 import type { AnalyticMetric, BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
 import type { Budget } from '@ses/core/models/interfaces/budget';
@@ -8,7 +9,8 @@ export const parseAnalyticsToSeriesBreakDownChart = (
   budgets: Budget[],
   isLight: boolean,
   barWidth: number,
-  metric: AnalyticMetric
+  metric: AnalyticMetric,
+  allBudgets: Budget[]
 ) => {
   const colorsLight = generateColorPalette(
     existingColors.length,
@@ -22,9 +24,11 @@ export const parseAnalyticsToSeriesBreakDownChart = (
 
   if (budgetsAnalytics) {
     const budgetKeys = Object.keys(budgetsAnalytics);
-
     budgetKeys.forEach((budgetKey, index) => {
-      const nameBudget = budgets.find((budget) => budget.codePath === budgetKey)?.name;
+      const searchCorrectBudget = budgets.length > 0 ? budgets : allBudgets;
+      const nameBudget = searchCorrectBudget.find(
+        (budget) => budget.codePath === removePatternAfterSlash(budgetKey)
+      )?.name;
       const budgetData = budgetsAnalytics[budgetKey];
       if (Array.isArray(budgetData)) {
         const dataForSeries = budgetData.map((budgetMetric) => getCorrectMetric(budgetMetric, metric));

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -10,6 +10,7 @@ import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { percentageRespectTo } from '@ses/core/utils/math';
 import lightTheme from '@ses/styles/theme/light';
 import { useMemo, useState } from 'react';
+import { removePatternAfterSlash } from '../BreakdownTable/utils';
 import { getCorrectMetricValuesOverViewChart } from './utils';
 import type { BudgetMetricWithName, DoughnutSeries } from '@ses/containers/Finances/utils/types';
 import type { AnalyticMetric, BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
@@ -141,7 +142,10 @@ export const useCardChartOverview = (
   if (budgetsAnalytics !== undefined) {
     for (const budgetMetricKey of Object.keys(budgetsAnalytics)) {
       const budgetMetric = budgetsAnalytics[budgetMetricKey];
-      const correspondingBudget = budgets.find((budget) => budget.codePath === budgetMetricKey);
+      const searchCorrectBudget = budgets.length > 0 ? budgets : allBudgets;
+      const correspondingBudget = searchCorrectBudget.find(
+        (budget) => budget.codePath === removePatternAfterSlash(budgetMetricKey)
+      );
       // use the name of budget or add label
       const budgetName = correspondingBudget ? formatBudgetName(correspondingBudget.name) : 'There is not name';
       const budgetCode = correspondingBudget?.code || 'No-code';

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -143,7 +143,7 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   const cardsToShow = loadMoreCards && isMobile ? cardsNavigationInformation.slice(0, 6) : cardsNavigationInformation;
 
   // All the logic required by the breakdown chart section
-  const breakdownChartSectionData = useBreakdownChart(budgets, year, codePath);
+  const breakdownChartSectionData = useBreakdownChart(budgets, year, codePath, allBudgets);
 
   // All the logic required by the BreakdownTable section
   const breakdownTable = useBreakdownTable(year, budgets, allBudgets);


### PR DESCRIPTION
…correct name


## Ticket
<!--- Your Ticket Link -->

## Description
Fix the name in the last level for breakdown chart and drought chart Some of the  code path use to match came with some * in the code path so its not match

## What solved
- [X] The name of the budget/category/core unit should be the same in the sections. **Current Output:** In the pie chart legend is displayed "No-code" and the breakdown chart legend displays "No-code".

## Screenshots (if apply)
