### PR TITLE
[QA-369] Remove the core unit word if not a core unit expense report

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -29,6 +29,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
     offChainData,
     hasOffChainData,
     hasActualsComparison,
+    isCoreUnit,
   } = useAccountsSnapshot(snapshot);
 
   return (
@@ -52,6 +53,7 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
         balance={cuReservesBalance}
         onChainData={onChainData}
         offChainData={offChainData}
+        isCoreUnit={isCoreUnit}
       />
       {hasActualsComparison && <ExpensesComparison rows={expensesComparisonRows} hasOffChainData={hasOffChainData} />}
     </Wrapper>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -34,7 +34,6 @@ const CUReserves: React.FC<CUReservesProps> = ({
   isCoreUnit,
 }) => {
   const { isLight } = useThemeContext();
-  console.log('snapshotOwner', snapshotOwner);
   return (
     <div>
       <HeaderContainer>

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -19,6 +19,7 @@ interface CUReservesProps {
   balance?: SnapshotAccountBalance;
   onChainData?: UIReservesData[];
   offChainData?: UIReservesData[];
+  isCoreUnit: boolean;
 }
 
 const CUReserves: React.FC<CUReservesProps> = ({
@@ -30,14 +31,15 @@ const CUReserves: React.FC<CUReservesProps> = ({
   balance,
   onChainData,
   offChainData,
+  isCoreUnit,
 }) => {
   const { isLight } = useThemeContext();
-
+  console.log('snapshotOwner', snapshotOwner);
   return (
     <div>
       <HeaderContainer>
         <SectionHeader
-          title="Total Core Unit Reserves"
+          title={`Total ${isCoreUnit ? 'Core Unit' : ''} Reserves`}
           subtitle={`On-chain and off-chain reserves accessible${snapshotOwner ? ` to the ${snapshotOwner}` : ''}.`}
           tooltip={
             'Explore on and off-chain balances in DAI and other currencies, identify the flow of funds and track the \
@@ -57,7 +59,7 @@ const CUReserves: React.FC<CUReservesProps> = ({
         <SimpleStatCard
           date={startDate}
           value={balance?.initialBalance}
-          caption="Initial Core Unit Reserves"
+          caption={`Initial ${isCoreUnit ? 'Core Unit' : ''}Reserves`}
           dynamicChanges
         />
         <FundChangeCard
@@ -75,7 +77,7 @@ const CUReserves: React.FC<CUReservesProps> = ({
         <SimpleStatCard
           date={endDate}
           value={balance?.newBalance}
-          caption="New Core Unit Reserves"
+          caption={`New ${isCoreUnit ? 'Core Unit' : ''} Reserves`}
           hasEqualSign
           isReserves
           dynamicChanges

--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -97,7 +97,7 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
     () => buildExpensesComparisonRows(actualsComparison, selectedToken, snapshot.period, hasOffChainData),
     [actualsComparison, hasOffChainData, selectedToken, snapshot.period]
   );
-
+  const isCoreUnit = snapshot.ownerType === 'CoreUnit';
   return {
     isLight,
     enableCurrencyPicker,
@@ -114,6 +114,7 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
     // expenses comparison
     hasActualsComparison,
     expensesComparisonRows,
+    isCoreUnit,
   };
 };
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
This pr remove the Core Units word when ownerType its not a Core-Unit

## What solved
- [X]  Remove the word “Core-Unit” from the account snapshot reports, if the owner is not a core unit. [image.png]

## Screenshots (if apply)
