### PR TITLE
[QA] Fix year picker styles

### DIFF
--- a/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
@@ -101,5 +101,5 @@ const Subtitle = styled('p')<WithIsLight>(({ isLight }) => ({
 }));
 
 const YearSelect = styled(SingleItemSelect)(() => ({
-  padding: '6.2px 15.58px',
+  padding: '7.2px 15.58px',
 }));

--- a/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
@@ -101,5 +101,5 @@ const Subtitle = styled('p')<WithIsLight>(({ isLight }) => ({
 }));
 
 const YearSelect = styled(SingleItemSelect)(() => ({
-  padding: '8px 16px',
+  padding: '6.2px 15.58px',
 }));

--- a/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
+++ b/src/stories/containers/Endgame/components/SectionHeader/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import { styled } from '@mui/material';
 import SingleItemSelect from '@ses/components/SingleItemSelect/SingleItemSelect';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
@@ -39,7 +39,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         <Subtitle isLight={isLight}>{subtitle}</Subtitle>
       </TextContainer>
       {yearsRange && (
-        <SingleItemSelect
+        <YearSelect
           isMobile={false}
           useSelectedAsLabel
           selected={selectedYear}
@@ -56,20 +56,26 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
 
 export default SectionHeader;
 
-const Header = styled.header({
+const Header = styled('header')(({ theme }) => ({
   display: 'flex',
-  flexDirection: 'row',
+  flexDirection: 'column',
   gap: 16,
-});
+  alignItems: 'flex-end',
 
-const TextContainer = styled.div({
+  [theme.breakpoints.up('tablet_768')]: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+}));
+
+const TextContainer = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   gap: 16,
   marginRight: 'auto',
 });
 
-const Title = styled.h2<WithIsLight>(({ isLight }) => ({
+const Title = styled('h2')<WithIsLight>(({ isLight }) => ({
   margin: 0,
   fontSize: 24,
   fontWeight: 600,
@@ -82,7 +88,7 @@ const Title = styled.h2<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const Subtitle = styled.p<WithIsLight>(({ isLight }) => ({
+const Subtitle = styled('p')<WithIsLight>(({ isLight }) => ({
   margin: 0,
   color: isLight ? '#231536' : '#D2D4EF',
   fontSize: 14,
@@ -92,4 +98,8 @@ const Subtitle = styled.p<WithIsLight>(({ isLight }) => ({
     fontSize: 16,
     lineHeight: '22px',
   },
+}));
+
+const YearSelect = styled(SingleItemSelect)(() => ({
+  padding: '8px 16px',
 }));


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Fix year picker styles 

## What solved
- [X] MET-1.3.  **Expected Output:** The title and subtitle of the section should be displayed across the width of the screen and the year dropdown below.  **Current Output:** The title and subtitle are displayed in several lines and the dropdown component next to them
- [X] MET-1.3.  **Expected Output:** The dropdown component should have a size: 92x34px.  **Current Output:** The view displays the dropdown with a size: 93.23x50px. 
