### PR TITLE
[SB] Fix the position of the tooltip for 768 and 1024 resolution

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -54,7 +54,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
 
   const options: EChartsOption = useMemo(
     () => ({
-      tooltip: createChartTooltip(selectedGranularity, year, isLight, isMobile),
+      tooltip: createChartTooltip(selectedGranularity, year, isLight, isMobile, isTablet, isDesktop1024),
       grid: {
         height: isMobile ? 192 : isTablet ? 390 : isDesktop1024 ? 392 : isDesktop1280 ? 392 : 392,
         width: isMobile ? 304 : isTablet ? 630 : isDesktop1024 ? 678 : isDesktop1280 ? 955 : 955,

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -43,7 +43,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
   };
 
   const options: EChartsOption = {
-    tooltip: createChartTooltip(selectedGranularity, year, isLight, isMobile),
+    tooltip: createChartTooltip(selectedGranularity, year, isLight, isMobile, false, false),
     grid: {
       height: isMobile ? 192 : isTablet ? 409 : isDesktop1024 ? 398 : isDesktop1280 ? 399 : 399,
       width: isMobile ? 304 : isTablet ? 645 : isDesktop1024 ? 704 : isDesktop1280 ? 955 : 955,


### PR DESCRIPTION
## Ticket
https://trello.com/c/1BmBP42a/330-bsn-1-budget-summary-navigation-list-of-issues

## Description
Fix the problem the tooltip cut  because isn't in the right position. 
At this moment in 768 and 1024 position the tooltip of breakdown chart cut in left side

## What solved
- [X] - Finances->MakerDAO Legacy Budget-> SPFs. Breakdown Chart. Tooltip.- ** **Expected Output:** The tooltip should display the full info. **Current Output:** The tooltip is cut off on the left side..

## Screenshots (if apply)
