### PR TITLE
[QA] Fix doughnut chart number rounding in the tooltip

### DIFF
--- a/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
+++ b/src/stories/containers/Finances/components/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances.tsx
@@ -116,7 +116,7 @@ const DoughnutChartFinances: React.FC<Props> = ({
               ? '<0.1'
               : itemRender.percent < 1
               ? usLocalizedNumber(itemRender.percent, 2)
-              : Math.round(itemRender.percent)
+              : usLocalizedNumber(itemRender.percent, 1)
           }%</div>
           <div style="margin-bottom:16px;color:${
             isLight ? '#000' : '#EDEFFF'


### PR DESCRIPTION
## Ticket
https://trello.com/c/FA7EohUK/386-qa-issues-bug-findings-fusion-v5

## Description
The numbers of the tooltip were being rounded to 0 decimal places which had incongruences between the legend and the tooltip

## What solved
- [X] Navigate to the [link](http://46.101.104.232:82/finances/legacy/core-units?year=2023) 2) Add up the percentages from the donut and from the indicators  **Expected Output:** The sum should be 100% **Current Output:** The sum is not 100%. From the donut is 101% and from the indicator 99.9% 
