### PR TITLE
[QA-338] Allow show negative value breakdown chart and line chart

### DIFF
--- a/src/core/utils/string.ts
+++ b/src/core/utils/string.ts
@@ -142,20 +142,28 @@ export const getCommentVerb = (comment: BudgetStatementComment, previousComment?
   return 'wrote';
 };
 
-export const replaceAllNumberLetOneBeforeDot = (num: number) => {
-  if (num < 1000) {
-    return num.toString();
-  } else if (num < 1000000) {
-    return (num / 1000).toFixed(1).replace(/\.?0+$/g, '') + 'K';
-  } else if (num < 1000000000) {
-    return (num / 1000000).toFixed(1).replace(/\.?0+$/g, '') + 'M';
-  } else if (num < 1000000000000) {
-    return (num / 1000000000).toFixed(1).replace(/\.?0+$/g, '') + 'B';
-  } else if (num < 1000000000000000) {
-    return (num / 1000000000000).toFixed(1).replace(/\.?0+$/g, '') + 'T';
+export const replaceAllNumberLetOneBeforeDot = (num: number, isShowNegative = false) => {
+  // Need to be sure that its negative
+  const isNegative = num < 0;
+  const mathAbsolute = Math.abs(num);
+
+  let result;
+
+  if (mathAbsolute < 1000) {
+    result = mathAbsolute.toString();
+  } else if (mathAbsolute < 1000000) {
+    result = (mathAbsolute / 1000).toFixed(1).replace(/\.?0+$/g, '') + 'K';
+  } else if (mathAbsolute < 1000000000) {
+    result = (mathAbsolute / 1000000).toFixed(1).replace(/\.?0+$/g, '') + 'M';
+  } else if (mathAbsolute < 1000000000000) {
+    result = (mathAbsolute / 1000000000).toFixed(1).replace(/\.?0+$/g, '') + 'B';
+  } else if (mathAbsolute < 1000000000000000) {
+    result = (mathAbsolute / 1000000000000).toFixed(1).replace(/\.?0+$/g, '') + 'T';
   } else {
-    return num.toString();
+    result = mathAbsolute.toString();
   }
+
+  return isShowNegative && isNegative ? '-' + result : result;
 };
 
 export const pascalCaseToNormalString = (str: string): string => str.replace(/([a-z])([A-Z])/g, '$1 $2');

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -94,7 +94,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
             return value.toString();
           }
 
-          return replaceAllNumberLetOneBeforeDot(value);
+          return replaceAllNumberLetOneBeforeDot(value, true);
         },
         color: isLight ? '#231536' : '#EDEFFF',
         fontSize: isMobile ? 10 : isTablet ? 14 : 14,

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
@@ -46,7 +46,7 @@ export const useMakerDAOExpenseMetrics = (year: string) => {
 
     // calculate the sum of all the rows for a metric
     const reduceMetric = (rows: AnalyticSeriesRow[], metric: AnalyticMetric) =>
-      rows.filter((element) => element.metric === metric).reduce((acc, current) => acc + Math.abs(current.value), 0);
+      rows.filter((element) => element.metric === metric).reduce((acc, current) => acc + current.value, 0);
 
     analytics.series.forEach((item) => {
       data.budget.push(reduceMetric(item.rows, 'Budget'));

--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -340,15 +340,15 @@ export const getAnalyticForWaterfall = (
 
         if (index === 0) {
           if (row.metric === 'ProtocolNetOutflow') {
-            netProtocolOutflow = Math.abs(row.sum) - Math.abs(row.value);
+            netProtocolOutflow = row.sum - row.value;
           }
           if (row.metric === 'PaymentsOnChain') {
-            paymentsOnChain = Math.abs(row.sum) - Math.abs(row.value);
+            paymentsOnChain = row.sum - row.value;
           }
 
           const getStartDifference = netProtocolOutflow - paymentsOnChain;
 
-          totalToStartEachBudget.set(removePatternAfterSlash(analyticPath), Math.abs(getStartDifference));
+          totalToStartEachBudget.set(removePatternAfterSlash(analyticPath), getStartDifference);
         }
         if (values[index]) {
           if (row.metric === 'ProtocolNetOutflow') {
@@ -375,15 +375,15 @@ export const getAnalyticForWaterfall = (
 
         if (index === 0) {
           if (row.metric === 'ProtocolNetOutflow') {
-            netProtocolOutflow = Math.abs(row.sum) - Math.abs(row.value);
+            netProtocolOutflow += row.sum - row.value;
           }
           if (row.metric === 'PaymentsOnChain') {
-            paymentsOnChain = Math.abs(row.sum) - Math.abs(row.value);
+            paymentsOnChain += row.sum - row.value;
           }
 
-          const moment = netProtocolOutflow - paymentsOnChain;
+          const difference = netProtocolOutflow - paymentsOnChain;
 
-          totalToStartEachBudget.set(analyticPath, Math.abs(moment));
+          totalToStartEachBudget.set(analyticPath, difference);
         }
         if (values[index]) {
           if (row.metric === 'ProtocolNetOutflow') {
@@ -404,7 +404,7 @@ export const getAnalyticForWaterfall = (
 
     const sumOfDifferences =
       values.length > 0
-        ? values.map((item) => Math.abs(item.ProtocolNetOutflow ?? 0) - Math.abs(item.PaymentsOnChain ?? 0))
+        ? values.map((item) => item.ProtocolNetOutflow - item.PaymentsOnChain)
         : Array.from({ length: arrayLength }, () => 0);
 
     summaryValues.set(element, sumOfDifferences);

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -565,7 +565,7 @@ export const getYearsRange = () => {
 
 const setMetric = (value: number, unit: string) =>
   ({
-    value: Math.abs(value),
+    value,
     unit,
   } as ValueAndUnit);
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Allow the chart of line metric and the breakdown chart 

## What solved
- [X] Protocol outflow negative numbers, e.g., DUX —> for breakdown chart should support the negative numbers —> y axis goes below 0. This is true for breakdown chart and expense metrics chart. This negative outflow should be also reflected in the reserves chart. Basically preserving the (-) negative values. Apeiron will provide further clarifications via wireframes.

## Screenshots (if apply)
