### PR TITLE
Fix snapshot reserves CU text spacing

### DIFF
--- a/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/stories/containers/TransparencyReport/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -58,7 +58,7 @@ const CUReserves: React.FC<CUReservesProps> = ({
         <SimpleStatCard
           date={startDate}
           value={balance?.initialBalance}
-          caption={`Initial ${isCoreUnit ? 'Core Unit' : ''}Reserves`}
+          caption={`Initial ${isCoreUnit ? 'Core Unit' : ''} Reserves`}
           dynamicChanges
         />
         <FundChangeCard


### PR DESCRIPTION
## Ticket
https://trello.com/c/YtFMkHoz/378-finances-view-general-issues-v4

## Description
There was twowords together without spacing in the account snapshot component

## What solved
- [X]  1) Navigate to the [link](https://expenses-dev.makerdao.network/core-unit/DUX/finances/reports?viewMonth=Jul2023&view=default&section=accounts-snapshots) 2) Scroll the page to the "Total Core Unit Reserves" section **Expected Output:** All words are separated by a space.
