### PR TITLE
[SB-1] Fix when only one metric is select show the name of the metric

### DIFF
--- a/src/stories/components/CustomMultiSelect/CustomMultiSelect.tsx
+++ b/src/stories/components/CustomMultiSelect/CustomMultiSelect.tsx
@@ -52,6 +52,7 @@ interface CustomMultiSelectProps extends Partial<WithLegacyBreakpoints> {
   defaultMetricsWithAllSelected?: string[];
   allowSelectAll?: boolean;
   selectNumberItemPerResolution?: boolean;
+  showMetricOneItemSelect?: boolean;
 }
 
 const defaultItemRender = (props: SelectItemProps) => <SelectItem {...props} />;
@@ -68,6 +69,7 @@ export const CustomMultiSelect = ({
   allowSelectAll = true,
   legacyBreakpoints = true,
   selectNumberItemPerResolution = false,
+  showMetricOneItemSelect = false,
 
   ...props
 }: CustomMultiSelectProps) => {
@@ -159,7 +161,12 @@ export const CustomMultiSelect = ({
       >
         {typeof props.label === 'string' ? (
           <Label active={activeItems.length > 0} isLight={isLight} hover={hover}>
-            {props.label} {activeItems.length > 0 ? `${activeItems.length}` : ''}
+            {props.label}{' '}
+            {showMetricOneItemSelect && activeItems.length === 1
+              ? ''
+              : activeItems.length > 0
+              ? activeItems.length
+              : ''}
           </Label>
         ) : (
           props.label({
@@ -295,7 +302,6 @@ const SelectContainer = styled.div<
   cursor: 'pointer',
   transition: 'all .3s ease',
   background: isLight ? 'white' : '#10191F',
-
   '&:hover': {
     border: isLight
       ? active

--- a/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
+++ b/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
@@ -57,7 +57,7 @@ const FilterTable: React.FC<Props> = ({
           selectNumberItemPerResolution
           defaultMetricsWithAllSelected={defaultMetricsWithAllSelected}
           positionRight={!isMobile}
-          label={activeItems.length === 1 ? activeItems[0] : 'Metrics'}
+          label={!isMobile && activeItems.length === 1 ? activeItems[0] : 'Metrics'}
           activeItems={activeItems}
           items={metrics}
           showMetricOneItemSelect

--- a/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
+++ b/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
@@ -57,10 +57,10 @@ const FilterTable: React.FC<Props> = ({
           selectNumberItemPerResolution
           defaultMetricsWithAllSelected={defaultMetricsWithAllSelected}
           positionRight={!isMobile}
-          label="Metrics"
+          label={activeItems.length === 1 ? activeItems[0] : 'Metrics'}
           activeItems={activeItems}
           items={metrics}
-          width={120}
+          showMetricOneItemSelect
           onChange={(value: string[]) => {
             handleSelectChange(value);
           }}


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
When one metric is select only show the same placeholder. When only one metric is select then should be show the  metric instead of placeholder with number of items

## What solved
- [X] BSN-1: (applicable to all budget levels): breakdown table: when it only has 1 metric selected it should show the name of that metric, and if it has multiple it should show the number between parentheses: Metrics (2). 

## Screenshots (if apply)
