### PR TITLE
[QA-369] Add metric selected to the tooltip

### DIFF
--- a/src/core/utils/string.ts
+++ b/src/core/utils/string.ts
@@ -197,3 +197,8 @@ export const getResourceLabel = (resourceType?: ResourceType): string => {
       return 'Ecosystem Actor';
   }
 };
+
+export const toLowerCaseFirstLetter = (word: string) => {
+  if (!word) return '';
+  return word?.charAt(0).toLocaleLowerCase() + word.slice(1);
+};

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -118,7 +118,7 @@ const DoughnutChartFinances: React.FC<Props> = ({
           <div style="display:flex;flex-direction:row;gap:20px">
               <div style="display:flex;flex-direction:column">
                 <div style="margin-bottom:4;color:${isLight ? '#000' : '#EDEFFF'};">${usLocalizedNumber(
-            itemRender.metrics[selectedMetricKey === 'budget' ? 'paymentsOnChain' : selectedMetricKey].value,
+            itemRender.metrics[selectedMetricKey].value,
             2
           )}</div>
                 <div style="font-weight:bold;color:${isLight ? '#231536' : '#9FAFB9'};">${

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/CardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/CardChartOverview.tsx
@@ -4,6 +4,7 @@ import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import DoughnutChartFinances from '../../OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances';
 import InformationBudgetCapOverview from '../../OverviewCardKeyDetailsBudget/InformationBudgetCapOverView/InformationBudgetCapOverView';
+import { FILTERS } from './utils';
 import type { DoughnutSeries } from '@ses/containers/Finances/utils/types';
 import type { AnalyticMetric } from '@ses/core/models/interfaces/analytic';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -19,32 +20,6 @@ interface Props {
   showSwiper: boolean;
   numberSliderPerLevel?: number;
 }
-
-const FILTERS: {
-  label: string;
-  value: AnalyticMetric;
-}[] = [
-  {
-    label: 'Actuals',
-    value: 'Actuals',
-  },
-  {
-    label: 'Forecast',
-    value: 'Forecast',
-  },
-  {
-    label: 'Net Expenses On-chain',
-    value: 'PaymentsOnChain',
-  },
-  {
-    label: 'Net Protocol Outflow',
-    value: 'ProtocolNetOutflow',
-  },
-  {
-    label: 'Budget',
-    value: 'Budget',
-  },
-];
 
 const CardChartOverview: React.FC<Props> = ({
   selectedMetric,
@@ -89,6 +64,7 @@ const CardChartOverview: React.FC<Props> = ({
               changeAlignment={changeAlignment}
               showSwiper={showSwiper}
               numberSliderPerLevel={numberSliderPerLevel}
+              selectedMetric={selectedMetric}
             />
           </ContainerChat>
         </ContainerCardChart>

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -13,7 +13,6 @@ import { percentageRespectTo } from '@ses/core/utils/math';
 import lightTheme from '@ses/styles/theme/light';
 import { useMemo, useState } from 'react';
 import { removePatternAfterSlash } from '../BreakdownTable/utils';
-import { getCorrectMetricValuesOverViewChart } from './utils';
 import type { BudgetMetricWithName, DoughnutSeries } from '@ses/containers/Finances/utils/types';
 import type { AnalyticMetric, BreakdownBudgetAnalytic } from '@ses/core/models/interfaces/analytic';
 import type { Budget } from '@ses/core/models/interfaces/budget';
@@ -206,42 +205,25 @@ export const useCardChartOverview = (
             value = budgetMetrics[item].budget.value || 0;
             break;
         }
-        const keyMetricValue = getCorrectMetricValuesOverViewChart(selectedMetric);
+
         return {
           name: removeBudgetWord(budgetMetrics[item].name),
           code: budgetMetrics[item].code,
           value,
           originalValue: value,
           actuals: budgetMetrics[item].actuals.value,
+          forecast: budgetMetrics[item].forecast.value,
+          paymentsOnChain: budgetMetrics[item].paymentsOnChain.value,
+          protocolNetOutflow: budgetMetrics[item].protocolNetOutflow.value,
+          budget: budgetMetrics[item].budget.value,
           budgetCap: budgetMetrics[item].budget.value,
-          percent: Math.round(percentageRespectTo(Math.abs(value), metric[keyMetricValue])),
+          percent: Math.round(percentageRespectTo(Math.abs(value), budgetMetrics[item].budget.value)),
           color: colorAssigner.getColor(item),
           isVisible: true,
           originalColor: colorAssigner.getColor(item),
         };
       });
-  }, [budgetMetrics, isLight, metric, selectedMetric]);
-
-  // Check some value affect the total 100%
-  const totalPercent = doughnutSeriesData.reduce((acc, curr) => acc + curr.percent, 0);
-  // Verify that sum of percent its 100% and there its not a 0%
-  if (totalPercent !== 100 && totalPercent !== 0) {
-    const difference = 100 - totalPercent;
-    doughnutSeriesData.forEach((item) => {
-      const adjustment = (item.percent / totalPercent) * difference;
-      item.percent = Math.round(item.percent + adjustment);
-    });
-
-    const checkForPercent = doughnutSeriesData.reduce((acc, curr) => acc + curr.percent, 0);
-    const roundingError = 100 - checkForPercent;
-    if (roundingError !== 0) {
-      const indexToAdjust = doughnutSeriesData.findIndex((item) => item.percent > 0);
-      // Fix the percent with some index in array of values
-      if (indexToAdjust !== -1) {
-        doughnutSeriesData[indexToAdjust].percent += roundingError;
-      }
-    }
-  }
+  }, [budgetMetrics, isLight, selectedMetric]);
 
   const numberItems = doughnutSeriesData.length;
   const changeAlignment = numberItems > 4;

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/utils.ts
@@ -35,3 +35,29 @@ export const getCorrectMetricValuesOverViewChart = (metric: AnalyticMetric) => {
       return 'budget';
   }
 };
+
+export const FILTERS: {
+  label: string;
+  value: AnalyticMetric;
+}[] = [
+  {
+    label: 'Actuals',
+    value: 'Actuals',
+  },
+  {
+    label: 'Forecast',
+    value: 'Forecast',
+  },
+  {
+    label: 'Net Expenses On-chain',
+    value: 'PaymentsOnChain',
+  },
+  {
+    label: 'Net Protocol Outflow',
+    value: 'ProtocolNetOutflow',
+  },
+  {
+    label: 'Budget',
+    value: 'Budget',
+  },
+];

--- a/src/stories/containers/Finances/utils/types.ts
+++ b/src/stories/containers/Finances/utils/types.ts
@@ -22,13 +22,17 @@ export interface DoughnutSeries {
   name: string;
   value: number;
   percent: number;
-  actuals: number;
   budgetCap: number;
   color: string;
   code?: string;
   isVisible?: boolean;
   originalColor?: string;
   originalValue?: number;
+  budget: number;
+  forecast: number;
+  protocolNetOutflow: number;
+  paymentsOnChain: number;
+  actuals: number;
 }
 
 export interface BarChartSeries {


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
Donut hover window should contain the information about the metric selected contrasted with the budget cap

## What solved
- [X] Donut hover window should contain the information about the metric selected contrasted with the budget cap

## Screenshots (if apply)
