### PR TITLE
[QA] Show tooltip as modals in mobile

### DIFF
--- a/src/stories/components/SESTooltip/SESTooltip.tsx
+++ b/src/stories/components/SESTooltip/SESTooltip.tsx
@@ -5,7 +5,7 @@ import useMobileDetector from '@ses/core/hooks/useMobileDetector';
 import lightTheme from '@ses/styles/theme/light';
 import classNames from 'classnames';
 import merge from 'deepmerge';
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import ModalBottomSheet from './ModalBottomSheet';
 import TooltipModalVariant from './TooltipModalVariant';
 import type { TooltipProps } from '@mui/material';
@@ -34,12 +34,6 @@ const SESTooltip: React.FC<SESTooltipProps> = ({
   const borderColor = borderColorProp || (isLight === false ? '#231536' : '#D4D9E1');
 
   const [controlledOpen, setControlledOpen] = React.useState(props.open ?? enableClickListener ? false : undefined);
-
-  useEffect(() => {
-    if (props.open !== undefined) {
-      setControlledOpen(props.open);
-    }
-  }, [props.open]);
 
   const defaultProps = useMemo<Partial<SESTooltipProps>>(
     () => ({

--- a/src/stories/components/SESTooltip/SESTooltip.tsx
+++ b/src/stories/components/SESTooltip/SESTooltip.tsx
@@ -16,6 +16,7 @@ export interface SESTooltipProps extends Omit<TooltipProps, 'title' | 'content'>
   borderColor?: React.CSSProperties['color'];
   fallbackPlacements?: TooltipProps['placement'][];
   showAsModalBottomSheet?: boolean;
+  showAsModal?: boolean;
 }
 
 const SESTooltip: React.FC<SESTooltipProps> = ({
@@ -26,6 +27,7 @@ const SESTooltip: React.FC<SESTooltipProps> = ({
   className,
   fallbackPlacements,
   showAsModalBottomSheet = false,
+  showAsModal = false,
   ...props
 }) => {
   const { isLight } = useThemeContext();
@@ -91,7 +93,7 @@ const SESTooltip: React.FC<SESTooltipProps> = ({
     );
   }
 
-  if (!showAsModalBottomSheet && isMobileResolution) {
+  if (!showAsModalBottomSheet && isMobileResolution && (showAsModal || typeof content === 'string')) {
     return (
       <>
         {React.cloneElement(children as React.ReactElement, {

--- a/src/stories/components/SESTooltip/SESTooltip.tsx
+++ b/src/stories/components/SESTooltip/SESTooltip.tsx
@@ -5,8 +5,9 @@ import useMobileDetector from '@ses/core/hooks/useMobileDetector';
 import lightTheme from '@ses/styles/theme/light';
 import classNames from 'classnames';
 import merge from 'deepmerge';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import ModalBottomSheet from './ModalBottomSheet';
+import TooltipModalVariant from './TooltipModalVariant';
 import type { TooltipProps } from '@mui/material';
 
 export interface SESTooltipProps extends Omit<TooltipProps, 'title' | 'content'> {
@@ -28,11 +29,17 @@ const SESTooltip: React.FC<SESTooltipProps> = ({
   ...props
 }) => {
   const { isLight } = useThemeContext();
-  const isMobileResolution = useMediaQuery(lightTheme.breakpoints.down('table_834'));
+  const isMobileResolution = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const isMobileDevice = !!useMobileDetector()?.mobile();
   const borderColor = borderColorProp || (isLight === false ? '#231536' : '#D4D9E1');
 
   const [controlledOpen, setControlledOpen] = React.useState(props.open ?? enableClickListener ? false : undefined);
+
+  useEffect(() => {
+    if (props.open !== undefined) {
+      setControlledOpen(props.open);
+    }
+  }, [props.open]);
 
   const defaultProps = useMemo<Partial<SESTooltipProps>>(
     () => ({
@@ -81,12 +88,25 @@ const SESTooltip: React.FC<SESTooltipProps> = ({
         content={content}
         open={!!controlledOpen}
         handleOpen={() => setControlledOpen(true)}
-        handleClose={() => setControlledOpen(false)}
+        handleClose={() => setControlledOpen(undefined)}
       >
         {React.cloneElement(children as React.ReactElement, {
           onClick: () => setControlledOpen((prev) => !prev),
         })}
       </ModalBottomSheet>
+    );
+  }
+
+  if (!showAsModalBottomSheet && isMobileResolution) {
+    return (
+      <>
+        {React.cloneElement(children as React.ReactElement, {
+          onClick: () => setControlledOpen((prev) => !prev),
+        })}
+        <TooltipModalVariant openModal={!!controlledOpen} handleCloseModal={() => setControlledOpen(undefined)}>
+          {content}
+        </TooltipModalVariant>
+      </>
     );
   }
 

--- a/src/stories/components/SESTooltip/TooltipModalVariant.tsx
+++ b/src/stories/components/SESTooltip/TooltipModalVariant.tsx
@@ -1,0 +1,101 @@
+import { styled } from '@mui/material';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import BasicModal from '../BasicModal/BasicModal';
+import { Close } from '../svg/close';
+
+interface TooltipModalVariantProps extends React.PropsWithChildren {
+  openModal: boolean;
+  handleCloseModal: () => void;
+}
+
+const TooltipModalVariant: React.FC<TooltipModalVariantProps> = ({ children, openModal, handleCloseModal }) => {
+  const { isLight } = useThemeContext();
+
+  return (
+    <BasicModalExtended
+      open={openModal}
+      handleClose={handleCloseModal}
+      slotProps={{
+        backdrop: {
+          sx: {
+            background: isLight ? 'rgba(52, 52, 66, 0.1)' : 'rgba(0, 22, 78, 0.1)',
+            backdropFilter: isLight ? 'blur(4px);' : 'blur(4px)',
+          },
+        },
+      }}
+    >
+      <Container>
+        <ContainerClose>
+          <StyledClose onClick={handleCloseModal} />
+        </ContainerClose>
+        {children}
+      </Container>
+    </BasicModalExtended>
+  );
+};
+
+export default TooltipModalVariant;
+
+export const BasicModalExtended = styled(BasicModal)({
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  maxHeight: 748,
+  // This to hidden border in safari
+  outline: 'none',
+  transform: 'translate(-50%, calc(-50% - 64px))',
+  width: '100%',
+});
+
+const Container = styled('div')(({ theme }) => ({
+  position: 'relative',
+  height: 'auto',
+  maxWidth: 'calc(100% - 32px)',
+  background: theme.palette.mode === 'light' ? '#FFFFFF' : '#10191F',
+  borderRadius: 6,
+  margin: '0 auto',
+  padding: '16px 24px 16px 16px',
+
+  '::-webkit-scrollbar': {
+    width: '1px',
+  },
+
+  [theme.breakpoints.up('tablet_768')]: {
+    borderRadius: '16px',
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    maxWidth: 729,
+    paddingBottom: 32,
+  },
+}));
+
+const ContainerClose = styled('div')(({ theme }) => ({
+  position: 'absolute',
+  top: 8,
+  right: 8,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    paddingRight: 6,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    paddingRight: 3,
+  },
+}));
+
+const StyledClose = styled(Close)(({ theme }) => ({
+  width: 14,
+  height: 14,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 20,
+    height: 20,
+  },
+}));


### PR DESCRIPTION
## Ticket
https://trello.com/c/9cI0ENhT/376-qa-issues-bug-findings-fusion-v4

## Description
On mobile now the tooltips are shown as modals instead as a popup

## What solved
- [X] MOBILE / Pop up toaster: currently we have an i icon popup text and instead of this, we want to switch to a pop up toaster on mobile screens with blurred background and clear front text.
