### PR TITLE
[QA] Limit breakdown table rows

### DIFF
--- a/src/core/utils/const.ts
+++ b/src/core/utils/const.ts
@@ -15,5 +15,4 @@ export const COOKIES_POLICY_PARAGRAPH_FOUR =
 
 export const LOCAL_STORAGE_AUTH_KEY = 'auth';
 export const DELEGATE_PAGE = 'https://vote.makerdao.com/delegates';
-export const MAX_ROWS_FINANCES_TABLE = 16;
 export const UMBRAL_CHART_WATERFALL = 1;

--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -6,7 +6,6 @@ import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
 import Link from 'next/link';
 import React from 'react';
-import { showOnlySixteenRowsWithOthers, sortTablesByRows } from '../../utils/utils';
 import { defaultOrder, orderMetrics } from '../HeaderTable/utils';
 import LinkCellComponent from '../LinkCellComponent/LinkCellComponent';
 import CellTable from './CellTable';
@@ -23,8 +22,6 @@ interface Props {
 
 const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, period, year }) => {
   const { isLight } = useThemeContext();
-  const orderData = sortTablesByRows(breakdownTable);
-  const showFooterAndCorrectNumber = showOnlySixteenRowsWithOthers(orderData);
   const iteration = period === 'Quarterly' ? 5 : period === 'Monthly' ? 13 : period === 'Annually' ? 1 : 3;
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const desk1440 = useMediaQuery(lightTheme.breakpoints.up('desktop_1024'));
@@ -44,7 +41,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
 
   return (
     <>
-      {showFooterAndCorrectNumber.map((table: TableFinances, index) => (
+      {breakdownTable.map((table: TableFinances, index) => (
         <TableContainer isLight={isLight} className={className} key={index}>
           <TableBody isLight={isLight}>
             {table.rows.map((row: ItemRow, index) => {

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -399,7 +399,40 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
       return acc;
     }, Array.from({ length: columnsCount }, () => ({ ...EMPTY_METRIC_VALUE })) as MetricValues[]);
 
-    return [tableHeader, tables];
+    // limit sub-tables up to 13 rows maximum
+    tables.forEach((table) => {
+      if (table.rows.length > 12) {
+        const rows = table.rows.slice(0, 12);
+        const others = table.rows.slice(12);
+        const othersTotal = others.reduce(
+          (acc, current) => {
+            for (let index = 0; index < current.columns.length; index++) {
+              Object.keys(acc.columns[0]).forEach((key) => {
+                acc.columns[index][key as keyof MetricValues] += current.columns[index][key as keyof MetricValues];
+              });
+            }
+            return acc;
+          },
+          {
+            name: 'Others',
+            isSummaryRow: true,
+            columns: table.rows[0].columns.map(() => ({
+              Actuals: 0,
+              Budget: 0,
+              Forecast: 0,
+              PaymentsOnChain: 0,
+              ProtocolNetOutflow: 0,
+            })),
+          } as ItemRow
+        );
+
+        table.rows = [...rows, othersTotal];
+      }
+    });
+
+    // sort final tables by the amount of rows
+    const sortedTables = tables.sort((a, b) => b.rows.length - a.rows.length);
+    return [tableHeader, sortedTables];
   }, [allBudgets, analytics, budgets, codePath, error, isMobile, lod, selectedGranularity]);
 
   const isLoading = !analytics && !error && (tableHeader === null || tableBody === null);

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -1,17 +1,9 @@
 import { fetchAnalytics } from '@ses/containers/Finances/api/queries';
 import { SortEnum } from '@ses/core/enums/sortEnum';
 import { BudgetStatus, ResourceType } from '@ses/core/models/interfaces/types';
-import { MAX_ROWS_FINANCES_TABLE } from '@ses/core/utils/const';
 import lightTheme from '@ses/styles/theme/light';
 import { DateTime } from 'luxon';
-import type {
-  DelegateExpenseTableHeader,
-  ItemRow,
-  LineChartSeriesData,
-  MetricValues,
-  MomentDataItem,
-  TableFinances,
-} from './types';
+import type { DelegateExpenseTableHeader, LineChartSeriesData, MetricValues, MomentDataItem } from './types';
 import type { ValuesDataWithBorder } from '@ses/core/models/dto/chartDTO';
 import type { ChangeTrackingEvent } from '@ses/core/models/interfaces/activity';
 import type {
@@ -458,85 +450,6 @@ export const ENUM_FOR_STORIES: SortEnum[] = [
   SortEnum.Neutral,
   SortEnum.Neutral,
 ];
-
-export const sortTablesByRows = (data: TableFinances[]) => {
-  if (!data) {
-    return [];
-  }
-  return data.sort((a, b) => b.rows.length - a.rows.length);
-};
-
-export const showOnlySixteenRowsWithOthers = (data: TableFinances[]) => {
-  const totalRows = data.reduce((acc, element) => acc + element.rows.length, 0);
-
-  if (totalRows <= MAX_ROWS_FINANCES_TABLE) {
-    // If the total rows are less than 16, return the data as it is
-    return data;
-  }
-
-  if (data.length > MAX_ROWS_FINANCES_TABLE) {
-    // there are more sub-tables than allowed rows so we return just the headers
-    return data.map((item) => ({
-      tableName: item.tableName,
-      rows: [item.rows[0]],
-      others: false,
-    }));
-  }
-
-  // at this point there are less sub-tables than allowed rows but more rows than allowed
-  const finalSubTables = [] as TableFinances[];
-  let remainingRows = MAX_ROWS_FINANCES_TABLE - data.length; // we already take in count the headers
-  for (const subTable of data) {
-    const finalSubTable = {
-      ...subTable,
-      rows: [subTable.rows[0]], // header
-    };
-
-    if (remainingRows === 0) {
-      // we already have the maximum number of rows
-      finalSubTables.push(finalSubTable);
-      continue;
-    }
-
-    if (subTable.rows.length - 1 <= remainingRows) {
-      // we can add all the rows
-      finalSubTable.rows.push(...subTable.rows.slice(1));
-      remainingRows -= subTable.rows.length - 1;
-    } else {
-      // we can just add a few rows (we need to reserve space for the "others" row)
-      finalSubTable.rows.push(...subTable.rows.slice(1, remainingRows));
-      // now add the "others" row
-      finalSubTable.rows.push(
-        subTable.rows.slice(remainingRows, subTable.rows.length).reduce(
-          (acc, current) => {
-            for (let index = 0; index < current.columns.length; index++) {
-              Object.keys(acc.columns[0]).forEach((key) => {
-                acc.columns[index][key as keyof MetricValues] += current.columns[index][key as keyof MetricValues];
-              });
-            }
-            return acc;
-          },
-          {
-            name: 'Others',
-            isSummaryRow: true,
-            columns: subTable.rows[0].columns.map(() => ({
-              Actuals: 0,
-              Budget: 0,
-              Forecast: 0,
-              PaymentsOnChain: 0,
-              ProtocolNetOutflow: 0,
-            })),
-          } as ItemRow
-        )
-      );
-      remainingRows = 0;
-    }
-
-    finalSubTables.push(finalSubTable);
-  }
-
-  return finalSubTables;
-};
 
 export const generateColorPalette = (index: number, numColors: number, existingColors: string[] = []) => {
   const baseHue = (index * (360 / numColors)) % 360;


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
Allow max 13 rows per sub table

## What solved
- [X] If there are more than 12 rows, group all additional rows (from the 13th row onwards) under a single line item named "Others". Others =/= Other, the latter is an uncategorized budget, while the former is a grouping of budget line items.  This rule applies to the specific Budget Category within a Breakdown Table and not to the Breakdown Table as a whole. Since currently the "Others" rule is applied to the Breakdown Table as a whole, the rest of the Budget Categories have no children...
