### PR TITLE
[EML] Add cumulative select button

### DIFF
--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -161,6 +161,7 @@ const dictionary = [
   'keyframes',
   'Uncategorized',
   'coord',
+  'dataset',
 ];
 
 module.exports = dictionary;

--- a/src/stories/components/svg/RadioInputSVG.tsx
+++ b/src/stories/components/svg/RadioInputSVG.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  checked: boolean;
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+const RadioInputSVG: React.FC<Props> = ({ checked, className, width = 12, height = 12 }) => (
+  <svg
+    className={className}
+    width={width}
+    height={height}
+    viewBox="0 0 12 13"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle cx="6" cy="6.5" r="5.625" stroke="#231536" strokeWidth="0.75" />
+    {checked && <circle cx="6" cy="6.5" r="4" fill="#231536" />}
+  </svg>
+);
+
+export default RadioInputSVG;

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/CumulativeFilter/CumulativeFilter.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/CumulativeFilter/CumulativeFilter.tsx
@@ -20,9 +20,7 @@ const CumulativeFilter: React.FC = () => {
   };
 
   const handleCheck = () => {
-    if (isActive) {
-      setCumulativeType(undefined);
-    }
+    setCumulativeType(isActive ? undefined : 'relative');
     setIsActive((prev) => !prev);
   };
 

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/CumulativeFilter/CumulativeFilter.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/CumulativeFilter/CumulativeFilter.tsx
@@ -1,0 +1,139 @@
+import { ClickAwayListener, Grow, Paper, Popper, styled } from '@mui/material';
+import CheckOnComponent from '@ses/components/svg/check-on-new';
+import CheckboxOff from '@ses/components/svg/checkbox-off';
+import { ThreeDots } from '@ses/components/svg/three-dots';
+import { useState, useRef } from 'react';
+import CumulativeSelectItem from './CumulativeSelectItem';
+
+export type CumulativeType = 'relative' | 'absolute';
+
+const CumulativeFilter: React.FC = () => {
+  const [isActive, setIsActive] = useState<boolean>(false);
+  const [open, setOpen] = useState<boolean>(false);
+  const anchorRef = useRef(null);
+  const [cumulativeType, setCumulativeType] = useState<CumulativeType | undefined>();
+
+  const handleOpenMenu = () => {
+    if (isActive) {
+      setOpen((prev) => !prev);
+    }
+  };
+
+  const handleCheck = () => {
+    if (isActive) {
+      setCumulativeType(undefined);
+    }
+    setIsActive((prev) => !prev);
+  };
+
+  return (
+    <>
+      <SelectBtn>
+        <CheckBtn onClick={handleCheck}>
+          {isActive ? (
+            <CheckOnComponent fill="#25273D" fillDark="#1AAB9B" width={12} height={12} />
+          ) : (
+            <CheckboxOff fill="#25273D" fillDark="#1AAB9B" width={12} height={12} />
+          )}
+        </CheckBtn>
+        Cumulative{' '}
+        <MenuBtn isActive={isActive} onClick={handleOpenMenu} ref={anchorRef}>
+          <ThreeDots fill={isActive ? '#231536' : '#91929D'} height={12} width={3} />
+        </MenuBtn>
+      </SelectBtn>
+
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        style={{ zIndex: 1 }}
+        placement="bottom-end"
+        transition
+        disablePortal
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === 'bottom-start' ? 'left top' : placement === 'bottom-end' ? 'right top' : 'left bottom',
+            }}
+          >
+            <CustomPaper>
+              <ClickAwayListener onClickAway={() => setOpen(false)}>
+                <div>
+                  <CumulativeSelectItem
+                    onClick={() => setCumulativeType('relative')}
+                    type="relative"
+                    selected={cumulativeType === 'relative'}
+                  />
+                  <Divider />
+                  <CumulativeSelectItem
+                    onClick={() => setCumulativeType('absolute')}
+                    type="absolute"
+                    selected={cumulativeType === 'absolute'}
+                  />
+                </div>
+              </ClickAwayListener>
+            </CustomPaper>
+          </Grow>
+        )}
+      </Popper>
+    </>
+  );
+};
+
+export default CumulativeFilter;
+
+const SelectBtn = styled('button')(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
+  color: theme.palette.mode === 'light' ? '#231536' : '#E2D8EE',
+  fontFamily: 'Inter, sans-serif',
+  fontSize: 14,
+  lineHeight: '18px',
+  fontWeight: 500,
+  background: theme.palette.mode === 'light' ? '#ffffff' : '#10191F',
+  borderRadius: 24,
+  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : '#343442'}`,
+  padding: '7px 16px',
+  outline: 'none',
+}));
+
+const CheckBtn = styled('div')(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 16,
+  height: 16,
+  cursor: 'pointer',
+}));
+
+const MenuBtn = styled('div')<{ isActive: boolean }>(({ isActive }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 16,
+  height: 16,
+  cursor: isActive ? 'pointer' : 'auto',
+}));
+
+const CustomPaper = styled(Paper)(({ theme }) => ({
+  width: 282,
+  background: theme.palette.mode === 'light' ? '#ffffff' : '#000A13',
+  borderRadius: 6,
+  overflow: 'hidden',
+  boxShadow:
+    theme.palette.mode === 'light'
+      ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
+      : '10px 15px 20px 6px rgba(20, 0, 141, 0.10)',
+  marginTop: 9,
+  marginRight: -18,
+}));
+
+const Divider = styled('div')(({ theme }) => ({
+  height: 1,
+  width: '100%',
+  background: theme.palette.mode === 'light' ? '#D4D9E1' : 'red',
+}));

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/CumulativeFilter/CumulativeSelectItem.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/CumulativeFilter/CumulativeSelectItem.tsx
@@ -1,0 +1,121 @@
+import { styled } from '@mui/material';
+import RadioInputSVG from '@ses/components/svg/RadioInputSVG';
+
+type ItemType = 'relative' | 'absolute';
+
+interface CumulativeSelectItemProps {
+  type: ItemType;
+  selected: boolean;
+  onClick: () => void;
+}
+
+const RelativeIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <line
+      x1="1.3999"
+      y1="15.5858"
+      x2="14.1278"
+      y2="2.85786"
+      stroke="#546978"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeDasharray="4 4"
+    />
+    <path d="M1 1L0.999999 17" stroke="#231536" strokeWidth="2" strokeLinecap="round" />
+    <path d="M1 17L17 17" stroke="#231536" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+const AbsoluteIcon = () => (
+  <svg width="18" height="19" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M1.11719 11.9424L15.2593 4.20025"
+      stroke="#546978"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeDasharray="4 4"
+    />
+    <path d="M1 1.02539L0.999999 17.0254" stroke="#231536" strokeWidth="2" strokeLinecap="round" />
+    <path d="M1 17.0254L17 17.0254" stroke="#231536" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+const CumulativeSelectItem: React.FC<CumulativeSelectItemProps> = ({ type, selected, onClick }) => (
+  <Item type={type} onClick={onClick}>
+    <Content>
+      <Icon>{type === 'relative' ? <RelativeIcon /> : <AbsoluteIcon />}</Icon>
+      <TextContainer>
+        <Title>{type === 'relative' ? 'Relative' : 'Absolute'} Cumulative</Title>
+        <Description>
+          {type === 'relative'
+            ? 'Aggregated expense metrics relative to the start of the year'
+            : 'A continuous aggregation of expenses over the entire dataset'}
+        </Description>
+      </TextContainer>
+    </Content>
+    <CheckIcon>
+      <RadioInput checked={selected} />
+    </CheckIcon>
+  </Item>
+);
+
+export default CumulativeSelectItem;
+
+const Item = styled('div')<{ type: ItemType }>(({ theme, type }) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  cursor: 'pointer',
+  padding: type === 'relative' ? '24px 16px 20px' : '20px 16px 24px',
+  gap: 16,
+
+  '&:hover': {
+    backgroundColor: theme.palette.mode === 'light' ? '#F7F9FA' : 'red',
+  },
+}));
+
+const Content = styled('div')({
+  display: 'flex',
+  gap: 8,
+});
+
+const Icon = styled('div')({
+  width: 16,
+  height: 16,
+});
+
+const TextContainer = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+});
+
+const Title = styled('div')(({ theme }) => ({
+  fontSize: 14,
+  lineHeight: '17px',
+  fontWeight: 400,
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+}));
+
+const Description = styled('div')(({ theme }) => ({
+  fontSize: 12,
+  lineHeight: '15px',
+  color: theme.palette.mode === 'light' ? '#708390' : 'red',
+}));
+
+const CheckIcon = styled('div')(() => ({
+  width: 16,
+  height: 16,
+}));
+
+const RadioInput = styled(RadioInputSVG)(({ theme }) => ({
+  '& > circle:first-of-type': {
+    stroke: theme.palette.mode === 'light' ? '#231536' : 'red',
+  },
+
+  '& > circle:nth(2)': {
+    fill: theme.palette.mode === 'light' ? '#231536' : 'red',
+  },
+}));

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/TitleFilterComponent.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/TitleFilterComponent.tsx
@@ -3,6 +3,7 @@ import SingleItemSelect from '@ses/components/SingleItemSelect/SingleItemSelect'
 import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import SectionTitle from '../../SectionTitle/SectionTitle';
+import CumulativeFilter from './CumulativeFilter/CumulativeFilter';
 import type { AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
 
 interface Props {
@@ -19,6 +20,7 @@ const TitleFilterComponent: React.FC<Props> = ({ title, handleChange, selectedVa
     />
 
     <FilterContainer>
+      <CumulativeFilter />
       <PeriodicSelectionFilter>
         <PeriodSelect
           items={[
@@ -64,7 +66,10 @@ const Container = styled.div({
 });
 
 const FilterContainer = styled.div({
+  display: 'flex',
   alignSelf: 'flex-end',
+  gap: 16,
+
   [lightTheme.breakpoints.up('tablet_768')]: {},
 });
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/tnG3VXBf/373-user-story-eml-21-cumulative-metric-check-for-expense-line-chart

## Description
Added the UI of the cumulative select item

## What solved
- [X] Should add in the Expense Metrics Line chart section, a new dropdown with the label: "Cumulative"
- [X] Should the dropdown contain the option to check/uncheck (checkbox)
- [X] Should the dropdown have the option to expand.
- [X]  Should display the Relative Cumulative and Absolute Cumulative options when the dropdown is expanded.
- [X] Should the dropdown be unchecked by default with the expand option disabled.
- [X] Should enable the expand option when the dropdown is checked. 
- [X] Should allow to check/uncheck the dropdown without opening the component.
- [X] Should the dropdown be expanded when clicking on the expand option showing the Relative Cumulative option selected by default.

## Screenshots (if apply)
![Screenshot_709](https://github.com/makerdao-ses/ecosystem-dashboard/assets/29311855/335181dc-0a7c-4463-b929-70a64196bf09)
