### PR TITLE
[GI-364] Add function to verify scientific notation

### DIFF
--- a/src/core/utils/humanization.ts
+++ b/src/core/utils/humanization.ts
@@ -2,26 +2,36 @@ export type HumanizedNumber = {
   value: string;
   suffix: string;
 };
-
-export const threeDigitsPrecisionHumanization = (num = 0, isHasAbsoluteValue = false): HumanizedNumber => {
+export const formatValueScientificNotation = (value: number) => {
+  const precisionValue = value.toPrecision(3);
+  if (precisionValue.includes('e')) {
+    // To avoid scientific notation, we use toFixed
+    return parseFloat(precisionValue).toFixed(0);
+  }
+  return precisionValue;
+};
+export const threeDigitsPrecisionHumanization = (num = 0, isHasAbsoluteValue = false) => {
   const absNum = isHasAbsoluteValue ? Math.abs(num) : num;
+  let value, suffix;
 
   if (absNum >= 1000000) {
-    return {
-      value: (num / 1000000).toPrecision(3),
-      suffix: 'M',
-    };
+    value = num / 1000000;
+    suffix = 'M';
   } else if (absNum >= 1000) {
-    return {
-      value: (num / 1000).toPrecision(3),
-      suffix: 'K',
-    };
+    value = num / 1000;
+    suffix = 'K';
   } else {
-    return {
-      value: num.toPrecision(3),
-      suffix: '',
-    };
+    value = num;
+    suffix = '';
   }
+
+  // Formatter values for scientific notation
+  const formattedValue = formatValueScientificNotation(value);
+
+  return {
+    value: formattedValue,
+    suffix,
+  };
 };
 
 export const usLocalizedNumber = (num: number, decimalPlace = 0): string => {


### PR DESCRIPTION
## Ticket
<!--- Your Ticket Link -->

## Description
Avoid the scientific notation add by toPrecision method to add format for the waterfall chart

## What solved
- [X] Finances-> Scope Framework Budget-> Support Scope->atlas/scopes/SUP/incubation/AAVE-00->atlas/scopes/SUP/incubation/AAVE-001. Reserves Chart section: https://expenses-dev.makerdao.network/finances/scopes/SUP/incubation/AAVE-001?year=2023. **Expected Output:**  The December column should display a −1000000 value.  **Current Output:** The column displays -100e+3K. 

## Screenshots (if apply)
