### PR TITLE
[QA] Fix delegates link in the buget statement section

### DIFF
--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
@@ -41,11 +41,18 @@ const DelegateExpenseTrendItem: React.FC<Props> = ({ budget, selectedMetric, now
   const isCoreUnitElement = budget.ownerType === 'CoreUnit';
 
   const link = useMemo(() => {
-    if (budget.ownerType === 'CoreUnit') {
-      return `${siteRoutes.coreUnitReports(budget.owner.shortCode)}?viewMonth=${DateTime.fromFormat(
-        budget.month,
-        'yyyy-LL-dd'
-      ).toFormat('LLLyyyy')}`;
+    switch (budget.ownerType) {
+      case 'CoreUnit':
+        return `${siteRoutes.coreUnitReports(budget.owner.shortCode)}?viewMonth=${DateTime.fromFormat(
+          budget.month,
+          'yyyy-LL-dd'
+        ).toFormat('LLLyyyy')}`;
+
+      case 'Delegates':
+        return `${siteRoutes.recognizedDelegateReport}?viewMonth=${DateTime.fromFormat(
+          budget.month,
+          'yyyy-LL-dd'
+        ).toFormat('LLLyyyy')}`;
     }
 
     // ecosystem actor by default


### PR DESCRIPTION
## Ticket
https://trello.com/c/FA7EohUK/386-qa-issues-bug-findings-fusion-v5

## Description
Previously the delegate's budgets were going to the ecosystem actors page instead of its own reporting page

## What solved
- [X] ALL SCREENS / Delegates, AlignedDelegates, Keepers, SPFs URLs for budget statements: should not include ecosystem actors in the URL.
