### PR TITLE
[QA] Add budget metrics modal

### DIFF
--- a/src/core/context/BudgetMetricsModalContext.tsx
+++ b/src/core/context/BudgetMetricsModalContext.tsx
@@ -1,0 +1,28 @@
+import BudgetMetricsModal from '@ses/containers/Finances/components/BudgetMetricsModal/BudgetMetricsModal';
+import { createContext, useContext, useState } from 'react';
+
+interface BudgetMetricsModalContextValues {
+  handleOpenModal: () => void;
+  openModal: boolean;
+}
+
+const BudgetMetricsModalContext = createContext<BudgetMetricsModalContextValues>({} as BudgetMetricsModalContextValues);
+const useBudgetMetricsModalContext = () => useContext(BudgetMetricsModalContext);
+
+const BudgetMetricsModalProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [openModal, setOpenModal] = useState<boolean>(false);
+
+  return (
+    <BudgetMetricsModalContext.Provider
+      value={{
+        handleOpenModal: () => setOpenModal((prev) => !prev),
+        openModal,
+      }}
+    >
+      {children}
+      <BudgetMetricsModal />
+    </BudgetMetricsModalContext.Provider>
+  );
+};
+
+export { useBudgetMetricsModalContext, BudgetMetricsModalProvider };

--- a/src/stories/components/BasicModal/BasicModal.tsx
+++ b/src/stories/components/BasicModal/BasicModal.tsx
@@ -1,5 +1,6 @@
 import Modal from '@mui/material/Modal';
 import * as React from 'react';
