### PR TITLE
[QA] Fix mobile cards budget utilization

### DIFF
--- a/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
+++ b/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
@@ -58,7 +58,16 @@ const CardNavigationMobile: React.FC<Props> = ({ image, title, totalDai, valueDa
                         isLight={isLight}
                       />
                     </ContainerBar>
-                    <Percent isLight={isLight}>{Math.round(percent)}%</Percent>
+                    <Percent isLight={isLight}>
+                      {percent === 0
+                        ? 0
+                        : percent < 0.1
+                        ? '<0.1'
+                        : percent < 1
+                        ? usLocalizedNumber(percent, 2)
+                        : Math.round(percent)}
+                      %
+                    </Percent>
                   </ContainerBarPercent>
                 </CardInformation>
               </ContainerData>

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -119,14 +119,14 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
           title: formatBudgetName(item.name),
           description: item.description || 'Finances of the core governance constructs described in the Maker Atlas.',
           href: `${siteRoutes.finances(item.codePath.replace('atlas/', ''))}?year=${year}`,
-          valueDai: budgetMetric[0].budget.value,
-          totalDai: allMetrics.budget,
+          valueDai: budgetMetric[0].paymentsOnChain.value,
+          totalDai: allMetrics.paymentsOnChain,
           code: item.code,
           color: isLight ? colorsLight[index] : colorsDark[index],
-          percent: Math.round(percentageRespectTo(budgetMetric[0].budget.value, allMetrics.budget)),
+          percent: percentageRespectTo(budgetMetric[0].paymentsOnChain.value, allMetrics.budget),
         };
       }),
-    [allMetrics.budget, budgets, budgetsAnalytics, colorsDark, colorsLight, isLight, year]
+    [allMetrics.budget, allMetrics.paymentsOnChain, budgets, budgetsAnalytics, colorsDark, colorsLight, isLight, year]
   );
   // Check some value affect the total 100%
   const totalPercent = cardsNavigationInformation.reduce((acc, curr) => acc + curr.percent, 0);
@@ -134,6 +134,7 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   if (totalPercent !== 100 && totalPercent !== 0) {
     const difference = 100 - totalPercent;
     cardsNavigationInformation.forEach((item) => {
+      if (item.percent < 1) return;
       const adjustment = (item.percent / totalPercent) * difference;
       item.percent = Math.round(item.percent + adjustment);
     });


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
Change the percentage of the budget utilization in the cards on mobile and change the budget by net on chain value

## What solved
- [X] mobile only / since there is no donut view, lets indicate budget utilization for each subbudgets; so we are not (on mobile only) going to show how much a subbudget is a part of the larger budget, but we are going to show a budget utilization of each specific sub budget. Budget boxes - metric shown should be utilization number - applicable to all levels on mobile.
