### PR TITLE
[QA] Add horizontal line when annual is selected

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
         "Swiper",
         "tokenomics",
         "topup",
+        "Uncategorized",
         "unoptimized",
         "viewports",
         "Wireframes"

--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -160,6 +160,7 @@ const dictionary = [
   'compat',
   'keyframes',
   'Uncategorized',
+  'coord',
 ];
 
 module.exports = dictionary;

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics.stories.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics.stories.tsx
@@ -27,7 +27,7 @@ const args = [
   {
     title: 'MakerDAO Expense Metrics',
     year: 2023,
-    series: buildExpenseMetricsLineChartSeries(chartData, [], true),
+    series: buildExpenseMetricsLineChartSeries(chartData, [], true, 'monthly'),
     selectedGranularity: 'monthly',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     handleGranularityChange: (value: string) => null,
@@ -35,7 +35,7 @@ const args = [
   {
     title: 'MakerDAO Expense Metrics',
     year: 2023,
-    series: buildExpenseMetricsLineChartSeries(chartData, [], false),
+    series: buildExpenseMetricsLineChartSeries(chartData, [], false, 'monthly'),
     selectedGranularity: 'monthly',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     handleGranularityChange: (value: string) => null,

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/useMakerDAOExpenseMetrics.tsx
@@ -70,8 +70,8 @@ export const useMakerDAOExpenseMetrics = (year: string) => {
   };
 
   const series: LineChartSeriesData[] = useMemo(
-    () => buildExpenseMetricsLineChartSeries(data, inactiveSeries, isLight),
-    [data, inactiveSeries, isLight]
+    () => buildExpenseMetricsLineChartSeries(data, inactiveSeries, isLight, selectedGranularity),
+    [data, inactiveSeries, isLight, selectedGranularity]
   );
 
   return {

--- a/src/stories/containers/Finances/utils/types.ts
+++ b/src/stories/containers/Finances/utils/types.ts
@@ -104,6 +104,9 @@ export interface LineChartSeriesData {
     color: string;
   };
   isVisible: boolean;
+  // there's not available types for this
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  renderItem?(params: any, api: any): any;
 }
 
 export interface ItemRow {

--- a/src/stories/containers/Finances/utils/utils.ts
+++ b/src/stories/containers/Finances/utils/utils.ts
@@ -780,7 +780,8 @@ export const buildExpenseMetricsLineChartSeries = (
     protocolNetOutflow: number[];
   },
   inactiveSeries: string[],
-  isLight: boolean
+  isLight: boolean,
+  granularity: AnalyticGranularity
 ) => {
   const disabled = {
     Budget: inactiveSeries.includes('Budget'),
@@ -790,51 +791,95 @@ export const buildExpenseMetricsLineChartSeries = (
     Actuals: inactiveSeries.includes('Actuals'),
   };
 
+  // there's not available types for this
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const render = (params: any, api: any) => {
+    const coord1 = api.coord([api.value(0, params.dataIndexInside), api.value(1, params.dataIndexInside)]);
+
+    return {
+      type: 'group',
+      children: [
+        {
+          type: 'line',
+          shape: {
+            x1: params.coordSys.x,
+            y1: coord1[1],
+            x2: params.coordSys.x + params.coordSys.width,
+            y2: coord1[1],
+          },
+          style: {
+            stroke: api.visual('color'),
+            lineWidth: 2,
+          },
+        },
+        {
+          type: 'circle',
+          transition: 'shape',
+          shape: {
+            cx: coord1[0],
+            cy: coord1[1],
+            r: 2,
+          },
+          style: {
+            stroke: api.visual('color'),
+            fill: 'white',
+            lineWidth: 2,
+          },
+        },
+      ],
+    };
+  };
+
   return [
     {
       name: 'Budget',
       data: disabled.Budget ? [] : data?.budget,
-      type: 'line',
+      type: granularity === 'annual' ? 'custom' : 'line',
       itemStyle: {
         color: disabled.Budget ? '#ccc' : isLight ? '#F99374' : '#F77249',
       },
       isVisible: !disabled.Budget,
+      renderItem: render,
     },
     {
       name: 'Forecast',
       data: disabled.Forecast ? [] : data?.forecast,
-      type: 'line',
+      type: granularity === 'annual' ? 'custom' : 'line',
       itemStyle: {
         color: disabled.Forecast ? '#ccc' : isLight ? '#447AFB' : '#447AFB',
       },
       isVisible: !disabled.Forecast,
+      renderItem: render,
     },
     {
       name: 'Net Protocol Outflow',
       data: disabled['Net Protocol Outflow'] ? [] : data?.protocolNetOutflow,
-      type: 'line',
+      type: granularity === 'annual' ? 'custom' : 'line',
       itemStyle: {
         color: disabled['Net Protocol Outflow'] ? '#ccc' : isLight ? '#7C6B95' : '#6C40AA',
       },
       isVisible: !disabled['Net Protocol Outflow'],
+      renderItem: render,
     },
     {
       name: 'Net Expenses On-Chain',
       data: disabled['Net Expenses On-Chain'] ? [] : data?.onChain,
-      type: 'line',
+      type: granularity === 'annual' ? 'custom' : 'line',
       itemStyle: {
         color: disabled['Net Expenses On-Chain'] ? '#ccc' : isLight ? '#FBCC5F' : '#FDC134',
       },
       isVisible: !disabled['Net Expenses On-Chain'],
+      renderItem: render,
     },
     {
       name: 'Actuals',
       data: disabled.Actuals ? [] : data?.actuals,
-      type: 'line',
+      type: granularity === 'annual' ? 'custom' : 'line',
       itemStyle: {
         color: disabled.Actuals ? '#ccc' : isLight ? '#2DC1B1' : '#1AAB9B',
       },
       isVisible: !disabled.Actuals,
+      renderItem: render,
     },
   ] as LineChartSeriesData[];
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/9cI0ENhT/376-qa-issues-bug-findings-fusion-v4

## Description
Add horizontal lines when annual granularity is selected in the expense metrics chart

## What solved
- [X] All screens / horizontal line through the dot on the expense metric chart