+import type { ModalOwnProps } from '@mui/material/Modal';
 
 interface Props {
   open: boolean;
@@ -8,8 +9,17 @@ interface Props {
   className?: string;
   classNameModal?: string;
   backdropProps?: React.HTMLAttributes<HTMLDivElement>;
+  slotProps?: ModalOwnProps['slotProps'];
 }
-const BasicModal: React.FC<Props> = ({ children, handleClose, open, className, classNameModal, backdropProps }) => (
+const BasicModal: React.FC<Props> = ({
+  children,
+  handleClose,
+  open,
+  className,
+  classNameModal,
+  backdropProps,
+  slotProps,
+}) => (
   <div className={classNameModal}>
     <Modal
       open={open}
@@ -17,6 +27,7 @@ const BasicModal: React.FC<Props> = ({ children, handleClose, open, className, c
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"
       BackdropProps={backdropProps}
+      slotProps={slotProps}
     >
       <div className={className}>{children}</div>
     </Modal>

--- a/src/stories/components/BasicModal/CategoryModalComponent.tsx
+++ b/src/stories/components/BasicModal/CategoryModalComponent.tsx
@@ -22,10 +22,12 @@ const CategoryModalComponent: React.FC = () => {
     <BasicModalExtended
       handleClose={handleCloseModal}
       open={openModal}
-      backdropProps={{
-        style: {
-          background: isLight ? 'rgba(52, 52, 66, 0.1)' : 'rgba(0, 22, 78, 0.1)',
-          backdropFilter: isLight ? 'blur(2px);' : 'blur(4px)',
+      slotProps={{
+        backdrop: {
+          sx: {
+            background: isLight ? 'rgba(52, 52, 66, 0.1)' : 'rgba(0, 22, 78, 0.1)',
+            backdropFilter: isLight ? 'blur(4px);' : 'blur(4px)',
+          },
         },
       }}
     >

--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -3,9 +3,11 @@ import Container from '@ses/components/Container/Container';
 import PageContainer from '@ses/components/Container/PageContainer';
 import IconTitleWithCode from '@ses/components/IconTitleWithCode/IconTitleWithCode';
 import { SEOHead } from '@ses/components/SEOHead/SEOHead';
+import { BudgetMetricsModalProvider } from '@ses/core/context/BudgetMetricsModalContext';
 import { toAbsoluteURL } from '@ses/core/utils/urls';
 import React from 'react';
 import BreakdownChartSection from './components/BreakdownChartSection/BreakdownChartSection';
+import BudgetMetricButtonModalTrigger from './components/BudgetMetricButtonModalTrigger/BudgetMetricButtonModalTrigger';
 import ConditionalWrapper from './components/ConditionalWrapper/ConditionalWrapper';
 import OverviewCardMobile from './components/OverviewCardMobile/OverviewCardMobile';
 import BreadcrumbYearNavigation from './components/SectionPages/BreadcrumbYearNavigation';
@@ -27,6 +29,7 @@ interface Props {
 
 const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, initialYear }) => {
   const {
+    isMobile,
     year,
     levelNumber,
     icon,
@@ -70,66 +73,74 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
         hasIcon={levelNumber !== 1}
       />
 
-      <Container>
-        <TitleContainer>
-          {/* Page title */}
-          {levelNumber === 1 ? (
-            <FirstLevelTitle>MakerDAO Finances</FirstLevelTitle>
-          ) : (
-            <NthTitleBox>
-              <IconTitleWithCode icon={icon || '/assets/img/default-icon-cards-budget.svg'} title={title} code={code} />
-            </NthTitleBox>
-          )}
-          <TitleDescription levelNumber={levelNumber}>
-            {levelNumber === 1
-              ? 'Learn more about MakerDAO expense metrics by looking at the data below. The data includes information about both immutable and scope frameworks budgets as defined in the MakerDAO Atlas. Additionally, the data from the period MakerDAO period 2021-2022 can be found in the MakerDAO Legacy budget section. Available metrics are the budgets, forecasts, protocol outflow, net expenses on-chain and the actuals.'
-              : description}
-          </TitleDescription>
-        </TitleContainer>
+      <BudgetMetricsModalProvider>
+        <Container>
+          <TitleContainer>
+            {/* Page title */}
+            {levelNumber === 1 ? (
+              <FirstLevelTitle>MakerDAO Finances</FirstLevelTitle>
+            ) : (
+              <NthTitleBox>
+                <IconTitleWithCode
+                  icon={icon || '/assets/img/default-icon-cards-budget.svg'}
+                  title={title}
+                  code={code}
+                />
+              </NthTitleBox>
+            )}
+            <TitleDescription levelNumber={levelNumber}>
+              {levelNumber === 1
+                ? 'Learn more about MakerDAO expense metrics by looking at the data below. The data includes information about both immutable and scope frameworks budgets as defined in the MakerDAO Atlas. Additionally, the data from the period MakerDAO period 2021-2022 can be found in the MakerDAO Legacy budget section. Available metrics are the budgets, forecasts, protocol outflow, net expenses on-chain and the actuals.'
+                : description}
+            </TitleDescription>
+          </TitleContainer>
 
-        <ContainerSections>
-          <WrapperDesk>
-            <CardChartOverview
-              selectedMetric={cardOverViewSectionData.selectedMetric}
-              handleSelectedMetric={cardOverViewSectionData.handleSelectedMetric}
-              paymentsOnChain={cardOverViewSectionData.paymentsOnChain}
+          {(levelNumber === 1 || isMobile) && <BudgetMetricButtonModalTrigger />}
+
+          <ContainerSections>
+            <WrapperDesk>
+              <CardChartOverview
+                selectedMetric={cardOverViewSectionData.selectedMetric}
+                handleSelectedMetric={cardOverViewSectionData.handleSelectedMetric}
+                paymentsOnChain={cardOverViewSectionData.paymentsOnChain}
+                budgetCap={cardOverViewSectionData.budgetCap}
+                doughnutSeriesData={cardOverViewSectionData.doughnutSeriesData}
+                isCoreThirdLevel={levelNumber >= 3}
+                changeAlignment={cardOverViewSectionData.changeAlignment}
+                showSwiper={cardOverViewSectionData.showSwiper}
+                numberSliderPerLevel={cardOverViewSectionData.numberSliderPerLevel}
+              />
+            </WrapperDesk>
+            <WrapperMobile>
+              <OverviewCardMobile
+                paymentsOnChain={cardOverViewSectionData.paymentsOnChain}
+                budgetCap={cardOverViewSectionData.budgetCap}
+              />
+            </WrapperMobile>
+            <CardsNavigation
               budgetCap={cardOverViewSectionData.budgetCap}
-              doughnutSeriesData={cardOverViewSectionData.doughnutSeriesData}
-              isCoreThirdLevel={levelNumber >= 3}
-              changeAlignment={cardOverViewSectionData.changeAlignment}
-              showSwiper={cardOverViewSectionData.showSwiper}
-              numberSliderPerLevel={cardOverViewSectionData.numberSliderPerLevel}
+              cardsNavigationInformation={cardsToShow}
+              canLoadMoreCards={canLoadMoreCards}
+              showMoreCards={showMoreCards}
+              toggleShowMoreCards={toggleShowMoreCards}
             />
-          </WrapperDesk>
-          <WrapperMobile>
-            <OverviewCardMobile
-              paymentsOnChain={cardOverViewSectionData.paymentsOnChain}
-              budgetCap={cardOverViewSectionData.budgetCap}
-            />
-          </WrapperMobile>
-          <CardsNavigation
-            budgetCap={cardOverViewSectionData.budgetCap}
-            cardsNavigationInformation={cardsToShow}
-            canLoadMoreCards={canLoadMoreCards}
-            showMoreCards={showMoreCards}
-            toggleShowMoreCards={toggleShowMoreCards}
+          </ContainerSections>
+
+          <BreakdownChartSection
+            isLoading={breakdownChartSectionData.isLoading}
+            year={year}
+            selectedMetric={breakdownChartSectionData.selectedMetric}
+            selectedGranularity={breakdownChartSectionData.selectedGranularity}
+            onMetricChange={breakdownChartSectionData.handleMetricChange}
+            onGranularityChange={breakdownChartSectionData.handleGranularityChange}
+            isDisabled={breakdownChartSectionData.isDisabled}
+            handleResetFilter={breakdownChartSectionData.handleResetFilterBreakDownChart}
+            series={breakdownChartSectionData.series}
+            handleToggleSeries={breakdownChartSectionData.handleToggleSeries}
+            refBreakDownChart={breakdownChartSectionData.refBreakDownChart}
           />
-        </ContainerSections>
-
-        <BreakdownChartSection
-          isLoading={breakdownChartSectionData.isLoading}
-          year={year}
-          selectedMetric={breakdownChartSectionData.selectedMetric}
-          selectedGranularity={breakdownChartSectionData.selectedGranularity}
-          onMetricChange={breakdownChartSectionData.handleMetricChange}
-          onGranularityChange={breakdownChartSectionData.handleGranularityChange}
-          isDisabled={breakdownChartSectionData.isDisabled}
-          handleResetFilter={breakdownChartSectionData.handleResetFilterBreakDownChart}
-          series={breakdownChartSectionData.series}
-          handleToggleSeries={breakdownChartSectionData.handleToggleSeries}
-          refBreakDownChart={breakdownChartSectionData.refBreakDownChart}
-        />
-      </Container>
+        </Container>
+      </BudgetMetricsModalProvider>
 
       <ConditionalWrapper period={breakdownTable.periodFilter}>
         <BreakdownTable

--- a/src/stories/containers/Finances/components/BudgetMetricButtonModalTrigger/BudgetMetricButtonModalTrigger.tsx
+++ b/src/stories/containers/Finances/components/BudgetMetricButtonModalTrigger/BudgetMetricButtonModalTrigger.tsx
@@ -1,0 +1,52 @@
+import { styled } from '@mui/material';
+import ArrowRight from '@ses/components/svg/ArrowRight';
+import { useBudgetMetricsModalContext } from '@ses/core/context/BudgetMetricsModalContext';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+
+const BudgetMetricButtonModalTrigger: React.FC = () => {
+  const { isLight } = useThemeContext();
+  const { handleOpenModal } = useBudgetMetricsModalContext();
+
+  return (
+    <ContainerOpenModal onClick={handleOpenModal}>
+      <Text>Learn about budget metrics</Text>
+      <ArrowRight fill={isLight ? '#231536' : '#D2D4EF'} />
+    </ContainerOpenModal>
+  );
+};
+
+export default BudgetMetricButtonModalTrigger;
+
+const ContainerOpenModal = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  cursor: 'pointer',
+  height: 34,
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  background: theme.palette.mode === 'light' ? '#F6F8F9' : '#343442',
+  border: theme.palette.mode === 'light' ? '1px solid #D4D9E1' : '1px solid #48495F',
+  borderRadius: '6px',
+  padding: '8px 16px 8px 16px',
+  marginTop: -2,
+  marginBottom: 24,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 240,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    marginBottom: 32,
+  },
+}));
+
+const Text = styled('span')(({ theme }) => ({
+  fontWeight: 400,
+  fontSize: 13,
+  lineHeight: '18px',
+  color: theme.palette.mode === 'light' ? '#231635' : '#D2D4EF',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 14,
+  },
+}));

--- a/src/stories/containers/Finances/components/BudgetMetricsModal/BudgetMetricsModal.tsx
+++ b/src/stories/containers/Finances/components/BudgetMetricsModal/BudgetMetricsModal.tsx
@@ -1,0 +1,338 @@
+import { styled } from '@mui/material';
+import BasicModal from '@ses/components/BasicModal/BasicModal';
+import { Close } from '@ses/components/svg/close';
+import { useBudgetMetricsModalContext } from '@ses/core/context/BudgetMetricsModalContext';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import SimpleBar from 'simplebar-react';
+
+const BudgetMetricsModal: React.FC = () => {
+  const { isLight } = useThemeContext();
+  const { openModal, handleOpenModal } = useBudgetMetricsModalContext();
+
+  return (
+    <BasicModalExtended
+      open={openModal}
+      handleClose={handleOpenModal}
+      slotProps={{
+        backdrop: {
+          sx: {
+            background: isLight ? 'rgba(52, 52, 66, 0.1)' : 'rgba(0, 22, 78, 0.1)',
+            backdropFilter: isLight ? 'blur(4px);' : 'blur(4px)',
+          },
+        },
+      }}
+    >
+      <Container>
+        <Header>
+          <ContainerTitle>
+            <Title>Budget</Title>
+            <ContainerClose>
+              <StyledClose onClick={handleOpenModal} />
+            </ContainerClose>
+          </ContainerTitle>
+          <ContainerDescription>
+            <Description>An estimate of income and expenditure for a set period.</Description>
+          </ContainerDescription>
+        </Header>
+        <ContainerScroll>
+          <SimpleBarStyled scrollbarMaxSize={64}>
+            <InsideModal>
+              <MetricItem>
+                <MetricTitle>Budget Cap</MetricTitle>
+                <MetricDescription>
+                  The maximum amount allocated for a specific budget category or project.
+                </MetricDescription>
+              </MetricItem>
+
+              <MetricItem>
+                <MetricTitle>Forecast</MetricTitle>
+                <MetricDescription>
+                  Predicted financial outcomes based on current data and trends for a future period.
+                </MetricDescription>
+              </MetricItem>
+
+              <MetricItem>
+                <MetricTitle>Actuals</MetricTitle>
+                <MetricDescription>
+                  The actual amount spent or received, compared against budgeted figures.
+                </MetricDescription>
+              </MetricItem>
+
+              <MetricItem>
+                <MetricTitle>Payments On-Chain</MetricTitle>
+                <MetricDescription>Transactions (expenses) made directly on the blockchain.</MetricDescription>
+              </MetricItem>
+
+              <MetricItem>
+                <MetricTitle>Payments Off-Chain Incl</MetricTitle>
+                <MetricDescription>
+                  Transactions (expenses) processed outside the blockchain network. similar to the way we do the expense
+                  categories on the home page.
+                </MetricDescription>
+              </MetricItem>
+            </InsideModal>
+          </SimpleBarStyled>
+        </ContainerScroll>
+      </Container>
+    </BasicModalExtended>
+  );
+};
+
+export default BudgetMetricsModal;
+
+const BasicModalExtended = styled(BasicModal)(({ theme }) => ({
+  position: 'absolute',
+  left: '50%',
+  height: 'calc(100% - 64px)',
+  maxHeight: '100%',
+  marginTop: 64,
+  marginBottom: 0,
+  // This to hidden border in safari
+  outline: 'none',
+  transform: 'translateX(-50%)',
+  width: 'max(100%, 375px)',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 'max(90%, 770px)',
+    height: 'calc(100% - 128px)',
+    marginBottom: 64,
+    maxHeight: 558,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    maxWidth: 729,
+  },
+}));
+
+const Container = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  overflowY: 'auto',
+  height: '100%',
+  background: theme.palette.mode === 'light' ? '#FFFFFF' : '#10191F',
+  boxShadow:
+    theme.palette.mode === 'light'
+      ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
+      : '10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
+  borderTopLeftRadius: '6px',
+  borderTopRightRadius: '6px',
+  paddingBottom: 16,
+
+  '::-webkit-scrollbar': {
+    width: '1px',
+  },
+
+  [theme.breakpoints.up('tablet_768')]: {
+    borderRadius: '16px',
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    maxWidth: 729,
+    paddingBottom: 32,
+  },
+}));
+
+const Header = styled('div')(({ theme }) => ({
+  paddingLeft: 16,
+  paddingRight: 16,
+  paddingTop: 16,
+  paddingBottom: 19,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  borderTopLeftRadius: 16,
+  borderTopRightRadius: 16,
+  background: theme.palette.mode === 'light' ? '#FFFFFF' : '#10191F',
+  boxShadow:
+    theme.palette.mode === 'light'
+      ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
+      : ' 10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    paddingLeft: 24,
+    paddingRight: 24,
+    paddingTop: 24,
+    paddingBottom: 16,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    paddingLeft: 40,
+    paddingRight: 40,
+  },
+}));
+
+const ContainerTitle = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  height: 19,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    height: 29,
+  },
+}));
+
+const Title = styled('div')(({ theme }) => ({
+  fontSize: 16,
+  lineHeight: '19px',
+  fontFamily: 'Inter, sans-serif',
+  fontStyle: 'normal',
+  fontWeight: 700,
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontWeight: 600,
+    fontSize: 24,
+    lineHeight: '29px',
+    letterSpacing: '0.4px',
+  },
+}));
+
+const Description = styled('div')(({ theme }) => ({
+  fontWeight: 400,
+  fontSize: 14,
+  lineHeight: '17px',
+  fontFamily: 'Inter, sans-serif',
+  fontStyle: 'normal',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
+  width: '100%',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 435,
+    fontWeight: 400,
+    fontSize: 16,
+    lineHeight: '22px',
+    alignItems: 'baseline',
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    width: 625,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    width: 725,
+  },
+}));
+
+const ContainerDescription = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 19,
+  alignItems: 'flex-end',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+    gap: 16,
+  },
+}));
+
+const ContainerClose = styled('div')(({ theme }) => ({
+  paddingRight: 3,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    paddingRight: 6,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    paddingRight: 3,
+  },
+}));
+
+const StyledClose = styled(Close)(({ theme }) => ({
+  width: 14,
+  height: 14,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 20,
+    height: 20,
+  },
+}));
+
+const SimpleBarStyled = styled(SimpleBar)(({ theme }) => ({
+  height: '100%',
+
+  '.simplebar-scrollbar::before': {
+    width: 4,
+    marginLeft: 4,
+    background: '#1aab9b',
+    borderRadius: 20,
+  },
+
+  [theme.breakpoints.up('tablet_768')]: {
+    maxHeight: 813,
+
+    '.simplebar-scrollbar::before': {
+      width: 6,
+    },
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    maxHeight: 847,
+  },
+}));
+
+const InsideModal = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 32,
+  padding: '16px 16px 0',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    padding: 24,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    padding: '32px 40px 0',
+  },
+}));
+
+const ContainerScroll = styled('div')(() => ({
+  height: '100%',
+  overflowY: 'auto',
+
+  '::-webkit-scrollbar': {
+    width: '1px',
+  },
+}));
+
+const MetricItem = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+}));
+
+const MetricTitle = styled('div')(({ theme }) => ({
+  fontWeight: 700,
+  fontSize: 14,
+  lineHeight: '17px',
+  fontStyle: 'normal',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 16,
+    lineHeight: '19px',
+  },
+}));
+
+const MetricDescription = styled('div')(({ theme }) => ({
+  fontWeight: 400,
+  fontSize: 14,
+  lineHeight: '17px',
+  fontStyle: 'normal',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 16,
+    lineHeight: '22px',
+  },
+}));

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/CardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/CardChartOverview.tsx
@@ -1,9 +1,13 @@
 import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
