### PR TITLE
[BUG-366] Take the zone from the time zone client

### DIFF
--- a/pages/core-unit/[code]/finances/reports/index.tsx
+++ b/pages/core-unit/[code]/finances/reports/index.tsx
@@ -85,9 +85,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       expenseCategories,
       snapshotLimitPeriods: snapshotLimitPeriods
         ? {
-            // serialize the date objects to ISO strings
-            earliest: snapshotLimitPeriods.earliest.toISO(),
-            latest: snapshotLimitPeriods.latest.toISO(),
+            earliest: snapshotLimitPeriods.earliest,
+            latest: snapshotLimitPeriods.latest,
           }
         : null,
     },

--- a/pages/ecosystem-actors/[code]/finances/reports/index.tsx
+++ b/pages/ecosystem-actors/[code]/finances/reports/index.tsx
@@ -81,9 +81,8 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
       expenseCategories,
       snapshotLimitPeriods: snapshotLimitPeriods
         ? {
-            // serialize the date objects to ISO strings
-            earliest: snapshotLimitPeriods.earliest.toISO(),
-            latest: snapshotLimitPeriods.latest.toISO(),
+            earliest: snapshotLimitPeriods.earliest,
+            latest: snapshotLimitPeriods.latest,
           }
         : null,
     },

--- a/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
+++ b/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
@@ -135,6 +135,7 @@ export const getLastSnapshotPeriod = async (
   ownerId: string,
   resourceType: ResourceType
 ): Promise<SnapshotLimitPeriods | undefined> => {
+  const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const { query, filter } = snapshotPeriodQuery(ownerId, resourceType);
   const data = await request<{ snapshots: [{ period: string }] }>(GRAPHQL_ENDPOINT, query, filter);
 
@@ -144,7 +145,7 @@ export const getLastSnapshotPeriod = async (
 
   const periods = data.snapshots.map((snapshot) =>
     DateTime.fromFormat(snapshot.period, 'yyyy/MM', {
-      zone: 'UTC',
+      zone: userTimeZone,
     })
   );
   return {

--- a/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
+++ b/src/stories/containers/TransparencyReport/transparencyReportAPI.ts
@@ -1,7 +1,6 @@
 import { GRAPHQL_ENDPOINT } from '@ses/config/endpoints';
 import request, { gql } from 'graphql-request';
 import { DateTime } from 'luxon';
-import type { SnapshotLimitPeriods } from '@ses/core/hooks/useBudgetStatementPager';
 import type { ResourceType } from '@ses/core/models/interfaces/types';
 
 export const CORE_UNIT_REQUEST = (shortCode: string) => ({
@@ -131,11 +130,15 @@ export const snapshotPeriodQuery = (ownerId: string, resourceType: ResourceType)
   },
 });
 
+export interface SnapshotLimitPeriodsString {
+  earliest: string;
+  latest: string;
+}
+
 export const getLastSnapshotPeriod = async (
   ownerId: string,
   resourceType: ResourceType
-): Promise<SnapshotLimitPeriods | undefined> => {
-  const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+): Promise<SnapshotLimitPeriodsString | undefined> => {
   const { query, filter } = snapshotPeriodQuery(ownerId, resourceType);
   const data = await request<{ snapshots: [{ period: string }] }>(GRAPHQL_ENDPOINT, query, filter);
 
@@ -145,11 +148,12 @@ export const getLastSnapshotPeriod = async (
 
   const periods = data.snapshots.map((snapshot) =>
     DateTime.fromFormat(snapshot.period, 'yyyy/MM', {
-      zone: userTimeZone,
+      zone: 'UTC',
     })
   );
   return {
-    earliest: DateTime.min(...periods),
-    latest: DateTime.max(...periods),
+    // serialize the date objects to ISO strings
+    earliest: DateTime.min(...periods).toISO(),
+    latest: DateTime.max(...periods).toISO(),
   };
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/wxhA1BDB/366-bug-no-access-to-march-2024-in-the-ecosystem-actors-expense-reports

## Description
Should allow navigating through to March 2024.

## What solved
- [X] Should allow navigating through to March 2024.

## Screenshots (if apply)
