### PR TITLE
[EML] Implement cumulative expenses metric filter

### DIFF
--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -168,6 +168,10 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
           title={`${levelNumber === 1 ? 'MakerDAO' : title} Expense Metrics`}
           handleGranularityChange={makerDAOExpensesMetrics.handleGranularityChange}
           selectedGranularity={makerDAOExpensesMetrics.selectedGranularity}
+          isCumulative={makerDAOExpensesMetrics.isCumulative}
+          handleToggleCumulative={makerDAOExpensesMetrics.handleToggleCumulative}
+          cumulativeType={makerDAOExpensesMetrics.cumulativeType}
+          handleChangeCumulativeType={makerDAOExpensesMetrics.handleChangeCumulativeType}
           series={makerDAOExpensesMetrics.series}
           handleToggleSeries={makerDAOExpensesMetrics.handleToggleSeries}
           isLoading={makerDAOExpensesMetrics.isLoading}

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/CumulativeFilter/CumulativeFilter.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/CumulativeFilter/CumulativeFilter.tsx
@@ -4,39 +4,43 @@ import CheckboxOff from '@ses/components/svg/checkbox-off';
 import { ThreeDots } from '@ses/components/svg/three-dots';
 import { useState, useRef } from 'react';
 import CumulativeSelectItem from './CumulativeSelectItem';
+import type { CumulativeType } from '../useMakerDAOExpenseMetrics';
 
-export type CumulativeType = 'relative' | 'absolute';
+interface CumulativeFilterProps {
+  isCumulative: boolean;
+  handleToggleCumulative: () => void;
+  cumulativeType: CumulativeType;
+  handleChangeCumulativeType: (value: CumulativeType) => void;
+}
 
