### PR TITLE
[QA] Update transition subtitle

### DIFF
--- a/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.tsx
+++ b/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.tsx
@@ -24,7 +24,7 @@ const BudgetTransitionStatusSection: React.FC<BudgetTransitionStatusSectionProps
     <Content id="section-budget-transition-status">
       <SectionHeader
         title="Budget Transition Status"
-        subtitle="Visualizing key shifts in resource allocation and expense trends in MakerDAO’s Endgame transition."
+        subtitle="Visualizing key shifts in resource allocation and expense trends in MakerDAO's Endgame transition."
       />
 
       <Card isLight={isLight}>

--- a/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.tsx
+++ b/src/stories/containers/Endgame/components/BudgetTransitionStatusSection/BudgetTransitionStatusSection.tsx
@@ -24,7 +24,7 @@ const BudgetTransitionStatusSection: React.FC<BudgetTransitionStatusSectionProps
     <Content id="section-budget-transition-status">
       <SectionHeader
         title="Budget Transition Status"
-        subtitle="Some context about the trends that will be occurring, as it relates to expense and endgame that visually telegraph the changes."
+        subtitle="Visualizing key shifts in resource allocation and expense trends in MakerDAO’s Endgame transition."
       />
 
       <Card isLight={isLight}>


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Update the Budget transition status subtitle of the endgame page

## What solved
- [X] Add a text about budget transition. Subtitle text: Visualizing key shifts in resource allocation and expense trends in MakerDAO’s Endgame transition. 
