### PR TITLE
Fix Metric label on tablet

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -29,6 +29,7 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
 }) => {
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
+  const isTablet = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
   const colorButton = isLight ? (isDisabled ? '#ECEFF9' : '#231536') : isDisabled ? '#48495F' : '#D4D9E1';
   const metricItems: SelectItem<AnalyticMetric>[] = [
     {
@@ -45,7 +46,7 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
       labelWhenSelected: isMobile ? 'Prtcol Outfl' : 'Protocol Outflow',
     },
     {
-      label: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',
+      label: isMobile ? 'Net Exp. On-Chain' : isTablet ? 'Net On-Chain' : 'Net Expenses On-chain',
       value: 'PaymentsOnChain',
       labelWhenSelected: 'Net On-chain',
     },


### PR DESCRIPTION
## Ticket
https://trello.com/c/fsngl7GB/364-finances-view-general-issues-v2

## Description
Make the label of the metric selected on the breakdown chart shorter

## What solved
- [X] Breakdown Chart section. Metrics: Net Expenses On-chain and Net Protocol Outflow. **Expected Output:**  The dropdown should show the defined dimensions. **Current Output:** The label is displayed in two lines, so the dropdown changes its dimension.
