### PR TITLE
Fix doughnut percentages

### DIFF
--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
-import { threeDigitsPrecisionHumanization } from '@ses/core/utils/humanization';
+import { threeDigitsPrecisionHumanization, usLocalizedNumber } from '@ses/core/utils/humanization';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import { getShortCode } from '../../SectionPages/CardChartOverview/utils';
@@ -43,7 +43,15 @@ const ItemLegendDoughnut: React.FC<Props> = ({
         </NameOrCode>
       </IconWithName>
       <ValueDescription isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>
-        <Percent isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>{`(${doughnutData.percent}%)`}</Percent>
+        <Percent isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>{`(${
+          doughnutData.percent === 0
+            ? 0
+            : doughnutData.percent < 0.1
+            ? '<0.1'
+            : doughnutData.percent < 1
+            ? usLocalizedNumber(doughnutData.percent, 2)
+            : Math.round(doughnutData.percent)
+        }%)`}</Percent>
         <ContainerValue>
           <Value isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>
             {valueRounded.value}

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -233,7 +233,7 @@ export const useCardChartOverview = (
         value,
         originalValue: value,
         metrics: budgetMetrics[item],
-        percent: Math.round(percentageRespectTo(Math.abs(value), metric[keyMetricValue])),
+        percent: percentageRespectTo(Math.abs(value), metric[keyMetricValue]),
         color,
         isVisible: true,
         originalColor: color,
@@ -242,19 +242,20 @@ export const useCardChartOverview = (
   }, [budgetMetrics, isLight, metric, selectedMetric]);
 
   // Check some value affect the total 100%
-  const totalPercent = doughnutSeriesData.reduce((acc, curr) => acc + curr.percent, 0);
+  const totalPercent = doughnutSeriesData.reduce((acc, curr) => acc + Math.round(curr.percent), 0);
   // Verify that sum of percent its 100% and there its not a 0%
   if (totalPercent !== 100 && totalPercent !== 0) {
     const difference = 100 - totalPercent;
     doughnutSeriesData.forEach((item) => {
+      if (item.percent < 1) return;
       const adjustment = (item.percent / totalPercent) * difference;
       item.percent = Math.round(item.percent + adjustment);
     });
 
-    const checkForPercent = doughnutSeriesData.reduce((acc, curr) => acc + curr.percent, 0);
+    const checkForPercent = doughnutSeriesData.reduce((acc, curr) => acc + Math.round(curr.percent), 0);
     const roundingError = 100 - checkForPercent;
     if (roundingError !== 0) {
-      const indexToAdjust = doughnutSeriesData.findIndex((item) => item.percent > 0);
+      const indexToAdjust = doughnutSeriesData.findIndex((item) => Math.round(item.percent) >= 1);
       // Fix the percent with some index in array of values
       if (indexToAdjust !== -1) {
         doughnutSeriesData[indexToAdjust].percent += roundingError;


### PR DESCRIPTION
## Ticket
https://trello.com/c/ol1mo4dH/371-finances-view-general-issues-v3

## Description
If the values for some items are too small relative to the others, the percentage was close to 0 but it was showing 0%

## What solved
- [X] Finances view, Pie chart section. Metric: Net Expenses On-chain.  **Expected Output:** The percent should be based on the values displayed by each budget. **Current Output:** Atlas Immutable displays 16.0k but with 0%
