### PR TITLE
Change the name for the other budget to uncategorized

### DIFF
--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -159,6 +159,7 @@ const dictionary = [
   'Outfl',
   'compat',
   'keyframes',
+  'Uncategorized',
 ];
 
 module.exports = dictionary;

--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -140,7 +140,7 @@ const TableContainer = styled.table<WithIsLight>(({ isLight }) => ({
 const Headed = styled.th<WithIsLight & { period?: PeriodicSelectionFilter; isHeader: boolean }>(
   ({ isLight, period, isHeader }) => ({
     borderRight: `1px solid ${isLight ? '#D8E0E3' : '#405361'}`,
-    fontSize: 11,
+    fontSize: 10,
     color: isLight ? '#231536' : '#D2D4EF',
     width: 87,
     textAlign: 'center',

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -295,7 +295,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
       subBudgets.forEach((subBudget) => {
         if (!rows.some((row) => row.name === subBudget.codePath)) {
           rows.push({
-            name: isMobile ? subBudget.code : subBudget.codePath,
+            name: subBudget.code === 'other' ? 'Uncategorized' : isMobile ? subBudget.code : subBudget.codePath,
             codePath: subBudget.codePath,
             columns: Array.from({ length: columnsCount }, () => ({ ...EMPTY_METRIC_VALUE })),
           });
@@ -307,7 +307,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
         if (!nameOrCode) {
           row.name = `${removePatternAfterSlash(row.name)}`;
         } else {
-          row.name = isMobile ? nameOrCode.code : nameOrCode.name;
+          row.name = nameOrCode.name === 'other' ? 'Uncategorized' : isMobile ? nameOrCode.code : nameOrCode.name;
         }
       });
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
Change the name for other budget

## What solved
- [X]  desktop + mobile / Rename “Other” to “Uncategorized” to avoid confusion with “Others”. Also, for “Uncategorized” do not show the line item in breakdown table if the value is 0. Check for font size (change to 10px?). [image.png](https://trello.com/1/cards/660d1a805f0a6a1b1edfb464/attachments/6615301ad929c9c6c4329ff3/previews/6615301bd929

## Screenshots (if apply)
