### PR TITLE
Change the text in the Finances page for the last session

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReports.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReports.tsx
@@ -40,7 +40,7 @@ const ExpenseReports: React.FC<Props> = ({
     <Container>
       <HeaderContainer>
         <SectionTitle
-          title="Expense Reports"
+          title="Budget Statement"
           tooltip="Explore the latest expense reports in a customizable table with options to filter by status  and selected financial metrics."
         />
         <ExpenseReportsFilters {...filterProps} />


### PR DESCRIPTION
## Ticket
https://trello.com/c/QJJf80oe/362-change-requests-sprint-review-v2

## Description
Change the name of the last session of the finances page to budget statement 

## What solved
- [X] Finances view:  change expense reports --> budget statement for all budget levels. [image.png]

## Screenshots (if apply)
