### PR TITLE
[QA] Change the modal title font size

### DIFF
--- a/src/stories/containers/Finances/components/BudgetMetricsModal/BudgetMetricsModal.tsx
+++ b/src/stories/containers/Finances/components/BudgetMetricsModal/BudgetMetricsModal.tsx
@@ -171,8 +171,8 @@ const ContainerTitle = styled('div')(({ theme }) => ({
 }));
 
 const Title = styled('div')(({ theme }) => ({
-  fontSize: 16,
-  lineHeight: '19px',
+  fontSize: 14,
+  lineHeight: '17px',
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
   fontWeight: 700,
@@ -180,8 +180,8 @@ const Title = styled('div')(({ theme }) => ({
 
   [theme.breakpoints.up('tablet_768')]: {
     fontWeight: 600,
-    fontSize: 24,
-    lineHeight: '29px',
+    fontSize: 16,
+    lineHeight: '19px',
     letterSpacing: '0.4px',
   },
 }));


### PR DESCRIPTION
## Ticket
https://trello.com/c/FA7EohUK/386-qa-issues-bug-findings-fusion-v5

## Description
Changed the font size of the title of the metric modal

## What solved
- [X] Change the font size of 'Budget' to 14px. (Requested in the Sprint Review). 
