### PR TITLE
[QA] Fix reserves chart bar legend format

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
+++ b/src/stories/containers/Finances/components/SectionPages/ReservesWaterfallChartSection/utils.ts
@@ -94,7 +94,7 @@ export const builderWaterfallSeries = (
           if (formatted.value === '0.0') return '';
           if (isMobile) {
             if (params.dataIndex === 0 || params.dataIndex === help.length - 1) {
-              return `{colorful|${formatted.value}\n${formatted.suffix}}`;
+              return `{colorful|${formatted.value}${formatted.suffix}}`;
             }
             return `{hidden|${formatted.value}}`;
           } else {
@@ -148,7 +148,8 @@ export const builderWaterfallSeries = (
 
           if (formatted.value === '0.0') return '';
           if (isMobile) {
-            return `-${formatted.value}\n${formatted.suffix}`;
+            const numberWithoutZero = formatted.value.replace('0.', '.');
+            return `${numberWithoutZero}${formatted.suffix}`;
           }
           return `-${formatted.value}${formatted.suffix}`;
         },
@@ -181,7 +182,8 @@ export const builderWaterfallSeries = (
 
           if (formatted.value === '0.0') return '';
           if (isMobile) {
-            return `+${formatted.value}\n${formatted.suffix}`;
+            const numberWithoutZero = formatted.value.replace('0.', '.');
+            return `${numberWithoutZero}${formatted.suffix}`;
           }
 
           return `+${formatted.value}${formatted.suffix}`;


### PR DESCRIPTION
## Ticket
https://trello.com/c/MKKLmwnP/395-qa-issues-bug-findings-fusion-v6

## Description
Change the format of the bar legend on the reserves chart

## What solved
- [X] MOBILE / Reserves Chart. Fix: Put everything back on the same line again without signs and leading zeros. • Drop the sign (+/-) from the numbers. The color and the placement above or below the bars indicates inflow vs outflow enough. • Drop the leading zeros in case of 0.?? numbers. So “.65M” instead of “0.65M”  —This is next iteration of issue https://www.notion.so/makerdao-ses/MOBILE-Reserves-chart-reduce-the-font-size-remove-the-margin-so-there-is-space-for-units-M-or-K-4385f7ad1aac4f5b8bc466dfe9e4df39 and will be included as hotfix to Release on May 2nd. 
