### PR TITLE
[QA] Fix doughnut chart percentage

### DIFF
--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
@@ -48,6 +48,7 @@ const ContainerLegend = styled.div<{ isCoreThirdLevel: boolean; changeAlignment:
     gap: isCoreThirdLevel ? 16 : 14,
     maxWidth: '100%',
     maxHeight: isCoreThirdLevel ? 180 : 210,
+
     [lightTheme.breakpoints.up('desktop_1280')]: {
       gap: 16,
       columnGap: 32,

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -443,7 +443,7 @@ const SwiperWrapper = styled.div<{ isCoreThirdLevel: boolean; numberSliderPerLev
       position: 'relative',
       height: 'calc(100% - 8px)',
       ...(numberSliderPerLevel === 10 && {
-        minWidth: 340,
+        minWidth: 365,
         height: 'calc(100% - 10px)',
       }),
     },

--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
@@ -50,7 +50,7 @@ const ItemLegendDoughnut: React.FC<Props> = ({
             ? '<0.1'
             : doughnutData.percent < 1
             ? usLocalizedNumber(doughnutData.percent, 2)
-            : Math.round(doughnutData.percent)
+            : usLocalizedNumber(doughnutData.percent, 1)
         }%)`}</Percent>
         <ContainerValue>
           <Value isLight={isLight} isCoreThirdLevel={isCoreThirdLevel}>

--- a/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -241,28 +241,6 @@ export const useCardChartOverview = (
     });
   }, [budgetMetrics, isLight, metric, selectedMetric]);
 
-  // Check some value affect the total 100%
-  const totalPercent = doughnutSeriesData.reduce((acc, curr) => acc + Math.round(curr.percent), 0);
-  // Verify that sum of percent its 100% and there its not a 0%
-  if (totalPercent !== 100 && totalPercent !== 0) {
-    const difference = 100 - totalPercent;
-    doughnutSeriesData.forEach((item) => {
-      if (item.percent < 1) return;
-      const adjustment = (item.percent / totalPercent) * difference;
-      item.percent = Math.round(item.percent + adjustment);
-    });
-
-    const checkForPercent = doughnutSeriesData.reduce((acc, curr) => acc + Math.round(curr.percent), 0);
-    const roundingError = 100 - checkForPercent;
-    if (roundingError !== 0) {
-      const indexToAdjust = doughnutSeriesData.findIndex((item) => Math.round(item.percent) >= 1);
-      // Fix the percent with some index in array of values
-      if (indexToAdjust !== -1) {
-        doughnutSeriesData[indexToAdjust].percent += roundingError;
-      }
-    }
-  }
-
   const numberItems = doughnutSeriesData.length;
   const changeAlignment = numberItems > 4;
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/FA7EohUK/386-qa-issues-bug-findings-fusion-v5

## Description
Add a decimal place to the percent in the doughnut chart. Also adjusted the legend container width to fit the legend width

## What solved
- [X]  ALL SCREENS / Donut chart current behaviour: Percentage values are rounded, so the sum will not be exactly 100%, adding a difference to one of the budget categories. 
