### PR TITLE
[QA] Sort navigation cards on mobile

### DIFF
--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -107,25 +107,27 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   // All the logic required by the CardNavigation section
   const cardsNavigationInformation = useMemo(
     () =>
-      budgets.map((item, index) => {
-        const budgetMetric =
-          budgetsAnalytics !== undefined && budgetsAnalytics[item.codePath] !== undefined
-            ? budgetsAnalytics[item.codePath]
-            : [newBudgetMetric()];
+      budgets
+        .map((item, index) => {
+          const budgetMetric =
+            budgetsAnalytics !== undefined && budgetsAnalytics[item.codePath] !== undefined
+              ? budgetsAnalytics[item.codePath]
+              : [newBudgetMetric()];
 
-        return {
-          image: item.image || '/assets/img/default-icon-cards-budget.svg',
-          codePath: item.codePath,
-          title: formatBudgetName(item.name),
-          description: item.description || 'Finances of the core governance constructs described in the Maker Atlas.',
-          href: `${siteRoutes.finances(item.codePath.replace('atlas/', ''))}?year=${year}`,
-          valueDai: budgetMetric[0].paymentsOnChain.value,
-          totalDai: allMetrics.paymentsOnChain,
-          code: item.code,
-          color: isLight ? colorsLight[index] : colorsDark[index],
-          percent: percentageRespectTo(budgetMetric[0].paymentsOnChain.value, allMetrics.budget),
-        };
-      }),
+          return {
+            image: item.image || '/assets/img/default-icon-cards-budget.svg',
+            codePath: item.codePath,
+            title: formatBudgetName(item.name),
+            description: item.description || 'Finances of the core governance constructs described in the Maker Atlas.',
+            href: `${siteRoutes.finances(item.codePath.replace('atlas/', ''))}?year=${year}`,
+            valueDai: budgetMetric[0].paymentsOnChain.value,
+            totalDai: allMetrics.paymentsOnChain,
+            code: item.code,
+            color: isLight ? colorsLight[index] : colorsDark[index],
+            percent: percentageRespectTo(budgetMetric[0].paymentsOnChain.value, allMetrics.budget),
+          };
+        })
+        .sort((a, b) => b.percent - a.percent),
     [allMetrics.budget, allMetrics.paymentsOnChain, budgets, budgetsAnalytics, colorsDark, colorsLight, isLight, year]
   );
   // Check some value affect the total 100%


### PR DESCRIPTION
## Ticket
https://trello.com/c/9cI0ENhT/376-qa-issues-bug-findings-fusion-v4

## Description
Sort the navigation cards on mobile by the percentage of budget utilization. Higher on top

## What solved
- [X] Budget categories + show more and no - show less, should be ordered by size - applicable to all budget levels. 
