### PR TITLE
fix:Add the metric select to tooltip in breakdown chart

### DIFF
--- a/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
+++ b/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
@@ -26,6 +26,7 @@ interface SingleItemSelectProps {
   selected?: string;
   onChange?: (value: string) => unknown;
   isMobile?: boolean;
+  maxHeightSimpleBar?: number;
 }
 
 const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
@@ -38,6 +39,7 @@ const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
   className,
   selected,
   onChange,
+  maxHeightSimpleBar = 178,
   isMobile = false,
 }) => {
   const { isLight } = useThemeContext();
@@ -176,7 +178,7 @@ const SingleItemSelect: React.FC<SingleItemSelectProps> = ({
                 <MenuList autoFocusItem={open} id={menuListId} aria-labelledby={inputId} onKeyDown={handleListKeyDown}>
                   <SimpleBar
                     style={{
-                      maxHeight: 178,
+                      maxHeight: maxHeightSimpleBar,
                     }}
                     className="filter-popup-scroll"
                   >

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -5,6 +5,7 @@ import {
   formatterBreakdownChart,
   getChartAxisLabelByGranularity,
   formatBudgetName,
+  removeBudgetWord,
 } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
@@ -12,7 +13,7 @@ import lightTheme from '@ses/styles/theme/light';
 import ReactECharts from 'echarts-for-react';
 import React, { useEffect, useMemo } from 'react';
 import type { BreakdownChartSeriesData } from '@ses/containers/Finances/utils/types';
-import type { AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
+import type { AnalyticGranularity, AnalyticMetric } from '@ses/core/models/interfaces/analytic';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { EChartsOption } from 'echarts-for-react';
 
@@ -22,6 +23,7 @@ interface BreakdownChartProps {
   series: BreakdownChartSeriesData[];
   handleToggleSeries: (series: string) => void;
   refBreakDownChart: React.RefObject<EChartsOption | null>;
+  selectedMetric?: AnalyticMetric;
 }
 
 const BreakdownChart: React.FC<BreakdownChartProps> = ({
@@ -30,6 +32,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
   series,
   handleToggleSeries,
   selectedGranularity,
+  selectedMetric,
 }) => {
   const { isLight } = useThemeContext();
   const isDesktop1280 = useMediaQuery(lightTheme.breakpoints.between('desktop_1280', 'desktop_1440'));
@@ -54,7 +57,17 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
 
   const options: EChartsOption = useMemo(
     () => ({
-      tooltip: createChartTooltip(selectedGranularity, year, isLight, isMobile, isTablet, isDesktop1024),
+      tooltip: createChartTooltip(
+        selectedGranularity,
+        year,
+        isLight,
+        isMobile,
+        isTablet,
+        isDesktop1024,
+        true,
+        selectedMetric,
+        true
+      ),
       grid: {
         height: isMobile ? 192 : isTablet ? 390 : isDesktop1024 ? 392 : isDesktop1280 ? 392 : 392,
         width: isMobile ? 304 : isTablet ? 630 : isDesktop1024 ? 678 : isDesktop1280 ? 955 : 955,
@@ -139,7 +152,19 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
       },
       series,
     }),
-    [isDesktop1024, isDesktop1280, isLight, isMobile, isTablet, selectedGranularity, series, upTable, xAxisStyles, year]
+    [
+      isDesktop1024,
+      isDesktop1280,
+      isLight,
+      isMobile,
+      isTablet,
+      selectedGranularity,
+      selectedMetric,
+      series,
+      upTable,
+      xAxisStyles,
+      year,
+    ]
   );
 
   useEffect(() => {
@@ -203,7 +228,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
                 <circle cx="6.5" cy="6.5" r="4" fill={element.itemStyle.colorOriginal} />
               </svg>
             </SVGContainer>
-            {formatBudgetName(element.name)}
+            {removeBudgetWord(formatBudgetName(element.name))}
           </LegendItem>
         ))}
       </LegendContainer>

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -74,6 +74,7 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
           selected={selectedMetric}
           onChange={(metric: string) => onMetricChange(metric as AnalyticMetric)}
           items={metricItems}
+          maxHeightSimpleBar={220}
           PopperProps={{
             placement: 'bottom-end',
           }}

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
@@ -64,6 +64,7 @@ const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
           series={series}
           handleToggleSeries={handleToggleSeries}
           refBreakDownChart={refBreakDownChart}
+          selectedMetric={selectedMetric}
         />
       </Wrapper>
     )}

--- a/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
@@ -103,3 +103,15 @@ export const setBorderRadiusForSeries = (
 
   return series;
 };
+
+export const getSelectMetricText = (metric: AnalyticMetric | undefined) => {
+  if (!metric) return 'Budget';
+  switch (metric) {
+    case 'ProtocolNetOutflow':
+      return 'Net Protocol Outflow';
+    case 'PaymentsOnChain':
+      return 'Net Expenses On-chain';
+    default:
+      return metric;
+  }
+};

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -43,7 +43,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
   };
 
   const options: EChartsOption = {
-    tooltip: createChartTooltip(selectedGranularity, year, isLight, isMobile, false, false),
+    tooltip: createChartTooltip(selectedGranularity, year, isLight, isMobile, false, false, false),
     grid: {
       height: isMobile ? 192 : isTablet ? 409 : isDesktop1024 ? 398 : isDesktop1280 ? 399 : 399,
       width: isMobile ? 304 : isTablet ? 645 : isDesktop1024 ? 704 : isDesktop1280 ? 955 : 955,

--- a/src/stories/containers/Finances/utils/chartTooltip.ts
+++ b/src/stories/containers/Finances/utils/chartTooltip.ts
@@ -1,7 +1,9 @@
 import { zIndexEnum } from '@ses/core/enums/zIndexEnum';
 import { formatNumber } from '@ses/core/utils/string';
-import { formatBudgetName } from './utils';
+import { getSelectMetricText } from '../components/BreakdownChartSection/utils';
+import { formatBudgetName, removeBudgetWord } from './utils';
 import type { BarChartSeries } from './types';
+import type { AnalyticMetric } from '@ses/core/models/interfaces/analytic';
 import type { EChartsOption } from 'echarts-for-react';
 
 export const createChartTooltip = (
@@ -10,7 +12,10 @@ export const createChartTooltip = (
   isLight: boolean,
   isMobile: boolean,
   isTable: boolean,
-  isDesktop1024: boolean
+  isDesktop1024: boolean,
+  isBudgetRemove?: boolean,
+  metric?: AnalyticMetric,
+  isShowMetric?: boolean
 ) => ({
   show: !isMobile,
   trigger: 'axis',
@@ -61,7 +66,9 @@ export const createChartTooltip = (
       <div style="background-color:${isLight ? '#fff' : '#000A13'};padding:16px;overflow:auto;border-radius:3px;">
         <div style="margin-bottom:16px;font-size:12px;font-weight:600;color:#B6BCC2;">${
           (selectedGranularity as string) === 'Annually' ? year : params?.[0]?.name
-        }</div>
+        }<span style="display:inline-block;margin-left:10px">${
+      isShowMetric ? getSelectMetricText(metric) : ''
+    }</span></div>
         <div style="display:flex;flex-direction:${flexDirection};gap:${gap};${minMax}">
           ${params
             .reverse()
@@ -78,9 +85,11 @@ export const createChartTooltip = (
               </svg>
               <span style="display: inline-block;font-size:14px;color:${
                 isLight ? '#231536' : '#B6BCC2'
-              };white-space:nowrap;overflow:hidden;text-overflow:ellipsis;${maxWithTable}"> ${formatBudgetName(
-                  item.seriesName
-                )}:</span>
+              };white-space:nowrap;overflow:hidden;text-overflow:ellipsis;${maxWithTable}"> ${
+                  !isBudgetRemove
+                    ? formatBudgetName(item.seriesName)
+                    : removeBudgetWord(formatBudgetName(item.seriesName))
+                }:</span>
               <span style="font-size:16px;font-weight:700;color:${
                 isLight ? '#231536' : '#EDEFFF'
               };display: inline-block;">${formatNumber(item.value)}</span>

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -1027,3 +1027,9 @@ export const hasSubLevels = (codePath: string, budgets: Budget[]) => {
     );
   });
 };
+
+export const removeBudgetWord = (name: string) => {
+  const wordToRemove = /Budget\s*$/i;
+
+  return name.replace(wordToRemove, '');
+};


### PR DESCRIPTION

## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Add the metric select to tooltip and  remove budget word for the legend of breakdown chart The information show in the chart its relate with other metric too, son remove budget word help to let it clear


## What solved
- [X] BSN-1: adjust the metric dropdown to show all five items without scroll. add the selected metric next to the month in the popup. **Breakdown chart: **change the names of the three selections to: Atlas Immutable, Scope Framework, MakerDAO Legacy. Remove the word "Budget" from the selection name because the metrics in the dropdown are not just about budgets, but they are also about expenses. 