### PR TITLE
[QA-376] Add the new text for the tooltip line chart and breakdown chart and e…

### DIFF
--- a/src/stories/containers/Finances/components/ReservesWaterfallFilters/ReservesWaterfallFilters.tsx
+++ b/src/stories/containers/Finances/components/ReservesWaterfallFilters/ReservesWaterfallFilters.tsx
@@ -44,7 +44,7 @@ const ReservesWaterfallFilters: React.FC<FiltersProps> = ({
       <SectionTitle
         title={title}
         tooltip={
-          'Customize this chart to display MakerDAO financial data by selecting one or more components from the dropdown, set to "All Components" by default, and choose your preferred granularity(Quarterly, Monthly, Yearly)'
+          'Customize this chart to display MakerDAO financial data by selecting one or more components from the dropdown and choose your preferred granularity (Quarterly, Monthly, Yearly) with a monthly default.'
         }
       />
 

--- a/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReports.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/ExpenseReports/ExpenseReports.tsx
@@ -41,7 +41,9 @@ const ExpenseReports: React.FC<Props> = ({
       <HeaderContainer>
         <SectionTitle
           title="Budget Statements"
-          tooltip="Explore the latest expense reports in a customizable table with options to filter by status  and selected financial metrics."
+          tooltip={
+            'Get insights into budget reporting activity: from contributors, reporting month, actuals, status,  to last modifications. Data includes specific financial details by department with a simple click on "View".'
+          }
         />
         <ExpenseReportsFilters {...filterProps} />
       </HeaderContainer>

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/TitleFilterComponent.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/TitleFilterComponent.tsx
@@ -15,7 +15,7 @@ const TitleFilterComponent: React.FC<Props> = ({ title, handleChange, selectedVa
   <Container>
     <SectionTitle
       title={title}
-      tooltip="View monthly expense metrics for the current year on this line chart, with a fixed legend of Budget, Forecast, Actuals, Net Expenses Off-Chain, and Net Expenses On-Chain, all toggleable for customized visualization."
+      tooltip="View expense metrics for the selected year on this line chart, with a fixed legend of Budget, Forecast, Actuals, Net Expenses Off-Chain, and Net Expenses On-Chain, all toggleable for customized visualization."
     />
 
     <FilterContainer>


### PR DESCRIPTION

## Ticket
https://trello.com/c/9cI0ENhT/376-qa-issues-bug-findings-fusion-v4

## Description
Add the new description for the tooltip in the breakdown and line chart, and also in the expense report section in the finances page

## What solved
- [X] Budget Statement description: "Get insights into budget reporting activity: from contributors, reporting month, actuals, status,  to last modifications. Data includes specific financial details by department with a simple click on "View."
- [X] Remove "monthly" and add " selected" from the expense metrics chart so that it will read to:  "View expense metrics for the selected year on this line chart, with a fixed legend of Budget, Forecast, Actuals, Net Expenses Off-Chain, and Net Expenses On-Chain, all toggleable for customized visualization."
- [X] Remove "set to 'All Components' by default," from the Reserves Chart description so that it will read: "Customize this chart to display MakerDAO financial data by selecting one or more components from the dropdown and choose your preferred granularity (Quarterly, Monthly, Yearly) with a monthly default." 

## Screenshots (if apply)
