### PR TITLE
[QA] Allow to load less items on navigation cards mobile

### DIFF
--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -38,8 +38,9 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
     handleChangeYears,
     cardsToShow,
     breakdownTable,
-    loadMoreCards,
-    handleLoadMoreCards,
+    canLoadMoreCards,
+    showMoreCards,
+    toggleShowMoreCards,
     makerDAOExpensesMetrics,
     breakdownChartSectionData,
     expenseReportSection,
@@ -108,8 +109,9 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
           </WrapperMobile>
           <CardsNavigation
             cardsNavigationInformation={cardsToShow}
-            handleLoadMoreCards={handleLoadMoreCards}
-            loadMoreCards={loadMoreCards}
+            canLoadMoreCards={canLoadMoreCards}
+            showMoreCards={showMoreCards}
+            toggleShowMoreCards={toggleShowMoreCards}
           />
         </ContainerSections>
 

--- a/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -16,11 +16,17 @@ import type { SwiperProps, SwiperRef } from 'swiper/react';
 
 interface Props {
   cardsNavigationInformation: NavigationCard[];
-  loadMoreCards: boolean;
-  handleLoadMoreCards: () => void;
+  canLoadMoreCards: boolean;
+  showMoreCards: boolean;
+  toggleShowMoreCards: () => void;
 }
 
-const CardsNavigation: React.FC<Props> = ({ cardsNavigationInformation, loadMoreCards, handleLoadMoreCards }) => {
+const CardsNavigation: React.FC<Props> = ({
+  cardsNavigationInformation,
+  canLoadMoreCards,
+  showMoreCards,
+  toggleShowMoreCards,
+}) => {
   const { isLight } = useThemeContext();
   const ref = useRef<SwiperRef>(null);
   const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
@@ -116,10 +122,10 @@ const CardsNavigation: React.FC<Props> = ({ cardsNavigationInformation, loadMore
             code={card.code ?? ''}
           />
         ))}
-        {loadMoreCards && (
+        {canLoadMoreCards && (
           <ContainerButton>
             <DividerStyle isLight={isLight} />
-            <BigButtonStyled title={'Load More'} onClick={handleLoadMoreCards} />
+            <BigButtonStyled title={`Load ${showMoreCards ? 'Less' : 'More'}`} onClick={toggleShowMoreCards} />
             <DividerStyle isLight={isLight} />
           </ContainerButton>
         )}

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -151,17 +151,22 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   }
 
   // if there too many cards we need to use a swiper on desktop but paginated on mobile
-  const [loadMoreCards, setLoadMoreCards] = useState<boolean>(cardsNavigationInformation.length > 6);
+  const [canLoadMoreCards, setCanLoadMoreCards] = useState<boolean>(cardsNavigationInformation.length > 6);
+  const [showMoreCards, setShowMoreCards] = useState<boolean>(false);
   useEffect(() => {
     // update when the levels/budgets change
-    setLoadMoreCards(cardsNavigationInformation.length > 6);
+    setCanLoadMoreCards(cardsNavigationInformation.length > 6);
+    setShowMoreCards(false);
   }, [cardsNavigationInformation.length]);
-  const handleLoadMoreCards = () => {
-    setLoadMoreCards(!loadMoreCards);
+
+  const toggleShowMoreCards = () => {
+    if (!canLoadMoreCards) return;
+
+    setShowMoreCards(!showMoreCards);
   };
 
   // pagination only happens on mobile devices
-  const cardsToShow = loadMoreCards && isMobile ? cardsNavigationInformation.slice(0, 6) : cardsNavigationInformation;
+  const cardsToShow = !showMoreCards && isMobile ? cardsNavigationInformation.slice(0, 6) : cardsNavigationInformation;
 
   // All the logic required by the breakdown chart section
   const breakdownChartSectionData = useBreakdownChart(budgets, year, codePath, allBudgets);
@@ -192,8 +197,9 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
     cardsToShow,
     breakdownChartSectionData,
     breakdownTable,
-    loadMoreCards,
-    handleLoadMoreCards,
+    canLoadMoreCards,
+    showMoreCards,
+    toggleShowMoreCards,
     makerDAOExpensesMetrics,
     expenseReportSection: expenseTrendFinances,
     reserveChart,


### PR DESCRIPTION
## Ticket
https://trello.com/c/9cI0ENhT/376-qa-issues-bug-findings-fusion-v4

## Description
Allow to load less items on navigation cards on mobile after the load more button is clicked if there are more than 6 items

## What solved
- [X] Budget categories + show more and no - show less, should be ordered by size - applicable to all budget levels.
