### PR TITLE
Fix last level doughnut chart color

### DIFF
--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -87,9 +87,7 @@ const DoughnutChartFinances: React.FC<Props> = ({
   const numberSlider = doughnutSeriesChunks.size;
   const options = useMemo(
     () => ({
-      color: visibleSeries.map((data) =>
-        doughnutSeriesData.length === 1 && data.value === 0 ? 'rgb(204, 204, 204)' : data.color
-      ),
+      color: visibleSeries.map((data) => data.color),
       tooltip: {
         extraCssText: `z-index:${zIndexEnum.ECHART_TOOL_TIP}`,
         show: true,
@@ -164,7 +162,7 @@ const DoughnutChartFinances: React.FC<Props> = ({
         },
       ],
     }),
-    [center, doughnutSeriesData.length, isLight, radius, selectedMetric, tooltipSelectedMetricLabel, visibleSeries]
+    [center, isLight, radius, selectedMetric, tooltipSelectedMetricLabel, visibleSeries]
   );
 
   const toggleSeriesVisibility = (seriesName: string) => {

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -201,43 +201,44 @@ export const useCardChartOverview = (
       isLight ? existingColors : existingColorsDark
     );
 
-    return Object.keys(budgetMetrics)
-      .sort()
-      .map((item) => {
-        let value;
-        switch (selectedMetric) {
-          case 'Actuals':
-            value = budgetMetrics[item].actuals.value || 0;
-            break;
-          case 'Forecast':
-            value = budgetMetrics[item].forecast.value || 0;
-            break;
-          case 'PaymentsOnChain':
-            value = budgetMetrics[item].paymentsOnChain.value || 0;
-            break;
-          case 'ProtocolNetOutflow':
-            value = budgetMetrics[item].protocolNetOutflow.value || 0;
-            break;
-          case 'Budget':
-            value = budgetMetrics[item].budget.value || 0;
-            break;
-          default:
-            value = budgetMetrics[item].budget.value || 0;
-            break;
-        }
-        const keyMetricValue = getCorrectMetricValuesOverViewChart(selectedMetric);
-        return {
-          name: removeBudgetWord(budgetMetrics[item].name),
-          code: budgetMetrics[item].code,
-          value,
-          originalValue: value,
-          metrics: budgetMetrics[item],
-          percent: Math.round(percentageRespectTo(Math.abs(value), metric[keyMetricValue])),
-          color: colorAssigner.getColor(item),
-          isVisible: true,
-          originalColor: colorAssigner.getColor(item),
-        };
-      });
+    const keys = Object.keys(budgetMetrics);
+    return keys.sort().map((item) => {
+      let value;
+      switch (selectedMetric) {
+        case 'Actuals':
+          value = budgetMetrics[item].actuals.value || 0;
+          break;
+        case 'Forecast':
+          value = budgetMetrics[item].forecast.value || 0;
+          break;
+        case 'PaymentsOnChain':
+          value = budgetMetrics[item].paymentsOnChain.value || 0;
+          break;
+        case 'ProtocolNetOutflow':
+          value = budgetMetrics[item].protocolNetOutflow.value || 0;
+          break;
+        case 'Budget':
+          value = budgetMetrics[item].budget.value || 0;
+          break;
+        default:
+          value = budgetMetrics[item].budget.value || 0;
+          break;
+      }
+      const keyMetricValue = getCorrectMetricValuesOverViewChart(selectedMetric);
+
+      const color = keys.length === 1 && value === 0 ? 'rgb(204, 204, 204)' : colorAssigner.getColor(item);
+      return {
+        name: removeBudgetWord(budgetMetrics[item].name),
+        code: budgetMetrics[item].code,
+        value,
+        originalValue: value,
+        metrics: budgetMetrics[item],
+        percent: Math.round(percentageRespectTo(Math.abs(value), metric[keyMetricValue])),
+        color,
+        isVisible: true,
+        originalColor: color,
+      };
+    });
   }, [budgetMetrics, isLight, metric, selectedMetric]);
 
   // Check some value affect the total 100%


### PR DESCRIPTION
## Ticket
https://trello.com/c/s9JOxwZX/368-change-requests-sprint-review-v3

## Description
Make the last level with only one item and zero values gray

## What solved
- [X] **The change should be done in the legend icon instead of the pie chart.** Deepest level: let's make it to the right of the donut, legend icon, gray if there is no value