### PR TITLE
[QA] Update transition chart legend

### DIFF
--- a/src/stories/containers/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
+++ b/src/stories/containers/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
@@ -27,11 +27,11 @@ const BudgetTransitionChart: React.FC<BudgetTransitionChartProps> = ({ data, sel
 
   const { series, legendsLabels } = useMemo(() => {
     const legacySeries = {
-      name: `Legacy Maker Budget - ${selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}`,
+      name: `Legacy Budget - ${selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}`,
       data: [] as SeriesData[],
     };
     const endgameSeries = {
-      name: `All Endgame Budgets - ${selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}`,
+      name: `Endgame Budget - ${selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}`,
       data: [] as SeriesData[],
     };
     const series = [legacySeries, endgameSeries];
@@ -255,10 +255,10 @@ const BudgetTransitionChart: React.FC<BudgetTransitionChartProps> = ({ data, sel
       </ChartContainer>
       <LegendContainer>
         <LegendItem isLight={isLight} variant="yellow">
-          Legacy Maker Budget - {selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}
+          Legacy Budget - {selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}
         </LegendItem>
         <LegendItem isLight={isLight} variant="green">
-          All Endgame Budgets - {selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}
+          Endgame Budgets - {selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}
         </LegendItem>
       </LegendContainer>
     </Wrapper>


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Update Chart legend in the transition status section of the endgame page

## What solved
- [X] Add a text about budget transition. The bars on the chart should represent two specific budgets: “Legacy Budget ”, “Endgame Budget”
