### PR TITLE
fix: use the same colors for the same paths

### DIFF
--- a/src/core/utils/colors.ts
+++ b/src/core/utils/colors.ts
@@ -6,6 +6,65 @@ import { BudgetStatus } from '../models/dto/coreUnitDTO';
 import { getCorrectRoleApi } from './string';
 import type { UserDTO } from '../models/dto/authDTO';
 
+export class LimitedColorAssigner {
+  private availableColors: string[];
+  // map of key -> color index
+  private assignedColors: Record<string, number>;
+  private assignedColorsAmount: number;
+
+  constructor(maxAssignedColor: number, handPickedColors: string[] = []) {
+    this.assignedColorsAmount = 0;
+    this.availableColors = this.generateColorPalette(
+      handPickedColors.length,
+      maxAssignedColor - handPickedColors.length,
+      handPickedColors
+    );
+    this.assignedColors = {};
+  }
+
+  private generateColorPalette = (index: number, numColors: number, existingColors: string[] = []) => {
+    const baseHue = (index * (360 / numColors)) % 360;
+    const colors = [];
+
+    for (let i = 0; i < numColors; i++) {
+      const hue = (baseHue + i * (360 / numColors)) % 360;
+      const color = `hsl(${hue}, 70%, 50%)`;
+      colors.push(color);
+    }
+
+    return [...existingColors, ...colors];
+  };
+
+  private hashIndex(key: string) {
+    let hash = 0;
+    for (let i = 0; i < key.length; i++) {
+      const charCode = key.charCodeAt(i);
+      hash = (hash * 31 + charCode) % this.availableColors.length;
+    }
+    return hash;
+  }
+
+  getColor = (key: string): string => {
+    if (typeof this.assignedColors[key] === 'number') {
+      return this.availableColors[this.assignedColors[key]];
+    }
+
+    if (this.assignedColorsAmount >= this.availableColors.length) {
+      throw Error('No more colors available');
+    }
+
+    let index = this.hashIndex(key);
+    const takenIndexes = Object.values(this.assignedColors);
+    while (takenIndexes.includes(index)) {
+      index = (index + 1) % this.availableColors.length;
+    }
+
+    this.assignedColors[key] = index;
+    this.assignedColorsAmount += 1;
+    return this.availableColors[index];
+  };
+}
+
 export const getColorForString = (value: string): string => {
   let hash = 0;
   let i;

--- a/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
@@ -1,10 +1,5 @@
-import {
-  existingColors,
-  existingColorsDark,
-  generateColorPalette,
-  getCorrectMetric,
-  transformPathToName,
-} from '../../utils/utils';
+import { LimitedColorAssigner } from '@ses/core/utils/colors';
+import { existingColors, existingColorsDark, getCorrectMetric, transformPathToName } from '../../utils/utils';
 import { removePatternAfterSlash } from '../SectionPages/BreakdownTable/utils';
 import type { BreakdownChartSeriesData } from '../../utils/types';
 import type { AnalyticMetric, BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
@@ -21,14 +16,8 @@ export const parseAnalyticsToSeriesBreakDownChart = (
   const series: BreakdownChartSeriesData[] = [];
 
   if (budgetsAnalytics) {
-    const budgetKeys = Object.keys(budgetsAnalytics);
-
-    const colorsLight = generateColorPalette(
-      existingColors.length,
-      budgetKeys.length - existingColors.length,
-      existingColors
-    );
-    const colorsDark = generateColorPalette(180, budgetKeys.length, existingColorsDark);
+    const budgetKeys = Object.keys(budgetsAnalytics).sort();
+    const colorAssigner = new LimitedColorAssigner(budgetKeys.length, isLight ? existingColors : existingColorsDark);
 
     budgetKeys.forEach((budgetKey, index) => {
       const searchCorrectBudget = budgets.length > 0 ? budgets : allBudgets;
@@ -49,8 +38,8 @@ export const parseAnalyticsToSeriesBreakDownChart = (
           barWidth,
           showBackground: false,
           itemStyle: {
-            color: isLight ? colorsLight[index] : colorsDark[index],
-            colorOriginal: isLight ? colorsLight[index] : colorsDark[index],
+            color: colorAssigner.getColor(budgetKey),
+            colorOriginal: colorAssigner.getColor(budgetKey),
           },
           isVisible: true,
         };
@@ -65,8 +54,8 @@ export const parseAnalyticsToSeriesBreakDownChart = (
           barWidth,
           showBackground: false,
           itemStyle: {
-            color: isLight ? colorsLight[index] : colorsDark[index],
-            colorOriginal: isLight ? colorsLight[index] : colorsDark[index],
+            color: colorAssigner.getColor(budgetKey),
+            colorOriginal: colorAssigner.getColor(budgetKey),
           },
           isVisible: true,
         };

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -33,13 +33,6 @@ export const useCardChartOverview = (
 
   const [selectedMetric, setSelectedMetric] = useState<AnalyticMetric>('Budget');
   const { isLight } = useThemeContext();
-  // const colorsLight = generateColorPalette(
-  //   existingColors.length,
-  //   Object.keys(budgetsAnalytics ?? {}).length - existingColors.length,
-  //   existingColors
-  // );
-
-  // const colorsDark = generateColorPalette(180, Object.keys(budgetsAnalytics ?? {}).length, existingColorsDark);
   const budgetWithNotChildren = useMemo(() => {
     const data = {
       budget: 0,

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -2,13 +2,13 @@ import { useMediaQuery } from '@mui/material';
 import {
   existingColors,
   existingColorsDark,
-  generateColorPalette,
   hasSubLevels,
   formatBudgetName,
   removeBudgetWord,
   transformPathToName,
 } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { LimitedColorAssigner } from '@ses/core/utils/colors';
 import { percentageRespectTo } from '@ses/core/utils/math';
 import lightTheme from '@ses/styles/theme/light';
 import { useMemo, useState } from 'react';
@@ -33,13 +33,13 @@ export const useCardChartOverview = (
 
   const [selectedMetric, setSelectedMetric] = useState<AnalyticMetric>('Budget');
   const { isLight } = useThemeContext();
-  const colorsLight = generateColorPalette(
-    existingColors.length,
-    Object.keys(budgetsAnalytics ?? {}).length - existingColors.length,
-    existingColors
-  );
+  // const colorsLight = generateColorPalette(
+  //   existingColors.length,
+  //   Object.keys(budgetsAnalytics ?? {}).length - existingColors.length,
+  //   existingColors
+  // );
 
-  const colorsDark = generateColorPalette(180, Object.keys(budgetsAnalytics ?? {}).length, existingColorsDark);
+  // const colorsDark = generateColorPalette(180, Object.keys(budgetsAnalytics ?? {}).length, existingColorsDark);
   const budgetWithNotChildren = useMemo(() => {
     const data = {
       budget: 0,
@@ -65,151 +65,167 @@ export const useCardChartOverview = (
     return data;
   }, [budgetsAnalytics]);
 
-  const metric: { [metric: string]: number } = {
-    actuals: 0,
-    forecast: 0,
-    budget: 0,
-    paymentsOnChain: 0,
-    protocolNetOutflow: 0,
-    paymentsOffChainIncluded: 0,
-  };
+  const { metric, budgetMetrics } = useMemo(() => {
+    const metric: { [metric: string]: number } = {
+      actuals: 0,
+      forecast: 0,
+      budget: 0,
+      paymentsOnChain: 0,
+      protocolNetOutflow: 0,
+      paymentsOffChainIncluded: 0,
+    };
 
-  const budgetMetrics: Record<string, BudgetMetricWithName> = {};
-  budgets.forEach((budget) => {
-    const budgetKey = budget.codePath;
-    const budgetName = budget.name ? formatBudgetName(budget.name) : transformPathToName(budget.codePath);
-    const budgetCode = budget.code ? budget.code : transformPathToName(budget.codePath);
-    if (budgetMetrics[budget.codePath]) {
-      const uniqueKey = `${budgetKey}-${budget.id}`;
-      budgetMetrics[uniqueKey] = {
-        name: budgetName,
-        code: budgetCode,
-        actuals: {
-          unit: 'DAI',
-          value: 0,
-        },
-        forecast: {
-          unit: 'DAI',
-          value: 0,
-        },
-        budget: {
-          unit: 'DAI',
-          value: 0,
-        },
-        paymentsOnChain: {
-          unit: 'DAI',
-          value: 0,
-        },
-        paymentsOffChainIncluded: {
-          unit: 'DAI',
-          value: 0,
-        },
-        protocolNetOutflow: {
-          unit: 'DAI',
-          value: 0,
-        },
-      };
-    } else {
-      budgetMetrics[budgetKey] = {
-        name: budgetName,
-        code: budgetCode,
-        actuals: {
-          unit: 'DAI',
-          value: 0,
-        },
+    const budgetMetrics: Record<string, BudgetMetricWithName> = {};
+    budgets.forEach((budget) => {
+      const budgetKey = budget.codePath;
+      const budgetName = budget.name ? formatBudgetName(budget.name) : transformPathToName(budget.codePath);
+      const budgetCode = budget.code ? budget.code : transformPathToName(budget.codePath);
+      if (budgetMetrics[budget.codePath]) {
+        const uniqueKey = `${budgetKey}-${budget.id}`;
+        budgetMetrics[uniqueKey] = {
+          name: budgetName,
+          code: budgetCode,
+          actuals: {
+            unit: 'DAI',
+            value: 0,
+          },
+          forecast: {
+            unit: 'DAI',
+            value: 0,
+          },
+          budget: {
+            unit: 'DAI',
+            value: 0,
+          },
+          paymentsOnChain: {
+            unit: 'DAI',
+            value: 0,
+          },
+          paymentsOffChainIncluded: {
+            unit: 'DAI',
+            value: 0,
+          },
+          protocolNetOutflow: {
+            unit: 'DAI',
+            value: 0,
+          },
+        };
+      } else {
+        budgetMetrics[budgetKey] = {
+          name: budgetName,
+          code: budgetCode,
+          actuals: {
+            unit: 'DAI',
+            value: 0,
+          },
 
-        forecast: {
-          unit: 'DAI',
-          value: 0,
-        },
-        budget: {
-          unit: 'DAI',
-          value: 0,
-        },
-        paymentsOnChain: {
-          unit: 'DAI',
-          value: 0,
-        },
-        paymentsOffChainIncluded: {
-          unit: 'DAI',
-          value: 0,
-        },
-        protocolNetOutflow: {
-          unit: 'DAI',
-          value: 0,
-        },
-      };
+          forecast: {
+            unit: 'DAI',
+            value: 0,
+          },
+          budget: {
+            unit: 'DAI',
+            value: 0,
+          },
+          paymentsOnChain: {
+            unit: 'DAI',
+            value: 0,
+          },
+          paymentsOffChainIncluded: {
+            unit: 'DAI',
+            value: 0,
+          },
+          protocolNetOutflow: {
+            unit: 'DAI',
+            value: 0,
+          },
+        };
+      }
+    });
+    if (budgetsAnalytics !== undefined) {
+      for (const budgetMetricKey of Object.keys(budgetsAnalytics)) {
+        const budgetMetric = budgetsAnalytics[budgetMetricKey];
+        const searchCorrectBudget = budgets.length > 0 ? budgets : allBudgets;
+        const correspondingBudget = searchCorrectBudget.find(
+          (budget) => budget.codePath === removePatternAfterSlash(budgetMetricKey)
+        );
+        // use the name of budget or add label
+        const budgetName = correspondingBudget
+          ? formatBudgetName(correspondingBudget.name)
+          : transformPathToName(budgetMetricKey);
+        const budgetCode = correspondingBudget?.code || transformPathToName(budgetMetricKey);
+        metric.actuals += budgetMetric[0].actuals.value || 0;
+        metric.forecast += budgetMetric[0].forecast.value || 0;
+        metric.budget += budgetMetric[0].budget.value || 0;
+        metric.paymentsOnChain += budgetMetric[0].paymentsOnChain.value || 0;
+        metric.protocolNetOutflow += budgetMetric[0].protocolNetOutflow.value || 0;
+        budgetMetrics[budgetMetricKey] = {
+          name: budgetName,
+          actuals: budgetMetric[0].actuals,
+          forecast: budgetMetric[0].forecast,
+          budget: budgetMetric[0].budget,
+          paymentsOnChain: budgetMetric[0].paymentsOnChain,
+          paymentsOffChainIncluded: budgetMetric[0].paymentsOffChainIncluded,
+          protocolNetOutflow: budgetMetric[0].protocolNetOutflow,
+          code: budgetCode,
+        };
+      }
     }
-  });
-  if (budgetsAnalytics !== undefined) {
-    for (const budgetMetricKey of Object.keys(budgetsAnalytics)) {
-      const budgetMetric = budgetsAnalytics[budgetMetricKey];
-      const searchCorrectBudget = budgets.length > 0 ? budgets : allBudgets;
-      const correspondingBudget = searchCorrectBudget.find(
-        (budget) => budget.codePath === removePatternAfterSlash(budgetMetricKey)
-      );
-      // use the name of budget or add label
-      const budgetName = correspondingBudget
-        ? formatBudgetName(correspondingBudget.name)
-        : transformPathToName(budgetMetricKey);
-      const budgetCode = correspondingBudget?.code || transformPathToName(budgetMetricKey);
-      metric.actuals += budgetMetric[0].actuals.value || 0;
-      metric.forecast += budgetMetric[0].forecast.value || 0;
-      metric.budget += budgetMetric[0].budget.value || 0;
-      metric.paymentsOnChain += budgetMetric[0].paymentsOnChain.value || 0;
-      metric.protocolNetOutflow += budgetMetric[0].protocolNetOutflow.value || 0;
-      budgetMetrics[budgetMetricKey] = {
-        name: budgetName,
-        actuals: budgetMetric[0].actuals,
-        forecast: budgetMetric[0].forecast,
-        budget: budgetMetric[0].budget,
-        paymentsOnChain: budgetMetric[0].paymentsOnChain,
-        paymentsOffChainIncluded: budgetMetric[0].paymentsOffChainIncluded,
-        protocolNetOutflow: budgetMetric[0].protocolNetOutflow,
-        code: budgetCode,
-      };
-    }
-  }
+
+    return {
+      metric,
+      budgetMetrics,
+    };
+  }, [allBudgets, budgets, budgetsAnalytics]);
 
   const handleSelectedMetric = (metric: AnalyticMetric) => {
     setSelectedMetric(metric);
   };
-  const doughnutSeriesData: DoughnutSeries[] = Object.keys(budgetMetrics).map((item, index) => {
-    let value;
-    switch (selectedMetric) {
-      case 'Actuals':
-        value = budgetMetrics[item].actuals.value || 0;
-        break;
-      case 'Forecast':
-        value = budgetMetrics[item].forecast.value || 0;
-        break;
-      case 'PaymentsOnChain':
-        value = budgetMetrics[item].paymentsOnChain.value || 0;
-        break;
-      case 'ProtocolNetOutflow':
-        value = budgetMetrics[item].protocolNetOutflow.value || 0;
-        break;
-      case 'Budget':
-        value = budgetMetrics[item].budget.value || 0;
-        break;
-      default:
-        value = budgetMetrics[item].budget.value || 0;
-        break;
-    }
-    const keyMetricValue = getCorrectMetricValuesOverViewChart(selectedMetric);
-    return {
-      name: removeBudgetWord(budgetMetrics[item].name),
-      code: budgetMetrics[item].code,
-      value,
-      originalValue: value,
-      actuals: budgetMetrics[item].actuals.value,
-      budgetCap: budgetMetrics[item].budget.value,
-      percent: Math.round(percentageRespectTo(value, metric[keyMetricValue])),
-      color: isLight ? colorsLight[index] : colorsDark[index],
-      isVisible: true,
-      originalColor: isLight ? colorsLight[index] : colorsDark[index],
-    };
-  });
+  const doughnutSeriesData: DoughnutSeries[] = useMemo(() => {
+    const colorAssigner = new LimitedColorAssigner(
+      Object.keys(budgetMetrics).length,
+      isLight ? existingColors : existingColorsDark
+    );
+
+    return Object.keys(budgetMetrics)
+      .sort()
+      .map((item) => {
+        let value;
+        switch (selectedMetric) {
+          case 'Actuals':
+            value = budgetMetrics[item].actuals.value || 0;
+            break;
+          case 'Forecast':
+            value = budgetMetrics[item].forecast.value || 0;
+            break;
+          case 'PaymentsOnChain':
+            value = budgetMetrics[item].paymentsOnChain.value || 0;
+            break;
+          case 'ProtocolNetOutflow':
+            value = budgetMetrics[item].protocolNetOutflow.value || 0;
+            break;
+          case 'Budget':
+            value = budgetMetrics[item].budget.value || 0;
+            break;
+          default:
+            value = budgetMetrics[item].budget.value || 0;
+            break;
+        }
+        const keyMetricValue = getCorrectMetricValuesOverViewChart(selectedMetric);
+        return {
+          name: removeBudgetWord(budgetMetrics[item].name),
+          code: budgetMetrics[item].code,
+          value,
+          originalValue: value,
+          actuals: budgetMetrics[item].actuals.value,
+          budgetCap: budgetMetrics[item].budget.value,
+          percent: Math.round(percentageRespectTo(value, metric[keyMetricValue])),
+          color: colorAssigner.getColor(item),
+          isVisible: true,
+          originalColor: colorAssigner.getColor(item),
+        };
+      });
+  }, [budgetMetrics, isLight, metric, selectedMetric]);
 
   // Check some value affect the total 100%
   const totalPercent = doughnutSeriesData.reduce((acc, curr) => acc + curr.percent, 0);


### PR DESCRIPTION
## Ticket
https://trello.com/c/FnTQ74C9/348-bsn-1-general-issues-v1

## Description
use the same way to assign colors on the legend of the doughnut chart and the breakdown chart

## What solved
- [X] The pie chart legend should match the breakdown chart legend, including the colors. **Current Output:**  The pie chart legend displays the MakerDAO Legacy budget in green color but the breakdown chart displays it in orange color. 
