### PR TITLE
[BSN] Fix unnamed budgets

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -81,6 +81,7 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
         : [...inactiveSeries, toggleSeries]
     );
   };
+  console.log('<<>>', allSeries);
   const series = useMemo(() => {
     const parsedSeries = allSeries.map((item) => {
       if (inactiveSeries.includes(item.name)) {
@@ -103,6 +104,7 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
 
     return setBorderRadiusForSeries(parsedSeries, barBorderRadius);
   }, [allSeries, barBorderRadius, inactiveSeries]);
+  console.log('>>>', series);
 
   return {
     isLoading,

--- a/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -81,7 +81,7 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
         : [...inactiveSeries, toggleSeries]
     );
   };
-  console.log('<<>>', allSeries);
+
   const series = useMemo(() => {
     const parsedSeries = allSeries.map((item) => {
       if (inactiveSeries.includes(item.name)) {
@@ -104,7 +104,6 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
 
     return setBorderRadiusForSeries(parsedSeries, barBorderRadius);
   }, [allSeries, barBorderRadius, inactiveSeries]);
-  console.log('>>>', series);
 
   return {
     isLoading,

--- a/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
@@ -18,17 +18,18 @@ export const parseAnalyticsToSeriesBreakDownChart = (
   metric: AnalyticMetric,
   allBudgets: Budget[]
 ) => {
-  const colorsLight = generateColorPalette(
-    existingColors.length,
-    budgets.length - existingColors.length,
-    existingColors
-  );
-
-  const colorsDark = generateColorPalette(180, budgets.length, existingColorsDark);
   const series: BreakdownChartSeriesData[] = [];
 
   if (budgetsAnalytics) {
     const budgetKeys = Object.keys(budgetsAnalytics);
+
+    const colorsLight = generateColorPalette(
+      existingColors.length,
+      budgetKeys.length - existingColors.length,
+      existingColors
+    );
+    const colorsDark = generateColorPalette(180, budgetKeys.length, existingColorsDark);
+
     budgetKeys.forEach((budgetKey, index) => {
       const searchCorrectBudget = budgets.length > 0 ? budgets : allBudgets;
       const nameBudget =

--- a/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
@@ -1,4 +1,10 @@
-import { existingColors, existingColorsDark, generateColorPalette, getCorrectMetric } from '../../utils/utils';
+import {
+  existingColors,
+  existingColorsDark,
+  generateColorPalette,
+  getCorrectMetric,
+  transformPathToName,
+} from '../../utils/utils';
 import { removePatternAfterSlash } from '../SectionPages/BreakdownTable/utils';
 import type { BreakdownChartSeriesData } from '../../utils/types';
 import type { AnalyticMetric, BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
@@ -19,7 +25,6 @@ export const parseAnalyticsToSeriesBreakDownChart = (
   );
 
   const colorsDark = generateColorPalette(180, budgets.length, existingColorsDark);
-
   const series: BreakdownChartSeriesData[] = [];
 
   if (budgetsAnalytics) {
@@ -35,7 +40,7 @@ export const parseAnalyticsToSeriesBreakDownChart = (
         const dataForSeries = budgetData.map((budgetMetric) => getCorrectMetric(budgetMetric, metric));
 
         series[index] = {
-          name: nameBudget || 'Not name',
+          name: nameBudget || transformPathToName(budgetKey),
           dataOriginal: dataForSeries,
           data: dataForSeries,
           type: 'bar',
@@ -51,7 +56,7 @@ export const parseAnalyticsToSeriesBreakDownChart = (
       } else {
         const dataForSeries = getCorrectMetric(budgetData, metric);
         series[index] = {
-          name: nameBudget || 'Not name',
+          name: nameBudget || transformPathToName(budgetKey),
           dataOriginal: [dataForSeries],
           data: [dataForSeries],
           type: 'bar',

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -77,17 +77,17 @@ export const useCardChartOverview = (
   const budgetMetrics: Record<string, BudgetMetricWithName> = {};
   budgets.forEach((budget) => {
     const budgetKey = budget.codePath;
-    const budgetName = formatBudgetName(budget.name) || transformPathToName(budget.codePath);
-    const budgetCode = budget.code || transformPathToName(budget.codePath);
+    const budgetName = budget.name ? formatBudgetName(budget.name) : transformPathToName(budget.codePath);
+    const budgetCode = budget.code ? budget.code : transformPathToName(budget.codePath);
     if (budgetMetrics[budget.codePath]) {
       const uniqueKey = `${budgetKey}-${budget.id}`;
       budgetMetrics[uniqueKey] = {
         name: budgetName,
+        code: budgetCode,
         actuals: {
           unit: 'DAI',
           value: 0,
         },
-
         forecast: {
           unit: 'DAI',
           value: 0,
@@ -108,11 +108,11 @@ export const useCardChartOverview = (
           unit: 'DAI',
           value: 0,
         },
-        code: budgetCode,
       };
     } else {
       budgetMetrics[budgetKey] = {
         name: budgetName,
+        code: budgetCode,
         actuals: {
           unit: 'DAI',
           value: 0,
@@ -138,7 +138,6 @@ export const useCardChartOverview = (
           unit: 'DAI',
           value: 0,
         },
-        code: budgetCode,
       };
     }
   });
@@ -150,8 +149,10 @@ export const useCardChartOverview = (
         (budget) => budget.codePath === removePatternAfterSlash(budgetMetricKey)
       );
       // use the name of budget or add label
-      const budgetName = correspondingBudget ? formatBudgetName(correspondingBudget.name) : 'Others';
-      const budgetCode = correspondingBudget?.code || 'Others';
+      const budgetName = correspondingBudget
+        ? formatBudgetName(correspondingBudget.name)
+        : transformPathToName(budgetMetricKey);
+      const budgetCode = correspondingBudget?.code || transformPathToName(budgetMetricKey);
       metric.actuals += budgetMetric[0].actuals.value || 0;
       metric.forecast += budgetMetric[0].forecast.value || 0;
       metric.budget += budgetMetric[0].budget.value || 0;


### PR DESCRIPTION
## Ticket
https://trello.com/c/FnTQ74C9/348-bsn-1-general-issues-v1

## Description
Fix the unnamed budgets on the first section and second sections, also fixed the colors for the breakdown chart when there are more analytics paths than budgets

## What solved
- [X] Finances view, Breakdown Table section. Clicking the atlas/legacy/scopes sub-budget.- ** **Expected Output:** The sub-budget values should be reflected in the pie chart and its legend.  **Current Output:** The values on the Net Expenses On-chain/Net Protocol Outflow metrics are displayed in the legend but not in the pie chart taking into account the colors.
