### PR TITLE
Fix gnosis link

### DIFF
--- a/src/stories/components/WalletTableCell/WalletTableCell.tsx
+++ b/src/stories/components/WalletTableCell/WalletTableCell.tsx
@@ -39,7 +39,7 @@ export const WalletTableCell = (props: WalletTableCellProps) => {
           <IconsContainer>
             <CopyIcon text={props.address ?? ''} defaultTooltip="Copy Address" />
 
-            <a href={`https://gnosis-safe.io/app/eth:${props.address}`} target="_blank">
+            <a href={`https://app.safe.global/home?safe=eth:${props.address}`} target="_blank">
               <Gnosis />
             </a>
           </IconsContainer>

--- a/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
+++ b/src/stories/containers/TransparencyReport/transparencyReportUtils.tsx
@@ -43,7 +43,7 @@ export const renderLinks = (address: string) => (
     </CustomLink>
     <CustomLink
       fontFamily={'Inter, sans-serif'}
-      href={`https://gnosis-safe.io/app/eth:${address}`}
+      href={`https://app.safe.global/home?safe=eth:${address}`}
       fontSize={16}
       fontSizeMobile={14}
       fontWeight={500}


### PR DESCRIPTION
## Ticket
https://trello.com/c/FA7EohUK/386-qa-issues-bug-findings-fusion-v5

## Description
Fix gnosis scan link

## What solved
- [X] ALL SCREENS / Gnosis Safe link: Gnosis Safe upgraded their front-end and the links no longer work in the expense reports. (applicable to all budget categories where gnosis safe is used in the MKR tab).   https://app.safe.global/home?safe=eth: after “:” enter the ethereum address as a variable.  after “:” enter the ethereum address as a variable.
