### PR TITLE
Fix ecosystem actors budget pager

### DIFF
--- a/pages/ecosystem-actors/[code]/finances/reports/index.tsx
+++ b/pages/ecosystem-actors/[code]/finances/reports/index.tsx
@@ -37,8 +37,8 @@ const EcosystemActorsTransparencyReportingPage: NextPage = ({
           snapshotLimitPeriods
             ? {
                 // deserialize the ISO strings to date objects
-                earliest: DateTime.fromISO(snapshotLimitPeriods.earliest),
-                latest: DateTime.fromISO(snapshotLimitPeriods.latest),
+                earliest: DateTime.fromISO(snapshotLimitPeriods.earliest).toUTC(),
+                latest: DateTime.fromISO(snapshotLimitPeriods.latest).toUTC(),
               }
             : undefined
         }


### PR DESCRIPTION
## Ticket
https://trello.com/c/wxhA1BDB/366-bug-no-access-to-march-2024-in-the-ecosystem-actors-expense-reports

## Description
Changed date to UTC

## What solved
- [X] Should allow navigating through to March 2024.
