### PR TITLE
[QA] Make numbers in waterfall bars 2 significant digits

### DIFF
--- a/src/core/utils/humanization.ts
+++ b/src/core/utils/humanization.ts
@@ -14,11 +14,11 @@ export const threeDigitsPrecisionHumanization = (num = 0, isHasAbsoluteValue = f
   const absNum = isHasAbsoluteValue ? Math.abs(num) : num;
   let value, suffix;
 
-  if (absNum >= 1000000) {
-    value = num / 1000000;
+  if (absNum >= 1_000_000) {
+    value = num / 1_000_000;
     suffix = 'M';
-  } else if (absNum >= 1000) {
-    value = num / 1000;
+  } else if (absNum >= 1_000) {
+    value = num / 1_000;
     suffix = 'K';
   } else {
     value = num;
@@ -31,6 +31,23 @@ export const threeDigitsPrecisionHumanization = (num = 0, isHasAbsoluteValue = f
   return {
     value: formattedValue,
     suffix,
+  };
+};
+
+export const twoSignificantDigitsHumanization = (num = 0, isHasAbsoluteValue = false) => {
+  let value = Math.abs(num);
+
+  const suffixes = ['', 'K', 'M', 'B', 'T'];
+  let suffixIndex = 0;
+
+  while (Math.round(value) >= 100) {
+    value /= 1000;
+    suffixIndex++;
+  }
+
+  return {
+    value: `${!isHasAbsoluteValue && num < 0 ? '-' : ''}${value.toPrecision(2)}`,
+    suffix: suffixes[suffixIndex],
   };
 };
 

--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -1,5 +1,5 @@
 import { UMBRAL_CHART_WATERFALL } from '@ses/core/utils/const';
-import { threeDigitsPrecisionHumanization } from '@ses/core/utils/humanization';
+import { twoSignificantDigitsHumanization } from '@ses/core/utils/humanization';
 import { removePatternAfterSlash } from '../BreakdownTable/utils';
 import type { LineWaterfall, MetricValues, WaterfallChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { Analytic, AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
@@ -90,8 +90,8 @@ export const builderWaterfallSeries = (
 
       label: {
         formatter: (params: EChartsOption) => {
-          const formatted = threeDigitsPrecisionHumanization(params.value, true);
-          if (formatted.value === '0.00') return '';
+          const formatted = twoSignificantDigitsHumanization(params.value, true);
+          if (formatted.value === '0.0') return '';
           if (isMobile) {
             if (params.dataIndex === 0 || params.dataIndex === help.length - 1) {
               return `{colorful|${formatted.value}}`;
@@ -143,9 +143,9 @@ export const builderWaterfallSeries = (
         fontSize: isMobile ? 8 : 12,
         position: 'bottom',
         formatter: (params: EChartsOption) => {
-          const formatted = threeDigitsPrecisionHumanization(params.value, true);
+          const formatted = twoSignificantDigitsHumanization(params.value, true);
 
-          if (formatted.value === '0.00') return '';
+          if (formatted.value === '0.0') return '';
           if (isMobile) {
             return `-${formatted.value}`;
           }
@@ -176,9 +176,9 @@ export const builderWaterfallSeries = (
         fontFamily: 'Inter, sans-serif',
         position: 'top',
         formatter: (params: EChartsOption) => {
-          const formatted = threeDigitsPrecisionHumanization(params.value, true);
+          const formatted = twoSignificantDigitsHumanization(params.value, true);
 
-          if (formatted.value === '0.00') return '';
+          if (formatted.value === '0.0') return '';
           if (isMobile) {
             return `+${formatted.value}`;
           }


### PR DESCRIPTION
## Ticket
https://trello.com/c/79RjUNM3/369-qa-issues-bug-findings-fusion-v3

## Description
Change the number formating way in the waterfall chart

## What solved
- [X] mobile only / reserves chart, make the connecting lines thinner. Two significant digits and add a unit. (732K —> 0.73M; 64.6K —> 65K). 
