### PR TITLE
[BSN] Fix waterfall filter image

### DIFF
--- a/src/stories/containers/Finances/components/ReservesWaterfallFilters/BudgetItem.tsx
+++ b/src/stories/containers/Finances/components/ReservesWaterfallFilters/BudgetItem.tsx
@@ -30,6 +30,7 @@ const BudgetItem: React.FC<SelectItemProps> = ({ checked = false, ...props }) =>
               src={props.params?.url || '/assets/img/default-icon-cards-budget.svg'}
               alt="Budget Icon"
               fill={true}
+              unoptimized
             />
           </ImageContainer>
         </>


### PR DESCRIPTION
## Ticket
https://trello.com/c/FnTQ74C9/348-bsn-1-general-issues

## Description
Fix images in the filter of the waterfall section

## What solved
- [X] Finances->MakerDAO Legacy Budget->Core Units, Reserves chart: All Categories filter expanded, the icons are not available.
