### PR TITLE
[QA] Update budget text to make it singular everywhere

### DIFF
--- a/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
+++ b/src/stories/containers/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
@@ -48,7 +48,7 @@ const BudgetStructureSection: React.FC<BudgetCompositionProps> = ({
       color: '#1AAB9B',
     },
     {
-      name: 'MakerDAO Legacy Budgets',
+      name: 'MakerDAO Legacy Budget',
       value: legacy,
       percent: (legacy * 100) / totalBudgetCap,
       actuals: 0,

--- a/src/stories/containers/Endgame/components/TotalBudgetContent/TotalBudgetContent.tsx
+++ b/src/stories/containers/Endgame/components/TotalBudgetContent/TotalBudgetContent.tsx
@@ -41,10 +41,10 @@ const TotalBudgetContent: React.FC<TotalBudgetContentProps> = ({
 
       <Legend>
         <LegendItem isLight={isLight} variant="gray">
-          Endgame Budgets
+          Endgame Budget
         </LegendItem>
         <LegendItem isLight={isLight} variant="blue">
-          Legacy Budgets
+          Legacy Budget
         </LegendItem>
       </Legend>
       <Bar defaultVariant="blue" isLight={isLight}>


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Change "Budgets" by "Budget" everywhere (except titles/subtitles)

## What solved
- [X] Budget names; make them consistent across different pages, no plural etc. **Budget names:** a. Budget utilization section:  - Endgame Budget, - Legacy Budget. b. Composition of Budget: - Scope Framework Budget, - Atlas Immutable Budget, - MakerDAO Legacy Budget.
