### PR TITLE
[QA369] Fix the width line chart for mobile resolutions

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
@@ -93,7 +93,7 @@ export const useReservesWaterfallChart = (codePath: string, budgets: Budget[], a
   const series = builderWaterfallSeries(dataReady, isMobile, isTable, isLight);
 
   const valuesLine = useMemo(() => calculateAccumulatedArray(dataReady), [dataReady]);
-  const linesChart = useMemo(() => generateLineSeries(valuesLine, isLight), [isLight, valuesLine]);
+  const linesChart = useMemo(() => generateLineSeries(valuesLine, isLight, isMobile), [isLight, isMobile, valuesLine]);
 
   series.push(...linesChart);
 

--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -203,7 +203,7 @@ export const calculateAccumulatedArray = (data: number[]) => {
   return accumulatedArray;
 };
 
-export const generateLineSeries = (lineSeriesData: number[], isLight: boolean) => {
+export const generateLineSeries = (lineSeriesData: number[], isLight: boolean, isMobile: boolean) => {
   const showLines = lineSeriesData.reduce((acc, curr) => acc + curr, 0);
   const series = [];
   if (showLines === 0) {
@@ -214,7 +214,7 @@ export const generateLineSeries = (lineSeriesData: number[], isLight: boolean) =
           disabled: true,
         },
         lineStyle: {
-          width: 3,
+          width: isMobile ? 1 : 3,
           zIndex: -1,
           z: 2,
           join: 'end',
@@ -253,7 +253,7 @@ export const generateLineSeries = (lineSeriesData: number[], isLight: boolean) =
         disabled: true,
       },
       lineStyle: {
-        width: 3,
+        width: isMobile ? 1 : 3,
         zIndex: -1,
         z: 2,
         join: 'end',


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
This pr fix the width of the reserve chart in mobile

## What solved
- [X] mobile only / reserves chart, make the connecting lines thinner. 

## Screenshots (if apply)
