### PR TITLE
[BSN-348] Add the umbral condition for start point

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
@@ -106,14 +106,20 @@ export const setBorderRadiusForSeries = (
       if (positiveCount + negativeCount === 1) {
         // Apply all borders if only one value
         s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, barBorderRadius, barBorderRadius];
+      } else if (isPositive && positiveCount === 1) {
+        // Only one positive value, apply all borders
+        s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, barBorderRadius, barBorderRadius];
       } else if (isPositive && seriesIndex === firstPositiveIndex) {
-        // Firts postive value bottom borders
+        // First positive value bottom borders
         s.data[dataIndex].itemStyle.borderRadius = [0, 0, barBorderRadius, barBorderRadius];
       } else if (isPositive && seriesIndex === lastPositiveIndex) {
-        // Last postive value top borders
+        // Last positive value top borders
         s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, 0, 0];
+      } else if (isNegative && negativeCount === 1) {
+        // Only one negative value, apply all borders
+        s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, barBorderRadius, barBorderRadius];
       } else if (isNegative && seriesIndex === firstNegativeIndex) {
-        // First value negative, top edges (inverted due to negative nature)
+        // First negative value, top edges (inverted due to negative nature)
         s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, 0, 0];
       } else if (isNegative && seriesIndex === lastNegativeIndex) {
         // Last negative value, bottom edges (inverted)

--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -347,8 +347,8 @@ export const getAnalyticForWaterfall = (
           }
 
           const getStartDifference = netProtocolOutflow - paymentsOnChain;
-
-          totalToStartEachBudget.set(removePatternAfterSlash(analyticPath), getStartDifference);
+          const checkValueLessZero = Math.abs(getStartDifference) < UMBRAL_CHART_WATERFALL ? 0 : getStartDifference;
+          totalToStartEachBudget.set(removePatternAfterSlash(analyticPath), checkValueLessZero);
         }
         if (values[index]) {
           if (row.metric === 'ProtocolNetOutflow') {
@@ -382,8 +382,8 @@ export const getAnalyticForWaterfall = (
           }
 
           const difference = netProtocolOutflow - paymentsOnChain;
-
-          totalToStartEachBudget.set(analyticPath, difference);
+          const checkValueLessZero = Math.abs(difference) < UMBRAL_CHART_WATERFALL ? 0 : difference;
+          totalToStartEachBudget.set(analyticPath, checkValueLessZero);
         }
         if (values[index]) {
           if (row.metric === 'ProtocolNetOutflow') {


### PR DESCRIPTION
## Ticket
https://trello.com/c/FnTQ74C9/348-bsn-1-general-issues-v1

## Description
Avoid big negative number with decimal, replace with cero, for the start point of the waterfall

## What solved
- [X]Finances->MakerDAO Legacy Budget->Keepers: http://46.101.104.232:82/finances/legacy/keepers?year=2023. Reserves Chart section.- ** **Expected Output:** If the Start column has the value of 0, then the number visible should be 0. **Current Output:**  The Start column is displayed with value = - 0.00267. 

## Screenshots (if apply)
