### PR TITLE
Change the behavior of borders in the breakdown chart

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -45,7 +45,7 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
   const handleGranularityChange = (value: AnalyticGranularity) => {
     setSelectedGranularity(value);
   };
-  const barBorderRadius = isMobile ? 4 : 6;
+  const barBorderRadius = isMobile ? 2 : 4;
 
   const isDisabled = selectedMetric === 'Budget' && selectedGranularity === 'monthly';
   const handleResetFilterBreakDownChart = () => {

--- a/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
@@ -110,23 +110,25 @@ export const setBorderRadiusForSeries = (
       const isNegative = (s.data[dataIndex].value ?? 0) < 0;
 
       if (positiveCount + negativeCount === 1) {
-        // Apply all borders if only one value
-        s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, barBorderRadius, barBorderRadius];
+        // Apply borders to the top or bottom depending of positive or negative
+        s.data[dataIndex].itemStyle.borderRadius = isPositive
+          ? [barBorderRadius, barBorderRadius, 0, 0]
+          : [0, 0, barBorderRadius, barBorderRadius];
       } else if (isPositive && positiveCount === 1) {
-        // Only one positive value, apply all borders
-        s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, barBorderRadius, barBorderRadius];
+        // Only one positive value, apply top borders
+        s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, 0, 0];
       } else if (isPositive && seriesIndex === firstPositiveIndex) {
-        // First positive value bottom borders
-        s.data[dataIndex].itemStyle.borderRadius = [0, 0, barBorderRadius, barBorderRadius];
+        // First positive value not bottom borders
+        s.data[dataIndex].itemStyle.borderRadius = [0, 0, 0, 0];
       } else if (isPositive && seriesIndex === lastPositiveIndex) {
         // Last positive value top borders
         s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, 0, 0];
       } else if (isNegative && negativeCount === 1) {
-        // Only one negative value, apply all borders
-        s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, barBorderRadius, barBorderRadius];
+        // Only one negative value, apply bottom borders
+        s.data[dataIndex].itemStyle.borderRadius = [0, 0, barBorderRadius, barBorderRadius];
       } else if (isNegative && seriesIndex === firstNegativeIndex) {
-        // First negative value, top edges (inverted due to negative nature)
-        s.data[dataIndex].itemStyle.borderRadius = [barBorderRadius, barBorderRadius, 0, 0];
+        // First negative value, bottom borders zero
+        s.data[dataIndex].itemStyle.borderRadius = [0, 0, 0, 0];
       } else if (isNegative && seriesIndex === lastNegativeIndex) {
         // Last negative value, bottom edges (inverted)
         s.data[dataIndex].itemStyle.borderRadius = [0, 0, barBorderRadius, barBorderRadius];


### PR DESCRIPTION
## Ticket
https://trello.com/c/L3OMliKC/338-qa-issues-bug-findings-fusion-v1

## Description
Remove the borders from the bottom of each bars, and add only to the top, its in negative or positive values

## What solved
- [X] -Finances->MakerDAO Legacy Budget-Breakdown Chart section: https://expenses-dev.makerdao.network/finances/legacy?year=2023. Metric: Net Expenses On-chain. **Expected Output:**  The border radio should be 0 on the bottom of the positive values. Apply this on the top for the negative numbers, **Current Output:** SPFs sub-category has a negative value in Aug month but the bar is not represented. ** 

## Screenshots (if apply)
