### PR TITLE
[QA] Fix  some labels end-game chart

### DIFF
--- a/src/stories/containers/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
+++ b/src/stories/containers/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
@@ -255,10 +255,10 @@ const BudgetTransitionChart: React.FC<BudgetTransitionChartProps> = ({ data, sel
       </ChartContainer>
       <LegendContainer>
         <LegendItem isLight={isLight} variant="yellow">
-          Legacy Budget - {selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}
+          Legacy - {selected === 'Budget' ? 'Budget Cap' : `Net ${!isMobile ? 'Expenses' : ''} On-chain`}
         </LegendItem>
         <LegendItem isLight={isLight} variant="green">
-          Endgame Budgets - {selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}
+          Endgame - {selected === 'Budget' ? 'Budget Cap' : `Net ${!isMobile ? 'Expenses' : ''} On-chain`}
         </LegendItem>
       </LegendContainer>
     </Wrapper>

--- a/src/stories/containers/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
+++ b/src/stories/containers/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
@@ -27,11 +27,11 @@ const BudgetTransitionChart: React.FC<BudgetTransitionChartProps> = ({ data, sel
 
   const { series, legendsLabels } = useMemo(() => {
     const legacySeries = {
-      name: `Legacy Budget - ${selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}`,
+      name: `Legacy - ${selected === 'Budget' ? 'Budget Cap' : `Net ${!isMobile ? 'Expenses' : ''} On-chain`}`,
       data: [] as SeriesData[],
     };
     const endgameSeries = {
-      name: `Endgame Budget - ${selected === 'Budget' ? 'Budget Cap' : 'Net On-chain'}`,
+      name: `Endgame - ${selected === 'Budget' ? 'Budget Cap' : `Net ${!isMobile ? 'Expenses' : ''} On-chain`}`,
       data: [] as SeriesData[],
     };
     const series = [legacySeries, endgameSeries];


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Fix the legend in the chart breakdown chart in endgame page

## What solved
- [X]  MET-1.4 Remove the word “Budget(s)” from the color legend below the chart, and replace it with the selected metric name.  So when “Budget Cap” metric is selected it says: “Legacy - Budget Cap”, “Endgame - Budget Cap”.  When “Net Expenses On-Chain” is selected it says; “Legacy - Net Expenses On-Chain” and “Endgame - Net Expenses On-Chain”.

