### PR TITLE
Hide zero value son the breakdown chart

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/utils.ts
@@ -81,7 +81,8 @@ export const setBorderRadiusForSeries = (
 
     // Identify first and last indices for positive and negative values
     series.forEach((s, seriesIndex) => {
-      const value = s.data[dataIndex].value ?? 0;
+      let value = s.data[dataIndex].value ?? 0;
+      value = Math.abs(value) < 0.004 ? 0 : value; // if the values es too small, consider it as 0
       if (value > 0) {
         if (firstPositiveIndex === -1) firstPositiveIndex = seriesIndex;
         lastPositiveIndex = seriesIndex;

--- a/src/stories/containers/Finances/utils/chartTooltip.ts
+++ b/src/stories/containers/Finances/utils/chartTooltip.ts
@@ -61,7 +61,7 @@ export const createChartTooltip = (
     if (params.every((item) => item.value === 0)) {
       return '';
     }
-    const filteredParams = !isShowZeroValues ? params : params.filter((item) => item.value !== 0);
+    const filteredParams = !isShowZeroValues ? params : params.filter((item) => item.value !== 0 && item.value > 0.004);
 
     const shortAmount = params.length > 10;
     const flexDirection = shortAmount ? 'row' : 'column';


### PR DESCRIPTION
## Ticket
https://trello.com/c/fsngl7GB/364-finances-view-general-issues-v2

## Description
Hide close to 0 values on the breakdown chart

## What solved
- [X] Finances. Breakdown Chart section. Metric: Net Expenses On-chain- ** **Expected Output:** The tooltip should show only the metrics with a value >0.  **Current Output:**  The March 2023 column shows the bar with straight borders and the tooltip reflects the Scope Framework metric with a value = 0. 
