### PR TITLE
Fix finances filter wrap

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChartFilter/BreakdownChartFilter.tsx
@@ -45,7 +45,7 @@ const BreakdownChartFilter: React.FC<BreakdownChartFilterProps> = ({
       labelWhenSelected: isMobile ? 'Prtcol Outfl' : 'Protocol Outflow',
     },
     {
-      label: isMobile ? 'Net Exp. On-Chain' : 'Net Expenses On-chain',
+      label: 'Net Expenses On-chain',
       value: 'PaymentsOnChain',
       labelWhenSelected: 'Net On-chain',
     },

--- a/src/stories/containers/Finances/components/BreakdownTableFinances/BreakdownTableFinances.tsx
+++ b/src/stories/containers/Finances/components/BreakdownTableFinances/BreakdownTableFinances.tsx
@@ -65,8 +65,10 @@ const BreakdownTableFinances = ({
 export default BreakdownTableFinances;
 const Container = styled.div({
   display: 'flex',
+  flexWrap: 'wrap',
   flexDirection: 'column',
   gap: 26,
+
   [lightTheme.breakpoints.up('tablet_768')]: {
     gap: 24,
     flexDirection: 'row',
@@ -80,5 +82,6 @@ const FilterContainer = styled.div({
 
   [lightTheme.breakpoints.up('tablet_768')]: {
     height: 48,
+    marginLeft: 'auto',
   },
 });

--- a/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReportsFilters.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReportsFilters.tsx
@@ -45,7 +45,7 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
         labelWhenSelected: 'Prtcol Outfl',
       },
       {
-        label: !isMobile ? 'Net Expenses On-chain' : 'Net Exp. On-Chain',
+        label: 'Net Expenses On-chain',
         value: 'PaymentsOnChain',
         labelWhenSelected: 'Net On-chain',
       },
@@ -54,7 +54,7 @@ const ExpenseReportsFilters: React.FC<ExpenseReportsFiltersProps> = ({
         value: 'Actuals',
       },
     ],
-    [isMobile]
+    []
   );
 
   return (

--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
@@ -67,7 +67,7 @@ export const useReservesWaterfallChart = (codePath: string, budgets: Budget[], a
     setSelectedGranularity(value);
   };
 
-  // This to catch some analitys that don't have budgets
+  // This to catch some analytics that don't have budgets
   const combinedElementsFromAnalytics = useMemo(() => {
     const newElements = selectAll
       .filter((selectAllPath) => !allBudgets.some((budget) => budget.codePath === selectAllPath))

--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -215,7 +215,6 @@ export const generateLineSeries = (lineSeriesData: number[], isLight: boolean) =
         },
         lineStyle: {
           width: 3,
-
           zIndex: -1,
           z: 2,
           join: 'end',


### PR DESCRIPTION
## Ticket
https://trello.com/c/ol1mo4dH/371-finances-view-general-issues-v3

## Description
When some metrics are selected on table the filter should float below the title to fit correctly

## What solved
- [X] Breakdown Chart: 768: change Net On-Chain to Net Expenses On-chain.
- [X] Breakdown Table and Breakdown Chart sections: Apply the behavior displayed in the Budget Statements section when the On-Chain and Off-Chain are selected.
