### PR TITLE
[ETA-21] Remove the 960 max-with in ecosystem actor profile

### DIFF
--- a/src/stories/containers/ActorsAbout/components/ActorSummary/ActorTitleAbout.tsx
+++ b/src/stories/containers/ActorsAbout/components/ActorSummary/ActorTitleAbout.tsx
@@ -483,4 +483,10 @@ const SocialMediaComponentStyled = styled(SocialMediaComponent)<WithIsLight & { 
 const Status = styled.div({
   marginLeft: 14,
   marginTop: -1,
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    marginLeft: 4,
+  },
+  [lightTheme.breakpoints.up('desktop_1024')]: {
+    marginLeft: 0,
+  },
 });

--- a/src/stories/containers/ActorsAbout/components/ActorSummary/ActorTitleWithDescription.tsx
+++ b/src/stories/containers/ActorsAbout/components/ActorSummary/ActorTitleWithDescription.tsx
@@ -53,14 +53,15 @@ const ContainerTitle = styled.div({
   [lightTheme.breakpoints.up('desktop_1024')]: {
     marginLeft: 'auto',
     marginRight: 'auto',
-    paddingLeft: 0,
-    paddingRight: 0,
-    maxWidth: 960,
+    paddingLeft: 32,
+    paddingRight: 32,
   },
 
   [lightTheme.breakpoints.up('desktop_1280')]: {
     maxWidth: 1184,
     margin: '0 auto',
+    paddingLeft: 0,
+    paddingRight: 0,
   },
   [lightTheme.breakpoints.up('desktop_1440')]: {
     margin: '0 auto',


### PR DESCRIPTION
## Ticket
https://trello.com/c/3EWKzArO/343-user-story-eat-21-ecosystem-actors-short-code

## Description
Fix the aligned  the header with the body

## What solved
- [X]  The header should be aligned with the body's text and the breadcrumb. **Current Output:** The header is displayed with a big left margin is displayed 

## Screenshots (if apply)
