### PR TITLE
Fix expense reports metric label

### DIFF
--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
@@ -69,6 +69,16 @@ const DelegateExpenseTrendItem: React.FC<Props> = ({ budget, selectedMetric, now
     return NaN;
   }, [budget, selectedMetric]);
 
+  const metricLabel = useMemo(() => {
+    switch (selectedMetric) {
+      case 'PaymentsOnChain':
+        return 'Net On-Chain';
+      case 'ProtocolNetOutflow':
+        return 'Protocol Outflow';
+    }
+    return selectedMetric;
+  }, [selectedMetric]);
+
   const elementInDesk = (
     <ContainerInside isLight={isLight}>
       <ContainerDesk>
@@ -104,7 +114,7 @@ const DelegateExpenseTrendItem: React.FC<Props> = ({ budget, selectedMetric, now
           <Date isLight={isLight}>{reportMonth}</Date>
         </ReportingMonth>
         <TotalActualsTable>
-          <LabelDescription isLight={isLight}>{selectedMetric}</LabelDescription>
+          <LabelDescription isLight={isLight}>{metricLabel}</LabelDescription>
           <TotalNumber isLight={isLight}>{usLocalizedNumber(value)} DAI</TotalNumber>
         </TotalActualsTable>
         <ContainerStatusTable>
@@ -133,7 +143,7 @@ const DelegateExpenseTrendItem: React.FC<Props> = ({ budget, selectedMetric, now
         </ContainerReportingMobile>
 
         <TotalContainerMobile>
-          <Total isLight={isLight}>{selectedMetric}</Total>
+          <Total isLight={isLight}>{metricLabel}</Total>
           <TotalNumber isLight={isLight}>{usLocalizedNumber(value)} DAI</TotalNumber>
         </TotalContainerMobile>
       </ContainerCardMobile>


### PR DESCRIPTION
## Ticket
https://trello.com/c/fsngl7GB/364-finances-view-general-issues-v2

## Description
Fixed the metric label on small resolutions
## What solved
- [X] Expense Reports section. Metric: Net Protocol Outflow. **Expected Output:**  The name displayed in the table should be similar to the filter's label as much as possible. **Current Output:** The filter's label displays Net Protocol Outflow but in the table, it refers to Protocol Net Outflow.  The text is too close to the Status label.
