### PR TITLE
[EAT-21] Add code in about actors

### DIFF
--- a/src/stories/containers/ActorsAbout/components/ActorSummary/ActorTitleAbout.tsx
+++ b/src/stories/containers/ActorsAbout/components/ActorSummary/ActorTitleAbout.tsx
@@ -59,7 +59,6 @@ export const ActorTitleAbout = ({ actorAbout }: Props) => {
                     <ShortCode isLight={isLight}>{actorAbout.shortCode}</ShortCode>
                     {actorAbout?.name && <TypographyTitle isLight={isLight}>{actorAbout?.name}</TypographyTitle>}
                   </ShortCodeTitle>
-                  {/* {actorAbout?.name && <TypographyTitle isLight={isLight}>{actorAbout?.name}</TypographyTitle>} */}
                   <TypographyCategory isLight={isLight}>
                     {pascalCaseToNormalString(actorAbout.category?.[0] ?? '')}
                   </TypographyCategory>
@@ -373,7 +372,7 @@ const ShortCode = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   fontWeight: 700,
   fontSize: 16,
   lineHeight: '19.36px',
-  color: isLight ? '#9FAFB9' : 'red',
+  color: isLight ? '#9FAFB9' : 'rgb(84, 105, 120)',
   [lightTheme.breakpoints.up('table_834')]: {
     fontSize: 24,
   },

--- a/src/stories/containers/ActorsAbout/components/ActorSummary/ActorTitleAbout.tsx
+++ b/src/stories/containers/ActorsAbout/components/ActorSummary/ActorTitleAbout.tsx
@@ -158,6 +158,7 @@ const TypographyTitle = styled(Typography, { shouldForwardProp: (prop) => prop !
     letterSpacing: '0.4px',
     marginRight: '4px',
     fontFamily: 'Inter, sans-serif',
+    lineHeight: '29.05px',
   },
   [lightTheme.breakpoints.up('desktop_1194')]: {
     width: 'revert',
@@ -375,6 +376,7 @@ const ShortCode = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   color: isLight ? '#9FAFB9' : 'rgb(84, 105, 120)',
   [lightTheme.breakpoints.up('table_834')]: {
     fontSize: 24,
+    lineHeight: '29.05px',
   },
 }));
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/3EWKzArO/343-user-story-eat-21-ecosystem-actors-short-code

## Description
Fix the text cut in the title of the title about

## What solved
- [X]  Should add the short code to each ecosystem actor in the EA About view.

## Screenshots (if apply)
