### PR TITLE
[QA] Breakdown table multiselect on mobile

### DIFF
--- a/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
+++ b/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
@@ -6,7 +6,6 @@ import ResponsiveButtonClearFilter from '@ses/components/ResponsiveButtonClearFi
 import SingleItemSelect from '@ses/components/SingleItemSelect/SingleItemSelect';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
-import { getCorrectValuesTableFilter } from '../SectionPages/BreakdownTable/utils';
 import MetricItem from './MetricItem';
 import type { SelectItemProps, MultiSelectItem } from '@ses/components/CustomMultiSelect/CustomMultiSelect';
 
@@ -58,16 +57,10 @@ const FilterTable: React.FC<Props> = ({
           selectNumberItemPerResolution
           defaultMetricsWithAllSelected={defaultMetricsWithAllSelected}
           positionRight={!isMobile}
-          label={
-            activeItems.length === 1
-              ? isMobile
-                ? getCorrectValuesTableFilter(activeItems[0], isMobile)
-                : activeItems[0]
-              : 'Metrics'
-          }
+          label={isMobile || activeItems.length !== 1 ? 'Metrics' : activeItems[0]}
           activeItems={activeItems}
           items={metrics}
-          showMetricOneItemSelect
+          showMetricOneItemSelect={!isMobile}
           onChange={(value: string[]) => {
             handleSelectChange(value);
           }}

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/utils.ts
@@ -111,16 +111,3 @@ export const convertFilterToGranularity = (period: PeriodicSelectionFilter): Ana
 };
 
 export const removePatternAfterSlash = (input: string) => input.replace(/\/\*.*$/, '');
-
-export const getCorrectValuesTableFilter = (metric: string, isMobile: boolean) => {
-  if (!isMobile) return metric;
-
-  switch (metric) {
-    case 'Net Protocol Outflow':
-      return 'Prtcol Outfl';
-    case 'Net Expenses On-chain':
-      return 'Net On-chain';
-    default:
-      return metric;
-  }
-};


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
On mobile the multiselect of the breakdown table should say "metrics" no matter how many metrics are selected

## What solved
- [X] Breakdown Table section. Selecting Net Expenses On-chain metric. **Expected Output:** The label on the filters should be displayed properly in one line. **Current Output:** The Semi-annual label is displayed in two lines and the filter takes more high
