### PR TITLE
[QA] Adjust multiselect to 8 items

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
@@ -126,9 +126,8 @@ export const useReservesWaterfallChart = (codePath: string, budgets: Budget[], a
       })) as MultiSelectItem[],
     [combinedElementsFromAnalytics]
   );
-
-  const popupContainerHeight =
-    budgets.length === 1 ? 100 : budgets.length === 2 ? 130 : budgets.length === 3 ? 150 : 180;
+  const itemsCount = Math.min(8, items.length + 1);
+  const popupContainerHeight = itemsCount * 40 + (itemsCount - 1) * 4;
 
   const isDisabled = activeElements.length === selectAll.length && selectedGranularity === 'monthly';
   return {


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Set popover menu to max height of 8 items in the waterfall chart section

## What solved
- [X] All metrics should be shown and the scroll bar should not be visible. **Current Output:** All metrics are displayed but the scroll bar appears.
