### PR TITLE
[QA-338] Fix scroll table bar chart add fit content

### DIFF
--- a/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
+++ b/src/stories/components/SingleItemSelect/SingleItemSelect.tsx
@@ -26,7 +26,7 @@ interface SingleItemSelectProps {
   selected?: string;
   onChange?: (value: string) => unknown;
   isMobile?: boolean;
-  maxHeightSimpleBar?: number;
+  maxHeightSimpleBar?: number | string;
 }
 
 const SingleItemSelect: React.FC<SingleItemSelectProps> = ({

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -74,7 +74,7 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
           selected={selectedMetric}
           onChange={(metric: string) => onMetricChange(metric as AnalyticMetric)}
           items={metricItems}
-          maxHeightSimpleBar={220}
+          maxHeightSimpleBar="fit-content"
           PopperProps={{
             placement: 'bottom-end',
           }}

--- a/src/stories/containers/Finances/components/BreakdownTableFinances/BreakdownTableFinances.tsx
+++ b/src/stories/containers/Finances/components/BreakdownTableFinances/BreakdownTableFinances.tsx
@@ -17,7 +17,7 @@ interface Props {
   minItems?: number;
   defaultMetricsWithAllSelected?: string[];
   allowSelectAll?: boolean;
-  popupContainerHeight?: number;
+  popupContainerHeight?: number | string;
   isDisabled?: boolean;
 }
 

--- a/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
+++ b/src/stories/containers/Finances/components/FiltersTable/FilterTable.tsx
@@ -22,7 +22,7 @@ interface Props {
   minItems?: number;
   defaultMetricsWithAllSelected?: string[];
   allowSelectAll?: boolean;
-  popupContainerHeight?: number;
+  popupContainerHeight?: number | string;
   isDisabled?: boolean;
 }
 

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/BreakdownTable.tsx
@@ -22,7 +22,7 @@ interface Props {
   maxItems?: number;
   minItems?: number;
   allowSelectAll?: boolean;
-  popupContainerHeight?: number;
+  popupContainerHeight?: number | string;
   breakdownTable: TableFinances[];
   isLoading: boolean;
   headerTable: MetricValues[];


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Add the fit-content for the height of the popover in the filters

## What solved
- [X] Breakdown chart and Breakdown Table sections. Metric filter. **Expected Output:** All metrics should be shown and the scroll bar should not be visible. 

## Screenshots (if apply)
