### PR TITLE
[QA] Fix quarterly tooltip spacing in title

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -120,8 +120,8 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
           return `
             <div style="background-color:${isLight ? '#fff' : '#000A13'};padding:16px;overflow:auto;border-radius:3px;">
               <div style="margin-bottom:16px;font-size:12px;font-weight:600;color:#B6BCC2;">${
-                (selectedGranularity as string) === 'Annually' ? year : params?.[0]?.name
-              }<span style="display:inline-block;margin-left:10px">${getSelectMetricText(selectedMetric)}</span></div>
+                (selectedGranularity as string) === 'Annually' ? year : params?.[0]?.name?.replace('’', "'")
+              }<span style="display:inline-block;margin-left:4px">${getSelectMetricText(selectedMetric)}</span></div>
               <div style="display:flex;flex-direction:${flexDirection};gap:${gap};${wrap}${minMax}">
                 ${filteredParams
                   .reverse()

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -116,12 +116,12 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
           <div style="background-color:${isLight ? '#fff' : '#000A13'};padding:16px;overflow:auto;border-radius:3px;">
             <div style="display: flex;justify-content: space-between;gap:24px;text-align:center;">
               <div style="margin-bottom:16px;font-size:12px;font-weight:600;color:#B6BCC2;">${
-                (selectedGranularity as string) === 'Annually' ? year : params?.[0]?.name
+                (selectedGranularity as string) === 'Annually' ? year : params?.[0]?.name?.replace('’', "'")
               }</div>
               ${
                 isCumulative
                   ? `<div style="text-transform:uppercase;font-weight:300;font-size:11px;color:${
-                      isLight ? '#434358' : '#546978'
+                      isLight ? '#434358' : '#B6BCC2'
                     }">${cumulativeType} cumulative</div>`
                   : ''
               }


### PR DESCRIPTION
## Ticket
https://trello.com/c/FA7EohUK/386-qa-issues-bug-findings-fusion-v5

## Description
Fix the spacing between the Q' and the number of the quarter in the tooltip

## What solved
- [X] ALL SCREENS / Breakdown chart: popup window on quarterly granularity has too much space. 
