### PR TITLE
[QA] Navigation percentage & values in mobile

### DIFF
--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -118,7 +118,6 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
               />
             </WrapperMobile>
             <CardsNavigation
-              budgetCap={cardOverViewSectionData.budgetCap}
               cardsNavigationInformation={cardsToShow}
               canLoadMoreCards={canLoadMoreCards}
               showMoreCards={showMoreCards}

--- a/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.stories.tsx
+++ b/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.stories.tsx
@@ -24,6 +24,8 @@ const args = [
     totalDai: 8950775,
     valueDai: 1790155,
     barColor: '#F99374',
+    percent: 23.0,
+    budgetCap: 10000000,
   },
 ];
 const [[LightMode, DarkMode]] = createThemeModeVariants(CardNavigationMobile, args);

--- a/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
+++ b/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
@@ -89,8 +89,11 @@ const CardNavigationMobile: React.FC<Props> = ({
                         isLight={isLight}
                       />
                     </ContainerBar>
-                    <Percent isLight={isLight}>
-                      {percent === 0
+                    <Percent isLight={isLight} isRightPartZero={budgetCap === 0}>
+                      {/* TODO: if the budget cap is 0 then show -- % */}
+                      {budgetCap === 0
+                        ? '-- '
+                        : percent === 0
                         ? 0
                         : percent < 0.1
                         ? '<0.1'
@@ -204,7 +207,7 @@ const ContainerBar = styled.div({
   borderRadius: 4,
 });
 
-const Percent = styled.div<WithIsLight>(({ isLight }) => ({
+const Percent = styled.div<WithIsLight & { isRightPartZero: boolean }>(({ isLight, isRightPartZero }) => ({
   textAlign: 'right',
   fontVariantNumeric: 'lin',
   fontFamily: 'Inter, sans-serif',
@@ -214,13 +217,15 @@ const Percent = styled.div<WithIsLight>(({ isLight }) => ({
   lineHeight: 'normal',
   textTransform: 'uppercase',
   width: 34,
-  color: isLight ? '#231536' : '#D2D4EF',
+  color: isRightPartZero ? (isLight ? '#9FAFB9' : '#708390') : isLight ? '#231536' : '#D2D4EF',
 }));
 
 const BarPercentRelativeToTotalStyled = styled(BarPercentRelativeToTotal)<WithIsLight & { barColor: string }>(
   ({ barColor, isLight }) => ({
     borderRadius: 4,
     backgroundColor: isLight ? '#ECF1F3' : '#10191F',
+    height: 16,
+
     '& > div': {
       background: barColor,
     },

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/InformationBudgetCapOverView/InformationBudgetCapOverView.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/InformationBudgetCapOverView/InformationBudgetCapOverView.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useMediaQuery } from '@mui/material';
 import HorizontalBudgetBar from '@ses/containers/FinancesOverview/components/HorizontalBudgetBar/HorizontalBudgetBar';
 
 import { useThemeContext } from '@ses/core/context/ThemeContext';
@@ -6,6 +7,7 @@ import { threeDigitsPrecisionHumanization } from '@ses/core/utils/humanization';
 import { percentageRespectTo } from '@ses/core/utils/math';
 import React from 'react';
 import lightTheme from 'styles/theme/light';
+import type { Theme } from '@mui/material';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 export type QuarterCardProps = {
@@ -16,6 +18,7 @@ export type QuarterCardProps = {
 
 const InformationBudgetCapOverview: React.FC<QuarterCardProps> = ({ paymentsOnChain, budgetCap, className }) => {
   const { isLight } = useThemeContext();
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
 
   const humanizedActuals = threeDigitsPrecisionHumanization(paymentsOnChain);
   const humanizedBudgetCap = threeDigitsPrecisionHumanization(budgetCap);
@@ -47,10 +50,13 @@ const InformationBudgetCapOverview: React.FC<QuarterCardProps> = ({ paymentsOnCh
       </Percent>
       <BarWrapper>
         <HorizontalBudgetBarStyled actuals={paymentsOnChain} prediction={0} budgetCap={budgetCap} />
+        <MobilePercent isLight={isLight} isRightPartZero={budgetCap === 0}>
+          {budgetCap === 0 ? '-- ' : percent}%
+        </MobilePercent>
       </BarWrapper>
       <Legend>
         <LegendItem isLight={isLight} dotColor={isLight ? '#2DC1B1' : '#1AAB9B'}>
-          <LegendLabelMobileTable>Net Exp On-Chain</LegendLabelMobileTable>
+          <LegendLabelMobileTable>Net {isMobile ? 'Expenses' : 'Exp'} On-Chain</LegendLabelMobileTable>
           <LegendLabel>Net Expenses On-Chain</LegendLabel>
         </LegendItem>
         <LegendItem isLight={isLight} dotColor={'#F75524'}>
@@ -134,6 +140,9 @@ const PredictionSymbol = styled.div<WithIsLight>(({ isLight }) => ({
 const NumberSuffix = styled.div({});
 
 const BarWrapper = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
   marginTop: 8,
   marginBottom: 8,
 
@@ -213,6 +222,7 @@ const LegendLabelMobileTable = styled.div({
   marginLeft: 4,
   fontSize: 14,
   lineHeight: 'normal',
+
   [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 14,
     lineHeight: 'normal',
@@ -278,6 +288,7 @@ const Description = styled.div<WithIsLight>(({ isLight }) => ({
 }));
 
 const Percent = styled.div<WithIsLight & { isRightPartZero: boolean }>(({ isLight, isRightPartZero }) => ({
+  display: 'none',
   fontFamily: 'Inter, sans-serif',
   fontSize: 20,
   fontStyle: 'normal',
@@ -286,6 +297,25 @@ const Percent = styled.div<WithIsLight & { isRightPartZero: boolean }>(({ isLigh
   textAlign: 'center',
   letterSpacing: '0.4px',
   color: isRightPartZero ? (isLight ? '#9FAFB9' : '#708390') : isLight ? '#405361' : '#9FAFB9',
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    display: 'block',
+  },
+}));
+
+const MobilePercent = styled.div<WithIsLight & { isRightPartZero: boolean }>(({ isLight, isRightPartZero }) => ({
+  fontFamily: 'Inter, sans-serif',
+  fontSize: 20,
+  fontStyle: 'normal',
+  fontWeight: 600,
+  lineHeight: 'normal',
+  textAlign: 'center',
+  letterSpacing: '0.4px',
+  color: isRightPartZero ? (isLight ? '#9FAFB9' : '#708390') : isLight ? '#405361' : '#9FAFB9',
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
 }));
 
 const DividerActualsBudgetCap = styled.div<WithIsLight>(({ isLight }) => ({
@@ -298,13 +328,20 @@ const DividerActualsBudgetCap = styled.div<WithIsLight>(({ isLight }) => ({
 }));
 
 const DividerCardChart = styled.div<WithIsLight>(({ isLight }) => ({
+  display: 'none',
   marginTop: 16,
   marginBottom: 16,
   borderBottom: `1px solid ${isLight ? '#D4D9E1' : '#405361'}`,
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    display: 'block',
+  },
+
   [lightTheme.breakpoints.up('desktop_1024')]: {
     marginTop: 16,
     marginBottom: 16,
   },
+
   [lightTheme.breakpoints.up('desktop_1280')]: {
     marginTop: 24,
     marginBottom: 24,

--- a/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -111,6 +111,7 @@ const CardsNavigation: React.FC<Props> = ({
         )}
       </WrapperDesk>
       <WrapperMobile>
+        <Subtitle isLight={isLight}>Subcategories</Subtitle>
         {cardsNavigationInformation.map((card: NavigationCard, index) => (
           <CardNavigationMobile
             budgetCap={budgetCap}
@@ -236,6 +237,18 @@ const WrapperMobile = styled.div({
     display: 'none',
   },
 });
+
+const Subtitle = styled.div<WithIsLight>(({ isLight }) => ({
+  fontSize: 14,
+  lineHeight: '22px',
+  fontWeight: 500,
+  color: isLight ? '#B6BCC2' : '#708390',
+  margin: '8px 0',
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
 
 const ContainerButton = styled.div({
   width: '100%',

--- a/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -15,7 +15,6 @@ import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { SwiperProps, SwiperRef } from 'swiper/react';
 
 interface Props {
-  budgetCap: number;
   cardsNavigationInformation: NavigationCard[];
   canLoadMoreCards: boolean;
   showMoreCards: boolean;
@@ -23,7 +22,6 @@ interface Props {
 }
 
 const CardsNavigation: React.FC<Props> = ({
-  budgetCap,
   cardsNavigationInformation,
   canLoadMoreCards,
   showMoreCards,
@@ -114,7 +112,7 @@ const CardsNavigation: React.FC<Props> = ({
         <Subtitle isLight={isLight}>Subcategories</Subtitle>
         {cardsNavigationInformation.map((card: NavigationCard, index) => (
           <CardNavigationMobile
-            budgetCap={budgetCap}
+            budgetCap={card.budgetCapValue || 0}
             valueDai={card?.valueDai || 0}
             totalDai={card?.totalDai || 0}
             href={card.href}

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -123,13 +123,14 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
             href: `${siteRoutes.finances(item.codePath.replace('atlas/', ''))}?year=${year}`,
             valueDai: budgetMetric[0].paymentsOnChain.value,
             totalDai: allMetrics.paymentsOnChain,
+            budgetCapValue: budgetMetric[0].budget.value,
             code: item.code,
             color: isLight ? colorsLight[index] : colorsDark[index],
-            percent: percentageRespectTo(budgetMetric[0].paymentsOnChain.value, allMetrics.budget),
+            percent: percentageRespectTo(budgetMetric[0].paymentsOnChain.value, budgetMetric[0].budget.value),
           };
         })
         .sort((a, b) => b.percent - a.percent),
-    [allMetrics.budget, allMetrics.paymentsOnChain, budgets, budgetsAnalytics, colorsDark, colorsLight, isLight, year]
+    [allMetrics.paymentsOnChain, budgets, budgetsAnalytics, colorsDark, colorsLight, isLight, year]
   );
 
   // if there too many cards we need to use a swiper on desktop but paginated on mobile

--- a/src/stories/containers/Finances/utils/types.ts
+++ b/src/stories/containers/Finances/utils/types.ts
@@ -17,6 +17,7 @@ export interface NavigationCard {
   href: string;
   totalDai?: number;
   valueDai?: number;
+  budgetCapValue?: number;
   color: string;
   code?: string;
   codePath?: string;


### PR DESCRIPTION
## Ticket
https://trello.com/c/FA7EohUK/386-qa-issues-bug-findings-fusion-v5

## What solved
- [X] MOBILE / Budget summary cards and budget utilization:  1. Lets move the % number to the right of the main budget utilization bar (the same way we’re doing it in the (sub)budget cards. 2. Lets make the (sub)budget utilization bars the same height as the main budget utilization bar. 3. Budget cap numbers for (sub)budgets should be the values for that specific (sub)budget and not for the whole main budget: e.g. SES should have 3.2M and not 18.6M. 4. Remove the horizontal line in budget utilization.