-const CumulativeFilter: React.FC = () => {
-  const [isActive, setIsActive] = useState<boolean>(false);
+const CumulativeFilter: React.FC<CumulativeFilterProps> = ({
+  isCumulative,
+  handleToggleCumulative,
+  cumulativeType,
+  handleChangeCumulativeType,
+}) => {
   const [open, setOpen] = useState<boolean>(false);
   const anchorRef = useRef(null);
-  const [cumulativeType, setCumulativeType] = useState<CumulativeType | undefined>();
 
   const handleOpenMenu = () => {
-    if (isActive) {
+    if (isCumulative) {
       setOpen((prev) => !prev);
     }
-  };
-
-  const handleCheck = () => {
-    setCumulativeType(isActive ? undefined : 'relative');
-    setIsActive((prev) => !prev);
   };
 
   return (
     <>
       <SelectBtn>
-        <CheckBtn onClick={handleCheck}>
-          {isActive ? (
+        <CheckBtn onClick={handleToggleCumulative}>
+          {isCumulative ? (
             <CheckOnComponent fill="#25273D" fillDark="#1AAB9B" width={12} height={12} />
           ) : (
             <CheckboxOff fill="#25273D" fillDark="#1AAB9B" width={12} height={12} />
           )}
         </CheckBtn>
         Cumulative{' '}
-        <MenuBtn isActive={isActive} onClick={handleOpenMenu} ref={anchorRef}>
-          <ThreeDots fill={isActive ? '#231536' : '#91929D'} height={12} width={3} />
+        <MenuBtn isActive={isCumulative} onClick={handleOpenMenu} ref={anchorRef}>
+          <ThreeDots fill={isCumulative ? '#231536' : '#91929D'} height={12} width={3} />
         </MenuBtn>
       </SelectBtn>
 
@@ -60,13 +64,13 @@ const CumulativeFilter: React.FC = () => {
               <ClickAwayListener onClickAway={() => setOpen(false)}>
                 <div>
                   <CumulativeSelectItem
-                    onClick={() => setCumulativeType('relative')}
+                    onClick={() => handleChangeCumulativeType('relative')}
                     type="relative"
                     selected={cumulativeType === 'relative'}
                   />
                   <Divider />
                   <CumulativeSelectItem
-                    onClick={() => setCumulativeType('absolute')}
+                    onClick={() => handleChangeCumulativeType('absolute')}
                     type="absolute"
                     selected={cumulativeType === 'absolute'}
                   />

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOExpenseMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOExpenseMetrics.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import MakerDAOChartMetrics from './MakerDAOChartMetrics/MakerDAOChartMetrics';
 import MakerDAOExpenseMetricsSkeleton from './MakerDAOExpenseMetricsSkeleton';
 import TitleFilterComponent from './TitleFilterComponent';
+import type { CumulativeType } from './useMakerDAOExpenseMetrics';
 import type { LineChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
 
@@ -11,6 +12,10 @@ interface Props {
   title: string;
   handleGranularityChange: (value: AnalyticGranularity) => void;
   selectedGranularity: AnalyticGranularity;
+  isCumulative: boolean;
+  handleToggleCumulative: () => void;
+  cumulativeType: CumulativeType;
+  handleChangeCumulativeType: (value: CumulativeType) => void;
   series: LineChartSeriesData[];
   handleToggleSeries: (series: string) => void;
   year: string;
@@ -21,13 +26,25 @@ const MakerDAOExpenseMetricsFinances: React.FC<Props> = ({
   title,
   handleGranularityChange,
   selectedGranularity,
+  isCumulative,
+  handleToggleCumulative,
+  cumulativeType,
+  handleChangeCumulativeType,
   series,
   handleToggleSeries,
   year,
   isLoading,
 }) => (
   <Container>
-    <TitleFilterComponent title={title} handleChange={handleGranularityChange} selectedValue={selectedGranularity} />
+    <TitleFilterComponent
+      title={title}
+      handleChange={handleGranularityChange}
+      selectedValue={selectedGranularity}
+      isCumulative={isCumulative}
+      handleToggleCumulative={handleToggleCumulative}
+      cumulativeType={cumulativeType}
+      handleChangeCumulativeType={handleChangeCumulativeType}
+    />
     <ContainerChart>
       {isLoading ? (
         <MakerDAOExpenseMetricsSkeleton />

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/TitleFilterComponent.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/TitleFilterComponent.tsx
@@ -4,15 +4,28 @@ import lightTheme from '@ses/styles/theme/light';
 import React from 'react';
 import SectionTitle from '../../SectionTitle/SectionTitle';
 import CumulativeFilter from './CumulativeFilter/CumulativeFilter';
+import type { CumulativeType } from './useMakerDAOExpenseMetrics';
 import type { AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
 
 interface Props {
   title: string;
   handleChange: (value: AnalyticGranularity) => void;
   selectedValue: AnalyticGranularity;
+  isCumulative: boolean;
+  handleToggleCumulative: () => void;
+  cumulativeType: CumulativeType;
+  handleChangeCumulativeType: (value: CumulativeType) => void;
 }
 
-const TitleFilterComponent: React.FC<Props> = ({ title, handleChange, selectedValue }) => (
+const TitleFilterComponent: React.FC<Props> = ({
+  title,
+  handleChange,
+  selectedValue,
+  isCumulative,
+  handleToggleCumulative,
+  cumulativeType,
+  handleChangeCumulativeType,
+}) => (
   <Container>
     <SectionTitle
       title={title}
@@ -20,7 +33,12 @@ const TitleFilterComponent: React.FC<Props> = ({ title, handleChange, selectedVa
     />
 
     <FilterContainer>
-      <CumulativeFilter />
+      <CumulativeFilter
+        isCumulative={isCumulative}
+        handleToggleCumulative={handleToggleCumulative}
+        cumulativeType={cumulativeType}
+        handleChangeCumulativeType={handleChangeCumulativeType}
+      />
       <PeriodicSelectionFilter>
         <PeriodSelect
           items={[


### PR DESCRIPTION
## Ticket
https://trello.com/c/tnG3VXBf/373-user-story-eml-21-cumulative-metric-check-for-expense-line-chart

## Description
Implement the Expense metrics cumulative filter to show the correct data in the chart

## What solved
- [X] Should the chart display cumulative data starting from the very beginning of the available data set, when Absolute Cumulative is checked.
- [X] Should the chart reset the cumulative count to 0 at the beginning of the selected time period (e.g., the start of the year, quarter, or month based on the user's granularity selection), when Relative Cumulative option is selected.
- [X] Should the selection between the Absolute and Relative options be done without reloading the page.
- [X] Should the system remember the user's last selection and apply it as the default option for subsequent views until the user changes it again.
- [X] Should this user story be applied to all granularity options (Monthly, Quarterly, Yearly) available in the cumulative view.
- [X] Should the Absolute Cumulative option be represented starting point of the chart is a cumulative value of a selected metric up to the start of the specified period. 

## Screenshots (if apply)
