### PR TITLE
[SB-1] Give a big number to avoid big zIndex of tooltip Apache Echart

### DIFF
--- a/src/core/enums/zIndexEnum.ts
+++ b/src/core/enums/zIndexEnum.ts
@@ -1,6 +1,7 @@
 export enum zIndexEnum {
-  HEADER_PAGE = 10,
-  BREAD_CRUMB_NAVIGATION = 8,
+  // HEADER and NAVIGATION has big number avoid z-index tooltip  collision with them
+  HEADER_PAGE = 999999999,
+  BREAD_CRUMB_NAVIGATION = 99999999,
   SMALL_ICON_AVATAR_WITH_ICON_COMPONENT = 4,
   OVERLAY_MOBILE_TOOLTIP = 4,
   CORE_UNIT_SUMMARY = 3,


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix apache echart tooltip overlap to header end the navigation

## What solved
- [X]  The tootltips should be displayed in the content space. **Current Output:**  The tooltip is displayed over the breadcrumb when the user scrolls up.  

