### PR TITLE
Add funcion to delete budget word

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -5,6 +5,7 @@ import {
   generateColorPalette,
   hasSubLevels,
   formatBudgetName,
+  removeBudgetWord,
 } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { percentageRespectTo } from '@ses/core/utils/math';
@@ -194,7 +195,7 @@ export const useCardChartOverview = (
     }
     const keyMetricValue = getCorrectMetricValuesOverViewChart(selectedMetric);
     return {
-      name: budgetMetrics[item].name || 'No name' + index,
+      name: removeBudgetWord(budgetMetrics[item].name) || 'No name' + index,
       code: budgetMetrics[item].code || 'No code' + index,
       value,
       originalValue: value,


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
[X] Delete the budget word from the pie chart

## What solved
- [X] Budget Summary: change the names of the three selections to: Atlas Immutable, Scope Framework, MakerDAO Legacy. Remove the word "Budget" from the color legend name because the metrics for the donut chart are not just about budgets.

## Screenshots (if apply)
