### PR TITLE
[BSN] Remove no-code work and put the path fragment to fix it

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -6,6 +6,7 @@ import {
   hasSubLevels,
   formatBudgetName,
   removeBudgetWord,
+  transformPathToName,
 } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { percentageRespectTo } from '@ses/core/utils/math';
@@ -76,7 +77,8 @@ export const useCardChartOverview = (
   const budgetMetrics: Record<string, BudgetMetricWithName> = {};
   budgets.forEach((budget) => {
     const budgetKey = budget.codePath;
-    const budgetName = formatBudgetName(budget.name);
+    const budgetName = formatBudgetName(budget.name) || transformPathToName(budget.codePath);
+    const budgetCode = budget.code || transformPathToName(budget.codePath);
     if (budgetMetrics[budget.codePath]) {
       const uniqueKey = `${budgetKey}-${budget.id}`;
       budgetMetrics[uniqueKey] = {
@@ -106,7 +108,7 @@ export const useCardChartOverview = (
           unit: 'DAI',
           value: 0,
         },
-        code: budget.code || 'No-code',
+        code: budgetCode,
       };
     } else {
       budgetMetrics[budgetKey] = {
@@ -136,7 +138,7 @@ export const useCardChartOverview = (
           unit: 'DAI',
           value: 0,
         },
-        code: budget.code || 'No-code',
+        code: budgetCode,
       };
     }
   });
@@ -195,8 +197,8 @@ export const useCardChartOverview = (
     }
     const keyMetricValue = getCorrectMetricValuesOverViewChart(selectedMetric);
     return {
-      name: removeBudgetWord(budgetMetrics[item].name) || 'No name' + index,
-      code: budgetMetrics[item].code || 'No code' + index,
+      name: removeBudgetWord(budgetMetrics[item].name),
+      code: budgetMetrics[item].code,
       value,
       originalValue: value,
       actuals: budgetMetrics[item].actuals.value,

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -969,6 +969,18 @@ export const formatBudgetName = (name: string) => {
   }
 };
 
+export const transformPathToName = (path: string) => {
+  if (!path) return '';
+  const transformedPath = path.replaceAll('/*', '');
+  const segments = transformedPath.split('/');
+
+  if (segments.length === 0) {
+    return '';
+  }
+
+  return segments[segments.length - 1] || '';
+};
+
 export const getKeyMetric = (metric: string) => {
   if (metric === 'Net Expenses On-chain') {
     return 'PaymentsOnChain';


### PR DESCRIPTION
## Ticket
https://trello.com/c/FnTQ74C9/348-bsn-1-general-issues-v1

## Description
using a name extracted by the path if there is not name or code

## What solved
- [X] Finances view, Breakdown Table section. Clicking the atlas/legacy/scopes sub-budget.- ** **Expected Output:** The subcategories name should match in all sections. **Current Output:** The legend shows subcategories with no-code name. The breakdown Chart displays them as Not name and the Reserves chart shows No-key-. 
