### PR TITLE
Fix Core Unit item links

### DIFF
--- a/src/stories/components/CoreUnitCard/CoreUnitCard.tsx
+++ b/src/stories/components/CoreUnitCard/CoreUnitCard.tsx
@@ -89,7 +89,7 @@ const CoreUnitCard = ({ coreUnit, isLoading = false }: CoreUnitCardProps) => {
   }
 
   return (
-    <Link href={`${siteRoutes.coreUnitReports(coreUnit.shortCode)}/${queryStrings}`} passHref legacyBehavior>
+    <Link href={`${siteRoutes.coreUnitAbout(coreUnit.shortCode)}/${queryStrings}`} passHref legacyBehavior>
       <CuCard>
         <Container isLight={isLight}>
           <Summary>

--- a/src/stories/components/CustomTable/ItemCoreUnit/ItemCoreUnit.tsx
+++ b/src/stories/components/CustomTable/ItemCoreUnit/ItemCoreUnit.tsx
@@ -20,7 +20,7 @@ export const ItemCoreUnit = ({ queryStrings, isLoading, columns, cu }: Props) =>
   return (
     <>
       <TableWrapper>
-        <Link href={`${siteRoutes.coreUnitReports(cu?.shortCode)}/${queryStrings}`} passHref legacyBehavior>
+        <Link href={`${siteRoutes.coreUnitAbout(cu?.shortCode)}/${queryStrings}`} passHref legacyBehavior>
           <TableRow isLight={isLight} isLoading={isLoading} columns={columns}>
             {columns?.map((column) => (
               <TableCell key={column?.header}>{column.cellRender?.(cu)}</TableCell>


### PR DESCRIPTION
## Ticket
https://trello.com/c/FA7EohUK/386-qa-issues-bug-findings-fusion-v5

## Description
All the spaces in the CU items of the CU table go to the CU Profile page, except the expense data and the last activity that goes to expense reports and activity respectively 

## What solved
- [X] ALL SCREENS / Core Units list: the section indicated in red should link to CUs profile page
