### PR TITLE
[BSN] Fix firefox overflow on the table header

### DIFF
--- a/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
@@ -150,7 +150,7 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
 
   alignItems: 'center',
   whiteSpace: 'pre',
-  overflow: 'auto',
+  overflow: 'hidden',
   '&::-webkit-scrollbar': {
     width: 0,
     height: 0,

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/HeaderMonthly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderMonthly/HeaderMonthly.tsx
@@ -54,7 +54,7 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
   boxShadow: isLight ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)' : 'red',
   alignItems: 'center',
   whiteSpace: 'pre',
-  overflow: 'auto',
+  overflow: 'hidden',
   height: 97,
   '&::-webkit-scrollbar': {
     width: 0,

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
@@ -55,7 +55,7 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
     : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px -40px rgba(7, 22, 40, 0.40)',
   alignItems: 'center',
   whiteSpace: 'pre',
-  overflow: 'auto',
+  overflow: 'hidden',
   height: 97,
   '&::-webkit-scrollbar': {
     width: 0,

--- a/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
+++ b/src/stories/containers/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
@@ -58,7 +58,7 @@ const Container = styled.div<WithIsLight>(({ isLight }) => ({
     : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px -40px rgba(7, 22, 40, 0.40)',
   alignItems: 'center',
   whiteSpace: 'pre',
-  overflow: 'auto',
+  overflow: 'hidden',
   minHeight: 87,
   '&::-webkit-scrollbar': {
     width: 0,


### PR DESCRIPTION
## Ticket
https://trello.com/c/FnTQ74C9/348-bsn-1-general-issues

## Description
Remove overflow in the table header of the breakdown table in finances

## What solved
- [X] Finances view, Breakdown table.- ** **Expected Output:** The header should be displayed properly.  **Current Output:** A horizontal bar in the header is displayed.
