### PR TITLE
[QA] Budget structure year picker

### DIFF
--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -158,6 +158,7 @@ const dictionary = [
   'Prtcol',
   'Outfl',
   'compat',
+  'keyframes',
 ];
 
 module.exports = dictionary;

--- a/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
+++ b/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
@@ -97,7 +97,9 @@ const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
     const defaultProps = {
       square: true,
       elevation: 0,
-      sx: { width: '200px' },
+      sx: {
+        width: '200px',
+      },
     } as PaperProps;
 
     return merge(defaultProps, PaperProps ?? {});
@@ -160,7 +162,7 @@ const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
           <StyledSelectChevronDown isOpen={open} fill={isLight ? '#231436' : '#E2D8EE'} />
         </ChevronContainer>
       </SelectBtn>
-      <Popper open={open} anchorEl={anchorRef.current} {...popperProps}>
+      <Popper open={open} anchorEl={anchorRef.current} style={{ zIndex: 1 }} {...popperProps}>
         {({ TransitionProps, placement }) => (
           <Grow
             {...TransitionProps}

--- a/src/stories/containers/Endgame/EndgameContainer.tsx
+++ b/src/stories/containers/Endgame/EndgameContainer.tsx
@@ -17,11 +17,12 @@ import type { Analytic } from '@ses/core/models/interfaces/analytic';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface EndgameContainerProps {
-  budgetStructureAnalytics: Analytic;
   budgetTransitionAnalytics: Analytic;
+  yearsRange: string[];
+  initialYear: string;
 }
 
-const EndgameContainer: React.FC<EndgameContainerProps> = ({ budgetStructureAnalytics, budgetTransitionAnalytics }) => {
+const EndgameContainer: React.FC<EndgameContainerProps> = ({ budgetTransitionAnalytics, yearsRange, initialYear }) => {
   const {
     isLight,
     isEnabled,
@@ -33,8 +34,11 @@ const EndgameContainer: React.FC<EndgameContainerProps> = ({ budgetStructureAnal
     transitionDataSelected,
     handleTransitionDateSelectedChange,
     budgetStructureData,
+    isLoadingBudgetStructure,
+    selectedYear,
+    handleYearChange,
     transitionStatusData,
-  } = useEndgameContainer(budgetStructureAnalytics, budgetTransitionAnalytics);
+  } = useEndgameContainer(budgetTransitionAnalytics, yearsRange, initialYear);
 
   return (
     <EndgamePageContainer isLight={isLight}>
@@ -75,6 +79,10 @@ const EndgameContainer: React.FC<EndgameContainerProps> = ({ budgetStructureAnal
                 scopes={budgetStructureData.scopes.budget}
                 immutable={budgetStructureData.immutable.budget}
                 legacy={budgetStructureData.legacy.budget}
+                isLoading={isLoadingBudgetStructure}
+                yearsRange={yearsRange}
+                selectedYear={selectedYear}
+                handleYearChange={handleYearChange}
               />
             </div>
           )}

--- a/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
+++ b/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react';
 import BudgetDoughnutChart from '../BudgetDoughnutChart/BudgetDoughnutChart';
 import SectionHeader from '../SectionHeader/SectionHeader';
 import TotalBudgetContent from '../TotalBudgetContent/TotalBudgetContent';
+import BudgetStructureSectionSkeleton from './BudgetStructureSectionSkeleton';
 import type { TotalBudgetContentProps } from '../TotalBudgetContent/TotalBudgetContent';
 import type { DoughnutSeries } from '@ses/containers/Finances/utils/types';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -76,7 +77,7 @@ const BudgetStructureSection: React.FC<BudgetCompositionProps> = ({
       />
 
       {isLoading ? (
-        'loading...'
+        <BudgetStructureSectionSkeleton />
       ) : (
         <Card isLight={isLight}>
           <TotalBudgetContent totalBudgetCap={totalBudgetCap} {...totalBudgetProps} />

--- a/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
+++ b/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
@@ -13,6 +13,10 @@ interface BudgetCompositionProps extends TotalBudgetContentProps {
   scopes: number;
   immutable: number;
   legacy: number;
+  isLoading: boolean;
+  yearsRange: string[];
+  selectedYear: string;
+  handleYearChange: (year: string) => void;
 }
 
 const BudgetStructureSection: React.FC<BudgetCompositionProps> = ({
@@ -20,6 +24,10 @@ const BudgetStructureSection: React.FC<BudgetCompositionProps> = ({
   immutable,
   legacy,
   totalBudgetCap,
+  isLoading,
+  yearsRange,
+  selectedYear,
+  handleYearChange,
   ...totalBudgetProps
 }) => {
   const { isLight } = useThemeContext();
@@ -62,15 +70,22 @@ const BudgetStructureSection: React.FC<BudgetCompositionProps> = ({
       <SectionHeader
         title="Endgame Budget Structure"
         subtitle="Some simple but poignant text about what endgame budgets are about"
+        yearsRange={yearsRange}
+        selectedYear={selectedYear}
+        handleYearChange={handleYearChange}
       />
 
-      <Card isLight={isLight}>
-        <TotalBudgetContent totalBudgetCap={totalBudgetCap} {...totalBudgetProps} />
-        <BudgetComposition isLight={isLight}>
-          <BudgetCompositionTitle isLight={isLight}>Composition of Budget</BudgetCompositionTitle>
-          {mounted && <BudgetDoughnutChart doughnutSeriesData={doughnutSeriesData} />}
-        </BudgetComposition>
-      </Card>
+      {isLoading ? (
+        'loading...'
+      ) : (
+        <Card isLight={isLight}>
+          <TotalBudgetContent totalBudgetCap={totalBudgetCap} {...totalBudgetProps} />
+          <BudgetComposition isLight={isLight}>
+            <BudgetCompositionTitle isLight={isLight}>Composition of Budget</BudgetCompositionTitle>
+            {mounted && <BudgetDoughnutChart doughnutSeriesData={doughnutSeriesData} />}
+          </BudgetComposition>
+        </Card>
+      )}
     </Content>
   );
 };

--- a/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSectionSkeleton.tsx
+++ b/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSectionSkeleton.tsx
@@ -1,0 +1,290 @@
+import { Skeleton, styled, useMediaQuery } from '@mui/material';
+import type { Theme } from '@mui/material';
+
+const BudgetStructureSectionSkeleton: React.FC = () => {
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
+  const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
+
+  return (
+    <Card>
+      <Content>
+        <TotalContainer>
+          <TotalNumber>
+            <Skeleton variant="rounded" width={196} height={30} />
+            <Skeleton variant="rounded" width={42} height={24} />
+          </TotalNumber>
+          <Skeleton variant="rounded" width={200} height={12} />
+        </TotalContainer>
+
+        <Divider />
+
+        <LegendContainer>
+          <LegendItem>
+            <Skeleton variant="circular" width={8} height={8} />
+            <Skeleton variant="rounded" width={79} height={12.5} />
+          </LegendItem>
+          <LegendItem>
+            <Skeleton variant="circular" width={8} height={8} />
+            <Skeleton variant="rounded" width={50} height={12.5} />
+          </LegendItem>
+        </LegendContainer>
+        <Skeleton variant="rounded" width={'100%'} height={16} />
+        <NumbersContainer>
+          <Skeleton variant="rounded" width={50} height={12.5} />
+          <Skeleton variant="rounded" width={79} height={12.5} />
+        </NumbersContainer>
+
+        <Skeleton variant="rounded" width={'100%'} height={33} style={{ marginTop: 32 }} />
+      </Content>
+      <BudgetCompositionContainer>
+        <Skeleton variant="rounded" width={180} height={12.5} />
+
+        <ChartContainer>
+          <SVG
+            width={isMobile || isTablet ? 129 : 192}
+            height={isMobile || isTablet ? 129 : 192}
+            viewBox="0 0 129 129"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <mask id="path-1-inside-1_29432_144440" fill="white">
+              <path d="M128.489 64.4307C128.489 99.7769 99.8357 128.431 64.4895 128.431C29.1432 128.431 0.489471 99.7769 0.489471 64.4307C0.489471 29.0844 29.1432 0.430664 64.4895 0.430664C99.8357 0.430664 128.489 29.0844 128.489 64.4307ZM32.4895 64.4307C32.4895 82.1038 46.8164 96.4307 64.4895 96.4307C82.1626 96.4307 96.4895 82.1038 96.4895 64.4307C96.4895 46.7576 82.1626 32.4307 64.4895 32.4307C46.8164 32.4307 32.4895 46.7576 32.4895 64.4307Z" />
+            </mask>
+            <path
+              d="M128.489 64.4307C128.489 99.7769 99.8357 128.431 64.4895 128.431C29.1432 128.431 0.489471 99.7769 0.489471 64.4307C0.489471 29.0844 29.1432 0.430664 64.4895 0.430664C99.8357 0.430664 128.489 29.0844 128.489 64.4307ZM32.4895 64.4307C32.4895 82.1038 46.8164 96.4307 64.4895 96.4307C82.1626 96.4307 96.4895 82.1038 96.4895 64.4307C96.4895 46.7576 82.1626 32.4307 64.4895 32.4307C46.8164 32.4307 32.4895 46.7576 32.4895 64.4307Z"
+              fill="#ECF1F3"
+              stroke="#ECF1F3"
+              strokeWidth="1.33333"
+              mask="url(#path-1-inside-1_29432_144440)"
+            />
+            <mask id="path-2-inside-2_29432_144440" fill="white">
+              <path d="M128.489 64.4307C128.489 49.8987 123.544 35.7993 114.466 24.4515L89.4778 44.4411C94.0167 50.115 96.4895 57.1647 96.4895 64.4307H128.489Z" />
+            </mask>
+            <path
+              d="M128.489 64.4307C128.489 49.8987 123.544 35.7993 114.466 24.4515L89.4778 44.4411C94.0167 50.115 96.4895 57.1647 96.4895 64.4307H128.489Z"
+              fill="#B6BCC2"
+              stroke="#B6BCC2"
+              strokeWidth="1.33333"
+              mask="url(#path-2-inside-2_29432_144440)"
+            />
+            <mask id="path-3-inside-3_29432_144440" fill="white">
+              <path d="M114.658 24.7431C104.742 12.2134 90.4971 3.84635 74.7244 1.28696C58.9517 -1.27244 42.7921 2.16095 29.4226 10.9121C16.053 19.6633 6.44069 33.0992 2.47534 48.5784C-1.49001 64.0575 0.47847 80.4601 7.99379 94.5615L36.2336 79.511C32.4759 72.4604 31.4917 64.2591 33.4743 56.5195C35.457 48.7799 40.2632 42.062 46.9479 37.6864C53.6327 33.3108 61.7125 31.5941 69.5989 32.8738C77.4852 34.1535 84.6076 38.337 89.5657 44.6019L114.658 24.7431Z" />
+            </mask>
+            <path
+              d="M114.658 24.7431C104.742 12.2134 90.4971 3.84635 74.7244 1.28696C58.9517 -1.27244 42.7921 2.16095 29.4226 10.9121C16.053 19.6633 6.44069 33.0992 2.47534 48.5784C-1.49001 64.0575 0.47847 80.4601 7.99379 94.5615L36.2336 79.511C32.4759 72.4604 31.4917 64.2591 33.4743 56.5195C35.457 48.7799 40.2632 42.062 46.9479 37.6864C53.6327 33.3108 61.7125 31.5941 69.5989 32.8738C77.4852 34.1535 84.6076 38.337 89.5657 44.6019L114.658 24.7431Z"
+              fill="#D1DEE6"
+              stroke="#D1DEE6"
+              strokeWidth="1.33333"
+              mask="url(#path-3-inside-3_29432_144440)"
+            />
+          </SVG>
+
+          <ChartLegendContainer>
+            <ChartLegendItem>
+              <ChartLegendLabel>
+                <Skeleton variant="circular" width={8} height={8} />
+                <Skeleton variant="rounded" width={135} height={12} />
+              </ChartLegendLabel>
+              <Skeleton variant="rounded" width={106} height={7} style={{ marginLeft: 12 }} />
+            </ChartLegendItem>
+            <ChartLegendItem>
+              <ChartLegendLabel>
+                <Skeleton variant="circular" width={8} height={8} />
+                <Skeleton variant="rounded" width={143} height={12} />
+              </ChartLegendLabel>
+              <Skeleton variant="rounded" width={115} height={7} style={{ marginLeft: 12 }} />
+            </ChartLegendItem>
+            <ChartLegendItem>
+              <ChartLegendLabel>
+                <Skeleton variant="circular" width={8} height={8} />
+                <Skeleton variant="rounded" width={156} height={12} />
+              </ChartLegendLabel>
+              <Skeleton variant="rounded" width={104} height={7} style={{ marginLeft: 12 }} />
+            </ChartLegendItem>
+          </ChartLegendContainer>
+        </ChartContainer>
+      </BudgetCompositionContainer>
+    </Card>
+  );
+};
+
+export default BudgetStructureSectionSkeleton;
+
+const Card = styled('div')(({ theme }) => ({
+  padding: '31px 0px 0px',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+  gap: 32,
+  borderRadius: 6,
+  border: `1px solid ${theme.palette.mode === 'light' ? 'rgba(212, 217, 225, 0.25)' : '#31424E'}`,
+  background: theme.palette.mode === 'light' ? '#FFF' : '#1E2C37',
+  boxShadow:
+    theme.palette.mode === 'light'
+      ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
+      : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px 0px rgba(7, 22, 40, 0.40)',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    flexDirection: 'row',
+    padding: '23px 15px',
+    gap: 16,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    padding: 31,
+    gap: 32,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    padding: '31px 0 31px 63px',
+    gap: 64,
+  },
+}));
+
+const Content = styled('div')(({ theme }) => ({
+  padding: '0px 15px',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    padding: 0,
+    width: 272,
+    minWidth: 272,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    minWidth: 350,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    minWidth: 387,
+  },
+}));
+
+const TotalContainer = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 8,
+}));
+
+const TotalNumber = styled('div')(() => ({
+  display: 'flex',
+  alignItems: 'flex-end',
+  gap: 6,
+}));
+
+const Divider = styled('div')(({ theme }) => ({
+  height: 1,
+  width: 'calc(100% - 17px)',
+  background: theme.palette.mode === 'light' ? '#ECF1F3' : '#31424E',
+  margin: '24px 8.5px',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 'calc(100% - 10px)',
+    margin: '23px 5px 24px',
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    width: 'calc(100% - 94px)',
+    margin: '23px 47px 24px',
+  },
+}));
+
+const LegendContainer = styled('div')(() => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginBottom: 14,
+}));
+
+const LegendItem = styled('div')(() => ({
+  display: 'flex',
+  gap: 4,
+  alignItems: 'center',
+}));
+
+const NumbersContainer = styled('div')(() => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginTop: 8,
+}));
+
+const BudgetCompositionContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  position: 'relative',
+  width: '100%',
+  height: 353,
+  padding: '24px 16px 0px',
+  backgroundColor: theme.palette.mode === 'light' ? 'rgba(236, 239, 249, 0.25)' : '#1E2C37',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    alignSelf: 'center',
+    height: 189,
+    padding: 0,
+    backgroundColor: theme.palette.mode === 'light' ? '#fff' : '#1E2C37',
+    borderLeft: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : '#31424E'}`,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    height: 241,
+    paddingRight: 45,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    paddingRight: 120,
+  },
+
+  [theme.breakpoints.up('desktop_1440')]: {
+    paddingRight: 140,
+  },
+}));
+
+const ChartContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 16,
+  marginTop: 24,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    flexDirection: 'row',
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 48,
+  },
+}));
+
+const SVG = styled('svg')({
+  '@keyframes pulse': {
+    '0%': {
+      opacity: 1,
+    },
+    '50%': {
+      opacity: 0.4,
+    },
+    '100%': {
+      opacity: 1,
+    },
+  },
+
+  animation: 'pulse 2s ease-in-out 0.5s infinite',
+});
+
+const ChartLegendContainer = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+}));
+
+const ChartLegendItem = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6.5,
+}));
+
+const ChartLegendLabel = styled('div')(() => ({
+  display: 'flex',
+  alignItems: 'flex-end',
+  gap: 4,
+}));

--- a/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
@@ -1,21 +1,71 @@
 import styled from '@emotion/styled';
+import SingleItemSelect from '@ses/components/SingleItemSelect/SingleItemSelect';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
-import React from 'react';
+import React, { useMemo } from 'react';
+import type { SelectItem } from '@ses/components/SingleItemSelect/SingleItemSelect';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface SectionHeaderProps {
   title: string;
   subtitle: string;
+
+  yearsRange?: string[];
+  selectedYear?: string;
+  handleYearChange?: (year: string) => void;
 }
 
-const SectionHeader: React.FC<SectionHeaderProps> = ({ title, subtitle }) => {
+const SectionHeader: React.FC<SectionHeaderProps> = ({
+  title,
+  subtitle,
+  yearsRange,
+  selectedYear,
+  handleYearChange,
+}) => {
   const { isLight } = useThemeContext();
+  const years: SelectItem<string>[] = useMemo(
+    () =>
+      (yearsRange ?? [])?.map((year) => ({
+        label: year,
+        value: year,
+      })),
+    [yearsRange]
+  );
+  // [
+  //   {
+  //     label: '2024',
+  //     value: '2024',
+  //   },
+  //   {
+  //     label: '2023',
+  //     value: '2023',
+  //   },
+  //   {
+  //     label: '2022',
+  //     value: '2022',
+  //   },
+  //   {
+  //     label: '2021',
+  //     value: '2021',
+  //   },
+  // ];
 
   return (
     <Header>
       <Title isLight={isLight}>{title}</Title>
       <Subtitle isLight={isLight}>{subtitle}</Subtitle>
+      {yearsRange && (
+        <SingleItemSelect
+          isMobile={false}
+          useSelectedAsLabel
+          selected={selectedYear}
+          onChange={handleYearChange}
+          items={years}
+          PopperProps={{
+            placement: 'bottom-end',
+          }}
+        />
+      )}
     </Header>
   );
 };

--- a/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
@@ -31,24 +31,6 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       })),
     [yearsRange]
   );
-  // [
-  //   {
-  //     label: '2024',
-  //     value: '2024',
-  //   },
-  //   {
-  //     label: '2023',
-  //     value: '2023',
-  //   },
-  //   {
-  //     label: '2022',
-  //     value: '2022',
-  //   },
-  //   {
-  //     label: '2021',
-  //     value: '2021',
-  //   },
-  // ];
 
   return (
     <Header>

--- a/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
@@ -34,8 +34,10 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
 
   return (
     <Header>
-      <Title isLight={isLight}>{title}</Title>
-      <Subtitle isLight={isLight}>{subtitle}</Subtitle>
+      <TextContainer>
+        <Title isLight={isLight}>{title}</Title>
+        <Subtitle isLight={isLight}>{subtitle}</Subtitle>
+      </TextContainer>
       {yearsRange && (
         <SingleItemSelect
           isMobile={false}
@@ -56,8 +58,15 @@ export default SectionHeader;
 
 const Header = styled.header({
   display: 'flex',
+  flexDirection: 'row',
+  gap: 16,
+});
+
+const TextContainer = styled.div({
+  display: 'flex',
   flexDirection: 'column',
   gap: 16,
+  marginRight: 'auto',
 });
 
 const Title = styled.h2<WithIsLight>(({ isLight }) => ({


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Add a year picker to show the data of only one year in the budget structure section of the endgame transition page

## What solved
- [X] Add a year selection functionality. Year selector quantifies over the whole Endgame Budget Structure section.