### PR TITLE
Hide empty Snapshot Balance

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/reserveUtils.ts
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/utils/reserveUtils.ts
@@ -33,7 +33,10 @@ export const getReserveAccounts = (
             .filter((transaction) => transaction.token === token)
             .sort(transactionSort),
           children: snapshot.snapshotAccount
-            .filter((childrenAccount) => childrenAccount.groupAccountId === account.id)
+            .filter(
+              (childrenAccount) =>
+                childrenAccount.groupAccountId === account.id && childrenAccount.snapshotAccountBalance.length > 0
+            )
             .map((childrenAccount) => ({
               ...childrenAccount,
               snapshotAccountBalance: childrenAccount.snapshotAccountBalance.filter(


### PR DESCRIPTION
## Ticket
https://trello.com/c/s9JOxwZX/368-change-requests-sprint-review-v3

## Description
Hide the empty snapshot balance in the on/off chain reserves of the snapshot accounts

## What solved
- [X] We made a change so that a "SnapshotBalance" entry isn't added if there is no data for a given wallet for a month (no initialBalance / inflow / outflow / newBalance). As such, we want the FE to not show wallets on this view that have NO SnapshotBalance entry. At the minute its showing NaN instead.
