### PR TITLE
[BSN] Change default amount of metrics on bigger desktops

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -37,6 +37,8 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
   const isDesk1280 = useMediaQuery(lightTheme.breakpoints.between('desktop_1280', 'desktop_1440'));
   const isDesk1440 = useMediaQuery(lightTheme.breakpoints.between('desktop_1440', 'desktop_1920'));
   const isDesk1920 = useMediaQuery(lightTheme.breakpoints.up('desktop_1920'));
+  const isUpDesk2400 = useMediaQuery(lightTheme.breakpoints.up(2400));
+  const isUpDesk3000 = useMediaQuery(lightTheme.breakpoints.up(3000));
   const [periodFilter, setPeriodFilter] = useState<PeriodicSelectionFilter>(() => {
     const urlPeriod = router.query.period as PeriodicSelectionFilter;
     if (urlPeriod && ['Annually', 'Semi-annual', 'Quarterly', 'Monthly'].includes(urlPeriod)) {
@@ -63,11 +65,13 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     } else if (periodFilter === 'Quarterly') {
       if (isTable) metricsCount = 1;
       if (isDesk1024 || isDesk1280 || isDesk1440) metricsCount = 2;
-      if (isDesk1920) metricsCount = 3;
+      if (isDesk1920 && !isUpDesk2400 && !isUpDesk3000) metricsCount = 3;
+      if (isUpDesk2400 && !isUpDesk3000) metricsCount = 4;
+      if (isUpDesk3000) metricsCount = 5;
     }
 
     return metricsCount;
-  }, [isDesk1024, isDesk1280, isDesk1440, isDesk1920, isMobile, isTable, periodFilter]);
+  }, [isDesk1024, isDesk1280, isDesk1440, isDesk1920, isMobile, isTable, isUpDesk2400, isUpDesk3000, periodFilter]);
 
   const [activeMetrics, setActiveMetrics] = useState<string[]>(() => {
     let urlMetrics = router.query.metric as string[] | undefined;


### PR DESCRIPTION
## Ticket
https://trello.com/c/FnTQ74C9/348-bsn-1-general-issues

## Description
From 2400px up we should 4 metrics and form 3000 on we show the 5 metrics by default

## What solved
- [X] Finances view, Breakdown Table section.- ** **Expected Output:** The amount of the metrics selected by default should depend on the screen resolution. **Current Output:** By default 3 metrics are selected but the table displays space that can be covered with another metric.
