### PR TITLE
[QA] Double chart y-lines

### DIFF
--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -40,7 +40,6 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
     cardOverViewSectionData,
     handleChangeYears,
     cardsToShow,
-    maxValue,
     breakdownTable,
     canLoadMoreCards,
     showMoreCards,
@@ -120,7 +119,6 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
             </WrapperMobile>
             <CardsNavigation
               cardsNavigationInformation={cardsToShow}
-              maxValue={maxValue}
               canLoadMoreCards={canLoadMoreCards}
               showMoreCards={showMoreCards}
               toggleShowMoreCards={toggleShowMoreCards}

--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -225,6 +225,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
         height: upTable ? 15 : 12,
         type: 'value',
         zlevel: 1,
+        splitNumber: 12,
         axisLine: {
           show: false,
         },

--- a/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
+++ b/src/stories/containers/Finances/components/CardNavigationMobile/CardNavigationMobile.tsx
@@ -3,7 +3,6 @@ import ArrowNavigationForCards from '@ses/components/svg/ArrowNavigationForCards
 import HorizontalBudgetBar from '@ses/containers/FinancesOverview/components/HorizontalBudgetBar/HorizontalBudgetBar';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { threeDigitsPrecisionHumanization, usLocalizedNumber } from '@ses/core/utils/humanization';
-import { percentageRespectTo } from '@ses/core/utils/math';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -22,7 +21,6 @@ interface Props {
   height?: number;
   code: string;
   percent: number;
-  maxValue: number;
 }
 
 const CardNavigationMobile: React.FC<Props> = ({
@@ -34,7 +32,6 @@ const CardNavigationMobile: React.FC<Props> = ({
   barColor,
   code,
   percent,
-  maxValue,
 }) => {
   const { isLight } = useThemeContext();
   const budgetCapFormatted = threeDigitsPrecisionHumanization(budgetCap);
@@ -46,11 +43,6 @@ const CardNavigationMobile: React.FC<Props> = ({
     (code.toLocaleLowerCase() === code ||
       (code.includes('-') && code.toUpperCase() !== code) ||
       /[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?/.test(code));
-
-  const maxPercentage =
-    percentageRespectTo(Math.max(budgetCap, valueDai), maxValue) > 97
-      ? 97
-      : percentageRespectTo(Math.max(budgetCap, valueDai), maxValue);
 
   return (
     <StyleCardNavigationGeneric>
@@ -94,7 +86,6 @@ const CardNavigationMobile: React.FC<Props> = ({
                         budgetCap={budgetCap}
                         actuals={valueDai}
                         prediction={0}
-                        maxPercentage={maxPercentage}
                       />
                     </ContainerBar>
                     <Percent isLight={isLight} isRightPartZero={budgetCap === 0}>

--- a/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -19,7 +19,6 @@ interface Props {
   canLoadMoreCards: boolean;
   showMoreCards: boolean;
   toggleShowMoreCards: () => void;
-  maxValue: number;
 }
 
 const CardsNavigation: React.FC<Props> = ({
@@ -27,7 +26,6 @@ const CardsNavigation: React.FC<Props> = ({
   canLoadMoreCards,
   showMoreCards,
   toggleShowMoreCards,
-  maxValue,
 }) => {
   const { isLight } = useThemeContext();
   const ref = useRef<SwiperRef>(null);
@@ -124,7 +122,6 @@ const CardsNavigation: React.FC<Props> = ({
             key={index}
             percent={card.percent}
             code={card.code ?? ''}
-            maxValue={maxValue}
           />
         ))}
         {canLoadMoreCards && (

--- a/src/stories/containers/Finances/useFinances.tsx
+++ b/src/stories/containers/Finances/useFinances.tsx
@@ -132,10 +132,6 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
         .sort((a, b) => b.percent - a.percent),
     [allMetrics.paymentsOnChain, budgets, budgetsAnalytics, colorsDark, colorsLight, isLight, year]
   );
-  const maxValue = useMemo(
-    () => Math.max(...cardsNavigationInformation.map((element) => [element.valueDai, element.budgetCapValue]).flat()),
-    [cardsNavigationInformation]
-  );
 
   // if there too many cards we need to use a swiper on desktop but paginated on mobile
   const [canLoadMoreCards, setCanLoadMoreCards] = useState<boolean>(cardsNavigationInformation.length > 6);
@@ -183,7 +179,6 @@ export const useFinances = (budgets: Budget[], allBudgets: Budget[], initialYear
     cardOverViewSectionData,
     router,
     cardsToShow,
-    maxValue,
     breakdownChartSectionData,
     breakdownTable,
     canLoadMoreCards,


### PR DESCRIPTION
## Ticket
https://trello.com/c/MKKLmwnP/395-qa-issues-bug-findings-fusion-v6

## Description
Previously it was showing 6 y-lines in the breakdown chart, now it is showing 12

## What solved
- [X] MOBILE / Mid-value support gridlines: introduce an in-between horizontal line between existing y axis values (e.g., 1, 3, 5, 7, 9, if values 0, 4, 6, 8, 10 are shown). Mid-value line has lower opacity and does not show the number values.
