### PR TITLE
[QA-376] Add Uncategorized in the page

### DIFF
--- a/src/stories/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/stories/components/Breadcrumbs/Breadcrumbs.tsx
@@ -22,6 +22,7 @@ interface BreadcrumbsProps {
 
 const Breadcrumbs = (props: BreadcrumbsProps) => {
   const { isLight } = useThemeContext();
+
   return (
     <Container
       className={props.className}
@@ -49,7 +50,7 @@ const Breadcrumbs = (props: BreadcrumbsProps) => {
               marginLeft={props.marginLeft}
               marginRight={props.marginRight}
             >
-              {item.label}
+              {item.label === 'Other' ? 'Uncategorized' : item.label}
             </Crumb>
           </Link>
           {i !== props.items.length - 1 && (

--- a/src/stories/components/Pagination/BreadCrumbWithIcons.tsx
+++ b/src/stories/components/Pagination/BreadCrumbWithIcons.tsx
@@ -125,7 +125,7 @@ const BreadCrumbWithIcons = ({ title, items = [], className, marginRightSeparato
               }}
               legacyBehavior
             >
-              <ItemMenu onClick={handleClose}>{item.label}</ItemMenu>
+              <ItemMenu onClick={handleClose}>{item.label === 'Other' ? 'Uncategorized' : item.label}</ItemMenu>
             </Link>
           </MenuItem>
         ))}

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -294,11 +294,13 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
       const subBudgets = allBudgets.filter((item) => item.parentId === budget.id);
       subBudgets.forEach((subBudget) => {
         if (!rows.some((row) => row.name === subBudget.codePath)) {
-          rows.push({
-            name: subBudget.code === 'other' ? 'Uncategorized' : isMobile ? subBudget.code : subBudget.codePath,
-            codePath: subBudget.codePath,
-            columns: Array.from({ length: columnsCount }, () => ({ ...EMPTY_METRIC_VALUE })),
-          });
+          if (subBudget.code !== 'other') {
+            rows.push({
+              name: subBudget.code === 'other' ? 'Uncategorized' : isMobile ? subBudget.code : subBudget.codePath,
+              codePath: subBudget.codePath,
+              columns: Array.from({ length: columnsCount }, () => ({ ...EMPTY_METRIC_VALUE })),
+            });
+          }
         }
       });
       // add correct rows name
@@ -310,10 +312,17 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
           row.name = nameOrCode.name === 'other' ? 'Uncategorized' : isMobile ? nameOrCode.code : nameOrCode.name;
         }
       });
-
+      const formatBudget = formatBudgetName(budget.name);
       // sub-table header
       const header: ItemRow = {
-        name: isMobile ? (lod === 3 ? formatBudgetName(budget.name) : budget.code) : formatBudgetName(budget.name),
+        name:
+          formatBudget === 'Other'
+            ? 'Uncategorized'
+            : isMobile
+            ? lod === 3
+              ? formatBudget
+              : budget.code
+            : formatBudget,
 
         isMain: true,
         codePath: budget.codePath,
@@ -335,7 +344,6 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
           }, Array(rows?.[0]?.columns?.length).fill(null))
           .filter((item) => item !== null),
       };
-
       // Check if only one element is only the header so don't need rows
       if (rows.length === 1) {
         table.rows = [header];

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -38,7 +38,7 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   const currentBudget = allBudgets.find((budget) => budget.codePath === codePath);
   const description = currentBudget?.description;
   const icon = currentBudget?.image;
-  const code = currentBudget?.code === 'other' ? 'Uncategorized' : currentBudget?.code;
+  const code = currentBudget?.code === 'other' ? 'Uncategorized' : currentBudget?.code || '';
   const formattedName = formatBudgetName((currentBudget?.name || codePath) ?? '');
   const title = formattedName === 'Other' ? 'Uncategorized' : formattedName;
 

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -38,8 +38,10 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   const currentBudget = allBudgets.find((budget) => budget.codePath === codePath);
   const description = currentBudget?.description;
   const icon = currentBudget?.image;
-  const code = currentBudget?.code ?? '';
-  const title = formatBudgetName((currentBudget?.name || codePath) ?? '');
+  const code = currentBudget?.code === 'other' ? 'Uncategorized' : currentBudget?.code;
+  const formattedName = formatBudgetName((currentBudget?.name || codePath) ?? '');
+  const title = formattedName === 'Other' ? 'Uncategorized' : formattedName;
+
   const handleChangeYears = (value: string) => {
     setYear(value);
     router.push(


### PR DESCRIPTION
## Ticket
https://trello.com/c/9cI0ENhT/376-qa-issues-bug-findings-fusion-v4

## Description
Fix the other in the page when you click in the row in the table

## What solved
- [X]  Breakdown table section. Clicking on the Uncategorized row. **Expected Output:** The item should have the same name when you access its specific level.  **Current Output:** The breadcrumb and the breakdown table are still showing the "Other" name.

## Screenshots (if apply)
