### PR TITLE
[QA-338] Remove the space between the sign and value waterfall chart

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -147,9 +147,9 @@ export const builderWaterfallSeries = (
 
           if (formatted.value === '0.00') return '';
           if (isMobile) {
-            return `- ${formatted.value}`;
+            return `-${formatted.value}`;
           }
-          return `- ${formatted.value}${formatted.suffix}`;
+          return `-${formatted.value}${formatted.suffix}`;
         },
       },
       stack: 'all',
@@ -180,10 +180,10 @@ export const builderWaterfallSeries = (
 
           if (formatted.value === '0.00') return '';
           if (isMobile) {
-            return `+ ${formatted.value}`;
+            return `+${formatted.value}`;
           }
 
-          return `+ ${formatted.value}${formatted.suffix}`;
+          return `+${formatted.value}${formatted.suffix}`;
         },
       },
       stack: 'all',


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion

## Description
Remove the space between sign and value in the waterfall

## What solved
- [X] Reserves Chart: Remove the space between the sign (+/-) and the numbers. 

## Screenshots (if apply)
