### PR TITLE
[QA-369] Add more with for the line

### DIFF
--- a/src/stories/containers/FinancesOverview/components/HorizontalBudgetBar/HorizontalBudgetBar.tsx
+++ b/src/stories/containers/FinancesOverview/components/HorizontalBudgetBar/HorizontalBudgetBar.tsx
@@ -93,7 +93,7 @@ const BudgetCapLine = styled.div<{ position: number }>(({ position }) => ({
   position: 'absolute',
   top: 0,
   left: `${position}%`,
-  width: 1,
+  width: 2,
   height: '100%',
-  background: '#F75524',
+  background: '#F99374',
 }));


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
Add more width to bar indication for better user experience

## What solved
- [X]  Budget cap line visibility: e.g, MakerDAO legacy budget cap line is not visible - make it thicker and more bright (improve visibility for mobile screens).

## Screenshots (if apply)