+import IconOpenModal from '@ses/components/svg/IconOpenModal';
+import { useBudgetMetricsModalContext } from '@ses/core/context/BudgetMetricsModalContext';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import DoughnutChartFinances from '../../OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances';
 import InformationBudgetCapOverview from '../../OverviewCardKeyDetailsBudget/InformationBudgetCapOverView/InformationBudgetCapOverView';
+import type { Theme } from '@mui/material';
 import type { DoughnutSeries } from '@ses/containers/Finances/utils/types';
 import type { AnalyticMetric } from '@ses/core/models/interfaces/analytic';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -58,6 +62,8 @@ const CardChartOverview: React.FC<Props> = ({
   numberSliderPerLevel,
 }) => {
   const { isLight } = useThemeContext();
+  const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('desktop_1024'));
+  const { handleOpenModal } = useBudgetMetricsModalContext();
 
   return (
     <Container isLight={isLight}>
@@ -73,6 +79,7 @@ const CardChartOverview: React.FC<Props> = ({
               {filterItem.label}
             </Item>
           ))}
+          <IconOpenModal width={isTablet ? 10.5 : 16} height={isTablet ? 10.5 : 16} onClick={handleOpenModal} />
         </ContainerFilters>
 
         <ContainerCardChart>
@@ -136,6 +143,7 @@ const ContainerFilters = styled.div({
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'flex-end',
+    alignItems: 'center',
     gap: 8,
   },
   [lightTheme.breakpoints.up('desktop_1024')]: {

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -167,6 +167,7 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
   const expenseTrendFinances = useExpenseReports(codePath);
 
   return {
+    isMobile,
     year,
     levelNumber,
     icon,


### PR DESCRIPTION
## Ticket
https://trello.com/c/9cI0ENhT/376-qa-issues-bug-findings-fusion-v4

## What solved
- [X] ALL SCREENS / Pop up toaster: (functionality applicable to all levels in finances view) add metrics descriptions when a user taps on the icon similar to how we have text explanation window for when a user taps on the “View all Expenses Categories” on the homepage (blurs the text in the backgorund, clear text in the front).  Place this pop up toaster after the description text of MakerDAO Finances.  “About Metrics”.  The content of the pop up toaster text is: “Budget: An estimate of income and expenditure for a set period. Budget Cap: The maximum amount allocated for a specific budget category or project. Forecast: Predicted financial outcomes based on current data and trends for a future period. Actuals: The actual amount spent or received, compared against budgeted figures. Payments On-Chain: Transactions (expenses) made directly on the blockchain. Payments Off-Chain Incl.: Transactions (expenses) processed outside the blockchain network.” 
