### PR TITLE
[SB-1]Fix sum values of the items in the  pie chart is not 100%

### DIFF
--- a/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
+++ b/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
@@ -4,7 +4,6 @@ import ArrowNavigationForCards from '@ses/components/svg/ArrowNavigationForCards
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
-import { percentageRespectTo } from '@ses/core/utils/math';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -21,12 +20,12 @@ interface Props {
   width?: number;
   height?: number;
   code?: string;
+  percent: number;
 }
 
-const CardNavigationMobile: React.FC<Props> = ({ image, title, totalDai, valueDai, href, barColor, code }) => {
+const CardNavigationMobile: React.FC<Props> = ({ image, title, totalDai, valueDai, href, barColor, code, percent }) => {
   const { isLight } = useThemeContext();
   const formatted = usLocalizedNumber(valueDai);
-  const percent = percentageRespectTo(valueDai, totalDai);
 
   return (
     <StyleCardNavigationGeneric>

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -217,8 +217,8 @@ export const useCardChartOverview = (
       item.percent = Math.round(item.percent + adjustment);
     });
 
-    const recheckTotalPercent = doughnutSeriesData.reduce((acc, curr) => acc + curr.percent, 0);
-    const roundingError = 100 - recheckTotalPercent;
+    const checkForPercent = doughnutSeriesData.reduce((acc, curr) => acc + curr.percent, 0);
+    const roundingError = 100 - checkForPercent;
     if (roundingError !== 0) {
       const indexToAdjust = doughnutSeriesData.findIndex((item) => item.percent > 0);
       // Fix the percent with some index in array of values

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -193,7 +193,6 @@ export const useCardChartOverview = (
         break;
     }
     const keyMetricValue = getCorrectMetricValuesOverViewChart(selectedMetric);
-
     return {
       name: budgetMetrics[item].name || 'No name' + index,
       code: budgetMetrics[item].code || 'No code' + index,
@@ -207,6 +206,27 @@ export const useCardChartOverview = (
       originalColor: isLight ? colorsLight[index] : colorsDark[index],
     };
   });
+
+  // Check some value affect the total 100%
+  const totalPercent = doughnutSeriesData.reduce((acc, curr) => acc + curr.percent, 0);
+  // Verify that sum of percent its 100% and there its not a 0%
+  if (totalPercent !== 100 && totalPercent !== 0) {
+    const difference = 100 - totalPercent;
+    doughnutSeriesData.forEach((item) => {
+      const adjustment = (item.percent / totalPercent) * difference;
+      item.percent = Math.round(item.percent + adjustment);
+    });
+
+    const recheckTotalPercent = doughnutSeriesData.reduce((acc, curr) => acc + curr.percent, 0);
+    const roundingError = 100 - recheckTotalPercent;
+    if (roundingError !== 0) {
+      const indexToAdjust = doughnutSeriesData.findIndex((item) => item.percent > 0);
+      // Fix the percent with some index in array of values
+      if (indexToAdjust !== -1) {
+        doughnutSeriesData[indexToAdjust].percent += roundingError;
+      }
+    }
+  }
 
   const numberItems = doughnutSeriesData.length;
   const changeAlignment = numberItems > 4;

--- a/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -120,6 +120,7 @@ const CardsNavigation: React.FC<Props> = ({
             title={card.title}
             barColor={card.color}
             key={index}
+            percent={card.percent}
           />
         ))}
         {loadMoreCards && (

--- a/src/stories/containers/Finances/utils/types.ts
+++ b/src/stories/containers/Finances/utils/types.ts
@@ -15,6 +15,7 @@ export interface NavigationCard {
   color: string;
   code?: string;
   codePath?: string;
+  percent: number;
 }
 
 export interface DoughnutSeries {


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix the sum of the all values in the pie chart and the mobile view should be 100%.
Right now because the round some times the sum of all items its less or more than 100%

## What solved
- [X] All.  **Resolution:** All **Steps to Reproduce:** **- Finances->MakerDAO Legacy Budget-> core units.- ** **Expected Output:** The sum of the percent should have as result 100%. 

