### PR TITLE
[GI-371] Remove unnecessary checking for the filter

### DIFF
--- a/src/stories/containers/Finances/components/ReservesWaterfallFilters/BudgetItem.tsx
+++ b/src/stories/containers/Finances/components/ReservesWaterfallFilters/BudgetItem.tsx
@@ -56,6 +56,7 @@ const CheckWrapper = styled.span({
 
 const StyledContainer = styled(Container)<{ isLight: boolean; checked: boolean }>(({ isLight, checked }) => ({
   gap: 16,
+  display: 'flex',
   position: 'relative',
   '&:hover': {
     background: isLight ? (checked ? '#EDEFFF' : '#F6F8F9') : checked ? '#231536' : '#25273D',

--- a/src/stories/containers/Finances/components/ReservesWaterfallFilters/ReservesWaterfallFilters.tsx
+++ b/src/stories/containers/Finances/components/ReservesWaterfallFilters/ReservesWaterfallFilters.tsx
@@ -62,7 +62,6 @@ const ReservesWaterfallFilters: React.FC<FiltersProps> = ({
         <SelectContainer>
           <ContainerFiltersMetric>
             <CustomMultiSelectStyled
-              isTextCut={activeItems.length === 1}
               label={label as string}
               activeItems={activeItems}
               withAll
@@ -158,30 +157,11 @@ const ContainerFiltersMetric = styled.div({
   },
 });
 
-const CustomMultiSelectStyled = styled(CustomMultiSelect)<{ isTextCut: boolean }>(({ isTextCut }) => ({
+const CustomMultiSelectStyled = styled(CustomMultiSelect)({
   '& > div:nth-of-type(2)': {
     borderRadius: 6,
   },
-  [lightTheme.breakpoints.up('tablet_768')]: {
-    ...(isTextCut && {
-      '& > div:first-of-type > div:first-of-type': {
-        maxWidth: 160,
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        overflow: ' hidden',
-      },
-    }),
-  },
-  [lightTheme.breakpoints.up('desktop_1024')]: {
-    ...(isTextCut && {
-      '& > div': {
-        '& > div:first-of-type': {
-          width: 'revert',
-        },
-      },
-    }),
-  },
-}));
+});
 
 const ContainerFilterTitle = styled.div({
   display: 'flex',


### PR DESCRIPTION
## Ticket
https://trello.com/c/ol1mo4dH/371-finances-view-general-issues-v3

## Description
Avoid that filter overlap with the check mark

## What solved
- [X] Reserves chart section, clicking on the categories filter. **Expected Output:** The longer categories' names should be displayed properly in two lines.  **Current Output:** The category's name overlaps with the selection indicator.

## Screenshots (if apply)
