### PR TITLE
Fix duplicate budgets same code-Path(*/*) in the table

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -167,7 +167,6 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
 
     // create a table for each budget for the current level
     const tables = [] as TableFinances[];
-
     if (budgets.length === 0) {
       const rows = Object.keys(data).map((path) => {
         const columns = Object.values(data[path]);
@@ -244,7 +243,9 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
             codePath: path,
             columns,
           } as ItemRow;
-        });
+          // Necessary to avoid duplicate codePAth
+        })
+        .filter((row) => removePatternAfterSlash(row.codePath || '') !== budget.codePath);
 
       // complete sub-table rows with missing sub-budgets
       // Note that will be some budgets that don't have subBudget

--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -454,7 +454,6 @@ export const processDataForWaterfall = (
 
   // Only sum the values where the filter is active
   totalToStartEachBudget.forEach((values, key) => {
-    console.log('hello', key);
     if (activeElements.includes(key)) {
       total += values;
     }


### PR DESCRIPTION


## Ticket
<!--- Your Ticket Link -->

## Description
Fix duplicate items in the table that have the same code path At this point there some code-Path are the same the different */*, so it's have to be the same and delete the duplicate items.

## What solved
- [X] - Finances->MakerDAO Legacy Budget-> SPFs-> Legal Work on MIP65.- ** **Expected Output:** This budget is represented as the deepest, the last one. **Current Output:** In the SPFs view, in the breakdown table this budget is displayed with one sub-budget. Clicking on this sub-budget directs to its view without any values. 

## Screenshots (if apply)
