### PR TITLE
[SB-1] Reset category filter to initial state

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
@@ -59,7 +59,7 @@ export const useReservesWaterfallChart = (codePath: string, budgets: Budget[], a
     setActiveElements(value);
   };
   const handleResetFilter = () => {
-    setActiveElements([]);
+    setActiveElements(selectAll);
     setSelectedGranularity('monthly');
   };
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Add the default value for categories in the waterfall chart

## What solved
- [X] - Finances, Reserves Chart section. Changing the period filter and selecting the Reset option.- ** **Expected Output:** Both filters should back to their default state. **Current Output:** All Categories is reset but without all elements selected. 

## Screenshots (if apply)
