### PR TITLE
[QA] Hide the budget status when there is no status in the budget statement

### DIFF
--- a/src/stories/components/TransparencyReporting/BudgetStatementPager/BudgetStatementPager.tsx
+++ b/src/stories/components/TransparencyReporting/BudgetStatementPager/BudgetStatementPager.tsx
@@ -14,7 +14,7 @@ interface BudgetStatementPagerProps {
   handleNext: () => void;
   hasNext: boolean;
   hasPrevious: boolean;
-  budgetStatus: BudgetStatus;
+  budgetStatus?: BudgetStatus;
   showExpenseReportStatusCTA: boolean;
   lastUpdate?: DateTime;
 }

--- a/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
+++ b/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
@@ -90,7 +90,6 @@ const CardNavigationMobile: React.FC<Props> = ({
                       />
                     </ContainerBar>
                     <Percent isLight={isLight} isRightPartZero={budgetCap === 0}>
-                      {/* TODO: if the budget cap is 0 then show -- % */}
                       {budgetCap === 0
                         ? '-- '
                         : percent === 0

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -12,7 +12,6 @@ import lightTheme from '../../../../styles/theme/light';
 import { CommentActivityContext } from '../../../core/context/CommentActivityContext';
 import { useThemeContext } from '../../../core/context/ThemeContext';
 import { useFlagsActive } from '../../../core/hooks/useFlagsActive';
-import { BudgetStatus } from '../../../core/models/dto/coreUnitDTO';
 import { toAbsoluteURL } from '../../../core/utils/urls';
 import { CoreUnitSummary } from '../../components/CoreUnitSummary/CoreUnitSummary';
 import { CustomLink } from '../../components/CustomLink/CustomLink';
@@ -101,7 +100,7 @@ export const TransparencyReport = ({
               handlePrevious={handlePreviousMonth}
               hasNext={hasNextMonth()}
               hasPrevious={hasPreviousMonth()}
-              budgetStatus={currentBudgetStatement?.status || BudgetStatus.Draft}
+              budgetStatus={currentBudgetStatement?.status}
               showExpenseReportStatusCTA={showExpenseReportStatusCTA}
               lastUpdate={lastUpdate}
               ref={pagerRef}

--- a/src/stories/containers/TransparencyReport/components/ExpenseReportStatusIndicator/ExpenseReportStatusIndicator.tsx
+++ b/src/stories/containers/TransparencyReport/components/ExpenseReportStatusIndicator/ExpenseReportStatusIndicator.tsx
@@ -8,13 +8,13 @@ import { BudgetStatus } from '../../../../../core/models/dto/coreUnitDTO';
 import ExpenseReportStatus from '../ExpenseReportStatus/ExpenseReportStatus';
 
 export type ExpenseReportStatusIndicatorProps = {
-  budgetStatus: BudgetStatus;
+  budgetStatus?: BudgetStatus;
   showCTA: boolean;
   className?: string;
 };
 
 const ExpenseReportStatusIndicator: React.FC<ExpenseReportStatusIndicatorProps> = ({
-  budgetStatus = BudgetStatus.Draft,
+  budgetStatus,
   showCTA,
   className,
 }) => {
@@ -29,7 +29,7 @@ const ExpenseReportStatusIndicator: React.FC<ExpenseReportStatusIndicatorProps> 
 
   return (
     <IndicatorContainer className={className}>
-      <ExpenseReportStatus status={budgetStatus} />
+      {budgetStatus && <ExpenseReportStatus status={budgetStatus} />}
       {showCTA && budgetStatus !== BudgetStatus.Final && (
         <Link href={url} shallow={true} legacyBehavior>
           <StyledLink>Go to {budgetStatus}</StyledLink>


### PR DESCRIPTION
## Ticket
https://trello.com/c/MKKLmwnP/395-qa-issues-bug-findings-fusion-v6

## Description
Hide the Budget statement status if it is `undefined`

## What solved
- [X] ALL SCREENS / Expense Reports: for those that are completely empty (not auto-generated) we don’t want to show the status at all.
