### PR TITLE
[GI-364] Add absolute value to fix the negative values

### DIFF
--- a/src/stories/containers/Finances/utils/chartTooltip.ts
+++ b/src/stories/containers/Finances/utils/chartTooltip.ts
@@ -61,7 +61,9 @@ export const createChartTooltip = (
     if (params.every((item) => item.value === 0)) {
       return '';
     }
-    const filteredParams = !isShowZeroValues ? params : params.filter((item) => item.value !== 0 && item.value > 0.004);
+    const filteredParams = !isShowZeroValues
+      ? params
+      : params.filter((item) => item.value !== 0 && Math.abs(item.value) > 0.004);
 
     const shortAmount = params.length > 10;
     const flexDirection = shortAmount ? 'row' : 'column';


### PR DESCRIPTION
## Ticket
https://trello.com/c/fsngl7GB/364-finances-view-general-issues-v2

## Description
Allow negative values in the tooltip

## What solved
- [X] Finances view, Breakdown Chart section. Metric: Net Expenses On-chain.  **Expected Output:** The tooltip should show the values > 0 and values < 0.  **Current Output:** The tooltip is not showing the negative numbers. 

## Screenshots (if apply)
