### PR TITLE
Fix breakdown chart filters

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -29,7 +29,6 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
 }) => {
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
-  const isTablet = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
   const colorButton = isLight ? (isDisabled ? '#ECEFF9' : '#231536') : isDisabled ? '#48495F' : '#D4D9E1';
   const metricItems: SelectItem<AnalyticMetric>[] = [
     {
@@ -46,7 +45,7 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
       labelWhenSelected: isMobile ? 'Prtcol Outfl' : 'Protocol Outflow',
     },
     {
-      label: isMobile ? 'Net Exp. On-Chain' : isTablet ? 'Net On-Chain' : 'Net Expenses On-chain',
+      label: isMobile ? 'Net Exp. On-Chain' : 'Net Expenses On-chain',
       value: 'PaymentsOnChain',
       labelWhenSelected: 'Net On-chain',
     },
@@ -118,6 +117,7 @@ const FilterContainer = styled.div({
   justifyContent: 'flex-end',
   gap: 16,
   zIndex: 1,
+  marginLeft: 'auto',
 });
 
 const Reset = styled.div({

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
@@ -85,8 +85,10 @@ const HeaderContainer = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   gap: 24,
+
   [lightTheme.breakpoints.up('tablet_768')]: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
   },


### PR DESCRIPTION
## Ticket
https://trello.com/c/ol1mo4dH/371-finances-view-general-issues-v3

## Description
Some metrics don't fit well in the current space of the breakdown chart filters

## What solved
- [X] Breakdown Chart section. Metrics: Net Expenses On-chain and Net Protocol Outflow. **Expected Output:**  The dropdown should show the defined dimensions. **Current Output:** The label is displayed in two lines, so the dropdown changes its dimension
