### PR TITLE
[QA] Empty doughnut charts in the last levels

### DIFF
--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -71,7 +71,9 @@ const DoughnutChartFinances: React.FC<Props> = ({
   const numberSlider = doughnutSeriesChunks.size;
   const options = useMemo(
     () => ({
-      color: visibleSeries.map((data) => data.color),
+      color: visibleSeries.map((data) =>
+        doughnutSeriesData.length === 1 && data.value === 0 ? 'rgb(204, 204, 204)' : data.color
+      ),
       tooltip: {
         extraCssText: `z-index:${zIndexEnum.ECHART_TOOL_TIP}`,
         show: true,
@@ -141,7 +143,7 @@ const DoughnutChartFinances: React.FC<Props> = ({
         },
       ],
     }),
-    [center, isLight, radius, visibleSeries]
+    [center, doughnutSeriesData.length, isLight, radius, visibleSeries]
   );
 
   const toggleSeriesVisibility = (seriesName: string) => {

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -167,11 +167,30 @@ export const useCardChartOverview = (
       }
     }
 
+    // if we don't have any data, we need to add a default value to avoid having an empty UI
+    // this mostly happens on leave nodes (last level)
+    if (Object.keys(budgetMetrics).length === 0) {
+      const emptyValue = {
+        unit: 'DAI',
+        value: 0,
+      };
+      budgetMetrics[codePath] = {
+        name: transformPathToName(codePath),
+        actuals: emptyValue,
+        forecast: emptyValue,
+        budget: emptyValue,
+        paymentsOnChain: emptyValue,
+        paymentsOffChainIncluded: emptyValue,
+        protocolNetOutflow: emptyValue,
+        code: transformPathToName(codePath),
+      };
+    }
+
     return {
       metric,
       budgetMetrics,
     };
-  }, [allBudgets, budgets, budgetsAnalytics]);
+  }, [allBudgets, budgets, budgetsAnalytics, codePath]);
 
   const handleSelectedMetric = (metric: AnalyticMetric) => {
     setSelectedMetric(metric);


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
Add empty values on levels where there are not data in the doughnut chart

## What solved
- [X] When there is a single budget entity like NGT NewGov Token or AA AllocatorDAO Axon, make it visible in the donut section. NGT example is showing the correct way. Applicable to all instances of singular budget entities.
- [X] Deepest level: let's make it to the right of the donut, legend icon, gray if there is no value: