### PR TITLE
Correct the name in the last session finances page

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReports.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReports.tsx
@@ -40,7 +40,7 @@ const ExpenseReports: React.FC<Props> = ({
     <Container>
       <HeaderContainer>
         <SectionTitle
-          title="Budget Statement"
+          title="Budget Statements"
           tooltip="Explore the latest expense reports in a customizable table with options to filter by status  and selected financial metrics."
         />
         <ExpenseReportsFilters {...filterProps} />


### PR DESCRIPTION
## Ticket
https://trello.com/c/QJJf80oe/362-change-requests-sprint-review-v2

## Description
Add the 's' to the title  in the Budget Statement section

## What solved
- [X]Finances View: Add the 's' to the Budget Statement section title.

## Screenshots (if apply)
