### PR TITLE
Hide load more when there are no items

### DIFF
--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -155,9 +155,7 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   const [loadMoreCards, setLoadMoreCards] = useState<boolean>(cardsNavigationInformation.length > 6);
   useEffect(() => {
     // update when the levels/budgets change
-    if (cardsNavigationInformation.length > 6) {
-      setLoadMoreCards(true);
-    }
+    setLoadMoreCards(cardsNavigationInformation.length > 6);
   }, [cardsNavigationInformation.length]);
   const handleLoadMoreCards = () => {
     setLoadMoreCards(!loadMoreCards);


### PR DESCRIPTION
## Ticket
https://trello.com/c/fsngl7GB/364-finances-view-general-issues-v2

## Description
Hide the load more button on levels where there are not items as it was showing up

## What solved
- [X]  MakerDAO Legacy Budget-> Core Units->Risk. Navigation card section: https://expenses-dev.makerdao.network/finances/legacy/core-units/RISK-001?year=2023&period=Annually&metric=Budget&metric=Forecast&metric=Net%20Protocol%20Outflow#breakdown-table.   **Expected Output:**  The Load More option should be visible only if there are more than 6 cards.**Current Output:** The option is visible even if there are no cards to show. 
