### PR TITLE
[QA] Fix mobile navigation cards percentages

### DIFF
--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -108,6 +108,7 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
             />
           </WrapperMobile>
           <CardsNavigation
+            budgetCap={cardOverViewSectionData.budgetCap}
             cardsNavigationInformation={cardsToShow}
             canLoadMoreCards={canLoadMoreCards}
             showMoreCards={showMoreCards}

--- a/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
+++ b/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
@@ -3,7 +3,7 @@ import BarPercentRelativeToTotal from '@ses/components/BarPercentRelativeToTotal
 import ArrowNavigationForCards from '@ses/components/svg/ArrowNavigationForCards';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 
-import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import { threeDigitsPrecisionHumanization, usLocalizedNumber } from '@ses/core/utils/humanization';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -11,6 +11,7 @@ import CardNavigationGeneric from '../CardNavigationGeneric';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
+  budgetCap: number;
   image: string;
   title: string;
   totalDai: number;
@@ -23,9 +24,20 @@ interface Props {
   percent: number;
 }
 
-const CardNavigationMobile: React.FC<Props> = ({ image, title, totalDai, valueDai, href, barColor, code, percent }) => {
+const CardNavigationMobile: React.FC<Props> = ({
+  budgetCap,
+  image,
+  title,
+  totalDai,
+  valueDai,
+  href,
+  barColor,
+  code,
+  percent,
+}) => {
   const { isLight } = useThemeContext();
-  const formatted = usLocalizedNumber(valueDai);
+  const budgetCapFormatted = threeDigitsPrecisionHumanization(budgetCap);
+  const valueFormatted = threeDigitsPrecisionHumanization(valueDai);
 
   const showCode = code && code.length > 0;
   const showCodeBelow =
@@ -58,10 +70,15 @@ const CardNavigationMobile: React.FC<Props> = ({ image, title, totalDai, valueDa
                 </ContainerIcon>
                 <CardInformation>
                   <ContainerTotal>
-                    <Total isLight={isLight}>
-                      {`${formatted}`}
-                      <Coin isLight={isLight}>DAI</Coin>
-                    </Total>
+                    <Value isLight={isLight}>
+                      {valueFormatted.value}
+                      <Suffix isLight={isLight}>{valueFormatted.suffix}</Suffix>
+                    </Value>
+                    <Value isLight={isLight}>/</Value>
+                    <Value isLight={isLight}>
+                      {budgetCapFormatted.value}
+                      <Suffix isLight={isLight}>{budgetCapFormatted.suffix}</Suffix>
+                    </Value>
                   </ContainerTotal>
                   <ContainerBarPercent>
                     <ContainerBar>
@@ -146,7 +163,7 @@ const CardInformation = styled.div({
   height: 17,
 });
 
-const Total = styled.div<WithIsLight>(({ isLight }) => ({
+const Value = styled.div<WithIsLight>(({ isLight }) => ({
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
   fontWeight: 600,
@@ -160,7 +177,7 @@ const Total = styled.div<WithIsLight>(({ isLight }) => ({
   display: 'flex',
 }));
 
-const Coin = styled.span<WithIsLight>(({ isLight }) => ({
+const Suffix = styled.span<WithIsLight>(({ isLight }) => ({
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
   fontWeight: 600,
@@ -252,4 +269,7 @@ const ContainerSpace = styled.div({
   flexDirection: 'row',
   justifyContent: 'space-between',
 });
-const ContainerTotal = styled.div({});
+const ContainerTotal = styled.div({
+  display: 'flex',
+  gap: 4,
+});

--- a/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -15,6 +15,7 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { SwiperProps, SwiperRef } from 'swiper/react';
 
 interface Props {
+  budgetCap: number;
   cardsNavigationInformation: NavigationCard[];
   canLoadMoreCards: boolean;
   showMoreCards: boolean;
@@ -22,6 +23,7 @@ interface Props {
 }
 
 const CardsNavigation: React.FC<Props> = ({
+  budgetCap,
   cardsNavigationInformation,
   canLoadMoreCards,
   showMoreCards,
@@ -111,6 +113,7 @@ const CardsNavigation: React.FC<Props> = ({
       <WrapperMobile>
         {cardsNavigationInformation.map((card: NavigationCard, index) => (
           <CardNavigationMobile
+            budgetCap={budgetCap}
             valueDai={card?.valueDai || 0}
             totalDai={card?.totalDai || 0}
             href={card.href}

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -130,27 +130,6 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
         .sort((a, b) => b.percent - a.percent),
     [allMetrics.budget, allMetrics.paymentsOnChain, budgets, budgetsAnalytics, colorsDark, colorsLight, isLight, year]
   );
-  // Check some value affect the total 100%
-  const totalPercent = cardsNavigationInformation.reduce((acc, curr) => acc + curr.percent, 0);
-  // Verify that sum of percent its 100% and there its not a 0%
-  if (totalPercent !== 100 && totalPercent !== 0) {
-    const difference = 100 - totalPercent;
-    cardsNavigationInformation.forEach((item) => {
-      if (item.percent < 1) return;
-      const adjustment = (item.percent / totalPercent) * difference;
-      item.percent = Math.round(item.percent + adjustment);
-    });
-
-    const checkForPercent = cardsNavigationInformation.reduce((acc, curr) => acc + curr.percent, 0);
-    const roundingError = 100 - checkForPercent;
-    if (roundingError !== 0) {
-      const indexToAdjust = cardsNavigationInformation.findIndex((item) => item.percent > 0);
-      // Fix the percent with some index in array of values
-      if (indexToAdjust !== -1) {
-        cardsNavigationInformation[indexToAdjust].percent += roundingError;
-      }
-    }
-  }
 
   // if there too many cards we need to use a swiper on desktop but paginated on mobile
   const [canLoadMoreCards, setCanLoadMoreCards] = useState<boolean>(cardsNavigationInformation.length > 6);


### PR DESCRIPTION
## Ticket
https://trello.com/c/9cI0ENhT/376-qa-issues-bug-findings-fusion-v4

## Description
Fix the percentage of the budget utilization and the way we display the net on-chain value

## What solved
- [X] Finances->Scope Framework Budget. Budget utilization indicated on the cards:  https://expenses-dev.makerdao.network/finances/scopes?year=2023. **Expected Output:** The values represented on the mobile resolution should match the values shown on the desktop for the Net Expenses On-chain metric. **Current Output:** The values displayed on mobile don't match the values shown on the desktop resolution.
