### PR TITLE
Add the same behavior when one element its select for the delegate

### DIFF
--- a/src/core/utils/filters.ts
+++ b/src/core/utils/filters.ts
@@ -1,5 +1,6 @@
 import { getStatusMip39AcceptedOrObsolete } from '../businessLogic/coreUnits';
 import type { CoreUnit } from '../models/interfaces/coreUnit';
+import type { MultiSelectItem } from '@ses/components/CustomMultiSelect/CustomMultiSelect';
 import type { ParsedUrlQuery } from 'querystring';
 
 const filterStatus = (lowerCaseStatuses: string[], data: CoreUnit) =>
@@ -77,4 +78,25 @@ export const getArrayParam = (key: string, urlSearchParams: ParsedUrlQuery) => {
 export const getStringParam = (key: string, urlSearchParams: ParsedUrlQuery) => {
   if (!urlSearchParams) return '';
   return (urlSearchParams[`${key}`] as string) || '';
+};
+
+export const getLabelMultiselectFilters = (
+  items: MultiSelectItem[],
+  activeItems: string[],
+  isMobile: boolean,
+  label: string
+) => {
+  // Determine single active item label for mobile and non-mobile
+  const singleActiveItemLabel =
+    activeItems.length === 1 ? items.find((item) => item.id === activeItems[0])?.content : null;
+
+  if (isMobile) {
+    return activeItems.length === 1 ? `${label} (${activeItems.length})` : `${label}`;
+  } else {
+    return items.length === activeItems.length
+      ? `All ${label}`
+      : activeItems.length === 1 && singleActiveItemLabel
+      ? singleActiveItemLabel
+      : `${label}`;
+  }
 };

--- a/src/stories/containers/Finances/components/ReservesWaterfallFilters/ReservesWaterfallFilters.tsx
+++ b/src/stories/containers/Finances/components/ReservesWaterfallFilters/ReservesWaterfallFilters.tsx
@@ -4,6 +4,7 @@ import { CustomMultiSelect } from '@ses/components/CustomMultiSelect/CustomMulti
 import ResetButton from '@ses/components/ResetButton/ResetButton';
 import ResponsiveButtonClearFilter from '@ses/components/ResponsiveButtonClearFilter/ResponsiveButtonClearFilter';
 import SingleItemSelect from '@ses/components/SingleItemSelect/SingleItemSelect';
+import { getLabelMultiselectFilters } from '@ses/core/utils/filters';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import SectionTitle from '../SectionTitle/SectionTitle';
@@ -35,19 +36,9 @@ const ReservesWaterfallFilters: React.FC<FiltersProps> = ({
   title,
 }) => {
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
-  // Show name if only one element its active
-  const singleActiveItemLabel =
-    activeItems.length === 1 ? items.find((item) => item.id === activeItems[0])?.content : null;
 
-  const label = isMobile
-    ? activeItems.length === 1
-      ? `Categories (${activeItems.length})`
-      : 'Categories'
-    : items.length === activeItems.length
-    ? 'All Categories'
-    : activeItems.length === 1 && singleActiveItemLabel
-    ? singleActiveItemLabel
-    : 'Categories';
+  const label = getLabelMultiselectFilters(items, activeItems, isMobile, 'Categories');
+
   return (
     <ContainerFilterTitle>
       <SectionTitle

--- a/src/stories/containers/RecognizedDelegates/components/FilterDelegate/FilterDelegate.tsx
+++ b/src/stories/containers/RecognizedDelegates/components/FilterDelegate/FilterDelegate.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
 
+import { useMediaQuery } from '@mui/material';
 import { CustomMultiSelect } from '@ses/components/CustomMultiSelect/CustomMultiSelect';
 import ResetButton from '@ses/components/ResetButton/ResetButton';
 import { Close } from '@ses/components/svg/close';
 
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 
+import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import DelegateSelectItem from './DelegateSelectItem';
 import type { SelectItemProps, MultiSelectItem } from '@ses/components/CustomMultiSelect/CustomMultiSelect';
@@ -19,6 +21,7 @@ interface Props {
 }
 
 const FilterDelegate: React.FC<Props> = ({ items, activeItems, handleSelectChange, handleResetFilter }) => {
+  const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const { isLight } = useThemeContext();
   const isEnable = isLight
     ? activeItems.length > 0
@@ -27,6 +30,20 @@ const FilterDelegate: React.FC<Props> = ({ items, activeItems, handleSelectChang
     : activeItems.length > 0
     ? '#D2D4EF'
     : '#48495F';
+
+  // Show name if only one element its active
+  const singleActiveItemLabel =
+    activeItems.length === 1 ? items.find((item) => item.id === activeItems[0])?.content : null;
+
+  const label = isMobile
+    ? activeItems.length === 1
+      ? `Recognized Delegates (${activeItems.length})`
+      : 'Recognized Delegates'
+    : items.length === activeItems.length
+    ? 'All Recognized Delegates'
+    : activeItems.length === 1 && singleActiveItemLabel
+    ? singleActiveItemLabel
+    : 'Recognized Delegates';
 
   return (
     <FiltersContainer>
@@ -41,15 +58,15 @@ const FilterDelegate: React.FC<Props> = ({ items, activeItems, handleSelectChang
       <FilterDelegatesContainer>
         <CustomMultiSelect
           positionRight={true}
-          label="Recognized Delegates"
+          label={label as string}
           activeItems={activeItems}
           items={items}
-          width={224}
           onChange={(value: string[]) => {
             handleSelectChange(value);
           }}
           withAll
           popupContainerWidth={343}
+          showMetricOneItemSelect
           listItemWidth={311}
           customAll={{
             content: 'All Recognized Delegates',

--- a/src/stories/containers/RecognizedDelegates/components/FilterDelegate/FilterDelegate.tsx
+++ b/src/stories/containers/RecognizedDelegates/components/FilterDelegate/FilterDelegate.tsx
@@ -7,6 +7,7 @@ import { Close } from '@ses/components/svg/close';
 
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 
+import { getLabelMultiselectFilters } from '@ses/core/utils/filters';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import DelegateSelectItem from './DelegateSelectItem';
@@ -31,20 +32,7 @@ const FilterDelegate: React.FC<Props> = ({ items, activeItems, handleSelectChang
     ? '#D2D4EF'
     : '#48495F';
 
-  // Show name if only one element its active
-  const singleActiveItemLabel =
-    activeItems.length === 1 ? items.find((item) => item.id === activeItems[0])?.content : null;
-
-  const label = isMobile
-    ? activeItems.length === 1
-      ? `Recognized Delegates (${activeItems.length})`
-      : 'Recognized Delegates'
-    : items.length === activeItems.length
-    ? 'All Recognized Delegates'
-    : activeItems.length === 1 && singleActiveItemLabel
-    ? singleActiveItemLabel
-    : 'Recognized Delegates';
-
+  const label = getLabelMultiselectFilters(items, activeItems, isMobile, 'Recognized Delegates');
   return (
     <FiltersContainer>
       <Reset>


### PR DESCRIPTION

## Ticket
https://trello.com/c/fpeJV0Lo/354-qa-issues-bug-findings-fusion-v2

## Description
Add the same behavior for filter in delegate page as multi select filter in the finances page

## What solved
Recognized delegates filter: spell out the name of the RD if only one RD is selected.[image.png](https://trello.com/1/cards/65fd33949f2746e5c61b515c/attachments/660bad621c332f8bfd2f8fdb/previews/660bad621c332f8bfd2f9107/download/image.png)

## Screenshots (if apply)
