### PR TITLE
[QA] Add units to the reserves chart on mobile

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -94,7 +94,7 @@ export const builderWaterfallSeries = (
           if (formatted.value === '0.0') return '';
           if (isMobile) {
             if (params.dataIndex === 0 || params.dataIndex === help.length - 1) {
-              return `{colorful|${formatted.value}}`;
+              return `{colorful|${formatted.value}\n${formatted.suffix}}`;
             }
             return `{hidden|${formatted.value}}`;
           } else {
@@ -110,6 +110,7 @@ export const builderWaterfallSeries = (
             color: isLight ? '#83A7FF' : '#447AFB',
             fontSize: isMobile ? 8 : 12,
             fontFamily: 'Inter, sans-serif',
+            align: 'center',
           },
           hidden: {
             color: 'rgba(0,0,0,0)',
@@ -147,7 +148,7 @@ export const builderWaterfallSeries = (
 
           if (formatted.value === '0.0') return '';
           if (isMobile) {
-            return `-${formatted.value}`;
+            return `-${formatted.value}\n${formatted.suffix}`;
           }
           return `-${formatted.value}${formatted.suffix}`;
         },
@@ -180,7 +181,7 @@ export const builderWaterfallSeries = (
 
           if (formatted.value === '0.0') return '';
           if (isMobile) {
-            return `+${formatted.value}`;
+            return `+${formatted.value}\n${formatted.suffix}`;
           }
 
           return `+${formatted.value}${formatted.suffix}`;


### PR DESCRIPTION
## Ticket
https://trello.com/c/FA7EohUK/386-qa-issues-bug-findings-fusion-v5

## Description
Add the unit to each column in the reserves chart in mobile

## What solved
- [X] MOBILE / Reserves chart: reduce the font size, remove the margin so there is space for units being horizontally places after values, if this does not work, put the units under values.