### PR TITLE
[QA] Make bars sharp on zero values

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -82,7 +82,7 @@ export const builderWaterfallSeries = (
         disabled: true,
       },
       itemStyle: {
-        borderRadius: 4,
+        borderRadius: [4, 4, 0, 0],
         color: (params: EChartsOption) => helpBarColors[params.dataIndex],
       },
       isVisible: true,


### PR DESCRIPTION
## Ticket
https://trello.com/c/9cI0ENhT/376-qa-issues-bug-findings-fusion-v4

## Description
Make bars in the start and final bars sharp on the zero level

## What solved
- [X] ALL SCREENS/ Reserves Chart: blue bars for start and finish values should not have rounded edges at the zero value (make them sharp).
