### PR TITLE
Fix categories field width on waterfall chart section

### DIFF
--- a/src/stories/containers/Finances/components/ReservesWaterfallFilters/ReservesWaterfallFilters.tsx
+++ b/src/stories/containers/Finances/components/ReservesWaterfallFilters/ReservesWaterfallFilters.tsx
@@ -173,13 +173,11 @@ const CustomMultiSelectStyled = styled(CustomMultiSelect)<{ isTextCut: boolean }
   },
   [lightTheme.breakpoints.up('tablet_768')]: {
     ...(isTextCut && {
-      '& > div': {
-        '& > div:first-of-type': {
-          width: 160,
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-          overflow: ' hidden',
-        },
+      '& > div:first-of-type > div:first-of-type': {
+        maxWidth: 160,
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        overflow: ' hidden',
       },
     }),
   },


### PR DESCRIPTION
## Ticket
https://trello.com/c/fsngl7GB/364-finances-view-general-issues-v2

## Description
Fix width of the categories field on the waterfall chart

## What solved
- [X] Reserves Chart section. https://expenses-dev.makerdao.network/finances/legacy/scopes?year=2023.  **Expected Output:**  The All categories filter's label should be displayed with the proper container. **Current Output:** The filter displays a big gap between the label and the arrow icon. 
