### PR TITLE
Fix negative values at the end and check dark mode status

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -77,7 +77,7 @@ export const builderWaterfallSeries = (
     {
       name: 'Reserves Balance',
       barWidth: isMobile ? 19 : isTable ? 39 : 48,
-      data: help,
+      data: help.map((item) => (Math.abs(item) < UMBRAL_CHART_WATERFALL ? 0 : item)),
       emphasis: {
         disabled: true,
       },


### PR DESCRIPTION
## Ticket
https://trello.com/c/TJJadCh4/345-user-story-eat-22-ecosystem-actors-status-indication

## Description
Fix small values waterfall chart

## What solved
- [x] Should implement the Dark mode.
- [X] Finances-> MakerDAO Legacy Budget-> Core Units->IS-001. Expense Reports section: https://expenses-dev.makerdao.network/finances/legacy/core-units/IS-001?year=2023.   **Expected Output:**  When the values are = 0, the number 0 should not be displayed. **Current Output:** The Finish 2023 column displays a value = -0.0130.

## Screenshots (if apply)
