### PR TITLE
[QA] Avoid red colors in the breakdown chart

### DIFF
--- a/src/core/utils/colors.ts
+++ b/src/core/utils/colors.ts
@@ -27,7 +27,11 @@ export class LimitedColorAssigner {
     const colors = [];
 
     for (let i = 0; i < numColors; i++) {
-      const hue = (baseHue + i * (360 / numColors)) % 360;
+      let hue = (baseHue + i * (360 / numColors)) % 360;
+      if (hue < 10 || hue > 350) {
+        // skip red hues, make them more orange
+        hue = (hue + 30) % 360;
+      }
       const color = `hsl(${hue}, 70%, 50%)`;
       colors.push(color);
     }


### PR DESCRIPTION
## Ticket
https://trello.com/c/MKKLmwnP/395-qa-issues-bug-findings-fusion-v6

## Description
Avoid red tones in the color palette generation

## What solved
- [X] ALL SCREENS / Breakdown chart: some colored sections of the vertical bars seem to have different width because of the color choices. Lets change the colors so that they will not produce this effect: replace red with a color that looks better with the backgrounds (light & dark mode)
