### PR TITLE
[SBN-1] Fix the tooltip when there are many items

### DIFF
--- a/src/stories/containers/Finances/utils/chartTooltip.ts
+++ b/src/stories/containers/Finances/utils/chartTooltip.ts
@@ -58,6 +58,7 @@ export const createChartTooltip = (
   formatter: function (params: BarChartSeries[]) {
     const shortAmount = params.length > 10;
     const flexDirection = shortAmount ? 'row' : 'column';
+    const wrap = shortAmount ? 'flex-wrap:wrap;' : '';
     const gap = shortAmount ? '16px' : '12px';
     const minMax = isTable ? 'max-width:300px' : isDesktop1024 ? 'max-width:400px' : 'min-width:190px;max-width:450px';
     const maxWithTable = isTable ? 'max-width:190px' : isDesktop1024 ? 'max-width:450px' : '';
@@ -68,7 +69,7 @@ export const createChartTooltip = (
         }<span style="display:inline-block;margin-left:10px">${
       isShowMetric ? getSelectMetricText(metric) : ''
     }</span></div>
-        <div style="display:flex;flex-direction:${flexDirection};gap:${gap};${minMax}">
+        <div style="display:flex;flex-direction:${flexDirection};gap:${gap};${wrap}${minMax}">
           ${params
             .reverse()
             .map(


### PR DESCRIPTION
## Ticket
https://trello.com/c/FnTQ74C9/348-bsn-1-general-issues

## Description
Adjust the umbral to one, for don't show the 0 values

## What solved
- [X] - Finances-> MakerDAO Legacy Budget-> Core Units view. Breakdown Chart, tooltip. Actuals metric selected.- ** **Expected Output:** The info visible in the tooltip should be displayed properly. **Current Output:**  Three elements are displayed and in the fourth the tooltip is cut off and a horizontal bar is displayed. 

## Screenshots (if apply)
