### PR TITLE
Negative values on doughnut chart

### DIFF
--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -133,7 +133,11 @@ const DoughnutChartFinances: React.FC<Props> = ({
               show: false,
             },
           },
-          data: visibleSeries,
+          data: visibleSeries.map((data) => ({
+            ...data,
+            // transform negative values to positive to avoid hidden values on the chart
+            value: Math.abs(data.value),
+          })),
         },
       ],
     }),

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
@@ -25,7 +25,7 @@ const ItemLegendDoughnut: React.FC<Props> = ({
   toggleSeriesVisibility,
 }) => {
   const { isLight } = useThemeContext();
-  const valueRounded = threeDigitsPrecisionHumanization(doughnutData?.value);
+  const valueRounded = threeDigitsPrecisionHumanization(doughnutData?.value, true);
   return (
     <LegendItem
       key={doughnutData.name}

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -150,7 +150,7 @@ export const useCardChartOverview = (
         metric.actuals += budgetMetric[0].actuals.value || 0;
         metric.forecast += budgetMetric[0].forecast.value || 0;
         metric.budget += budgetMetric[0].budget.value || 0;
-        metric.paymentsOnChain += budgetMetric[0].paymentsOnChain.value || 0;
+        metric.paymentsOnChain += Math.abs(budgetMetric[0].paymentsOnChain.value || 0);
         metric.protocolNetOutflow += budgetMetric[0].protocolNetOutflow.value || 0;
         budgetMetrics[budgetMetricKey] = {
           name: budgetName,
@@ -192,6 +192,7 @@ export const useCardChartOverview = (
             value = budgetMetrics[item].forecast.value || 0;
             break;
           case 'PaymentsOnChain':
+            // todo: if we use absolute values, then the legend is positive too which is wrong
             value = budgetMetrics[item].paymentsOnChain.value || 0;
             break;
           case 'ProtocolNetOutflow':
@@ -212,7 +213,7 @@ export const useCardChartOverview = (
           originalValue: value,
           actuals: budgetMetrics[item].actuals.value,
           budgetCap: budgetMetrics[item].budget.value,
-          percent: Math.round(percentageRespectTo(value, metric[keyMetricValue])),
+          percent: Math.round(percentageRespectTo(Math.abs(value), metric[keyMetricValue])),
           color: colorAssigner.getColor(item),
           isVisible: true,
           originalColor: colorAssigner.getColor(item),

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -192,7 +192,6 @@ export const useCardChartOverview = (
             value = budgetMetrics[item].forecast.value || 0;
             break;
           case 'PaymentsOnChain':
-            // todo: if we use absolute values, then the legend is positive too which is wrong
             value = budgetMetrics[item].paymentsOnChain.value || 0;
             break;
           case 'ProtocolNetOutflow':


### PR DESCRIPTION
## Ticket
https://trello.com/c/QJJf80oe/362-change-requests-sprint-review-v2

## Description
Allow to display "negative" values on the doughnut chart

## What solved
- [X] Pie chart: Add the negative value representation. Use absolute numbers and indicate the negative values with a (-) sign.
