### PR TITLE
[QA] Change expense report default sorting

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ExpenseReports/useExpenseReports.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ExpenseReports/useExpenseReports.tsx
@@ -28,13 +28,13 @@ export const useExpenseReports = (budgetPath: string) => {
   };
 
   // column sorting
-  const [sortColumn, setSortColumn] = useState<number>(1);
+  const [sortColumn, setSortColumn] = useState<number>(4);
   const [headersSort, setHeadersSort] = useState<SortEnum[]>([
     SortEnum.Disabled,
-    SortEnum.Desc,
-    SortEnum.Disabled,
-    SortEnum.Disabled,
     SortEnum.Neutral,
+    SortEnum.Disabled,
+    SortEnum.Disabled,
+    SortEnum.Desc,
   ]);
 
   const onSortClick = (index: number) => {

--- a/src/stories/containers/Finances/components/SectionTitle/SectionTitle.tsx
+++ b/src/stories/containers/Finances/components/SectionTitle/SectionTitle.tsx
@@ -49,7 +49,7 @@ const SectionTitle: React.FC<SectionTitleProps> = ({ title, tooltip, hash }) => 
         </SESTooltip>
       </Tooltip>
       <CopyWrapper>
-        <CopyIcon text={href} width={22} height={22} />
+        <CopyIcon defaultTooltip="Copy link" text={href} width={22} height={22} />
       </CopyWrapper>
     </Container>
   );


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Change the default order of the expense report table, now it is sorted by last activity

## What solved
- [X] MER-1: Expense Reports “Last Modified” column default state after refresh/f5. Lets make the default state of this section, i.e., the state after refresh/f5 to be “last modified” and not “last reporting month”. We do not want to surface the empty reports (temporary fix) **Make the last modified filter as default.
