### PR TITLE
Fix waterfall chart finish date

### DIFF
--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -723,17 +723,17 @@ export const formatterWaterfallChart = (
   switch (granularity) {
     case 'monthly':
       if (index === 0 || index === 13) {
-        return `{start|${value}}\n{startYear|${year}}`;
+        return `{start|${value}}\n{startYear|${index === 13 ? Number(year) + 1 : year}}`;
       }
       return `{month|${value}}\n{year|${year}}`;
     case 'quarterly':
       if (index === 0 || index === 5) {
-        return `{start|${value}}\n{startYear|${year}}`;
+        return `{start|${value}}\n{startYear|${index === 5 ? Number(year) + 1 : year}}`;
       }
       return `{month|${value}}\n{year|${year}}`;
     case 'annual':
       if (index === 0 || index === 2) {
-        return `{start|${value}}\n{startYear|${year}}`;
+        return `{start|${value}}\n{startYear|${index === 2 ? Number(year) + 1 : year}}`;
       }
       return `{month|${value}}\n{year|${year}}`;
     default:


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
The finish date should be next year instead the same year

## What solved
- [X] Reserves Chart: Finish and start reserves should match. 
