### PR TITLE
[QA-338] Fix the multi-selected to reflect items select in brackets

### DIFF
--- a/src/stories/components/CustomMultiSelect/CustomMultiSelect.tsx
+++ b/src/stories/components/CustomMultiSelect/CustomMultiSelect.tsx
@@ -165,7 +165,7 @@ export const CustomMultiSelect = ({
             {showMetricOneItemSelect && activeItems.length === 1
               ? ''
               : activeItems.length > 0
-              ? activeItems.length
+              ? `(${activeItems.length})`
               : ''}
           </Label>
         ) : (

--- a/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
+++ b/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
@@ -6,6 +6,7 @@ import ResponsiveButtonClearFilter from '@ses/components/ResponsiveButtonClearFi
 import SingleItemSelect from '@ses/components/SingleItemSelect/SingleItemSelect';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
+import { getCorrectValuesTableFilter } from '../SectionPages/BreakdownTable/utils';
 import MetricItem from './MetricItem';
 import type { SelectItemProps, MultiSelectItem } from '@ses/components/CustomMultiSelect/CustomMultiSelect';
 
@@ -57,7 +58,13 @@ const FilterTable: React.FC<Props> = ({
           selectNumberItemPerResolution
           defaultMetricsWithAllSelected={defaultMetricsWithAllSelected}
           positionRight={!isMobile}
-          label={!isMobile && activeItems.length === 1 ? activeItems[0] : 'Metrics'}
+          label={
+            activeItems.length === 1
+              ? isMobile
+                ? getCorrectValuesTableFilter(activeItems[0], isMobile)
+                : activeItems[0]
+              : 'Metrics'
+          }
           activeItems={activeItems}
           items={metrics}
           showMetricOneItemSelect
@@ -100,7 +107,7 @@ export default FilterTable;
 
 const FiltersContainer = styled.div({
   display: 'grid',
-  gap: '16px',
+  gap: '12px',
   gridTemplateColumns: 'auto auto auto',
   gridTemplateRows: 'auto',
   placeItems: 'space-between',

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/utils.ts
@@ -111,3 +111,16 @@ export const convertFilterToGranularity = (period: PeriodicSelectionFilter): Ana
 };
 
 export const removePatternAfterSlash = (input: string) => input.replace(/\/\*.*$/, '');
+
+export const getCorrectValuesTableFilter = (metric: string, isMobile: boolean) => {
+  if (!isMobile) return metric;
+
+  switch (metric) {
+    case 'Net Protocol Outflow':
+      return 'Prtcol Outfl';
+    case 'Net Expenses On-chain':
+      return 'Net On-chain';
+    default:
+      return metric;
+  }
+};


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Add the brackets for items count in the multiselect component Fix the gap in the filters to adjust the big metrics

## What solved
- [X] BSN-1: (applicable to all budget levels): breakdown table: when it only has 1 metric selected it should show the name of that metric, and if it has multiple it should show the number between parentheses: Metrics 

## Screenshots (if apply)
