### PR TITLE
[QA] Fix uncategorized totals and classification

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -193,7 +193,15 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     // group data in an easier structure to manage
     analytics.series.forEach((series) => {
       series.rows.forEach((row) => {
-        const path = row.dimensions[0].path;
+        let path = row.dimensions[0].path;
+
+        if (path.includes('*')) {
+          // it can be an uncategorized budget
+          const reducedPath = removePatternAfterSlash(path);
+          if (budgets.some((budget) => budget.codePath === reducedPath)) {
+            path = reducedPath; // it is not uncategorized
+          }
+        }
 
         if (!data[path]) {
           // create the path as it does not exist
@@ -481,7 +489,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     // now we create the main table header
     // it is guaranteed below that all the sub-tables have a header
     const subTableHeaders = tables.map((table) => {
-      const mainRow = table.rows.find((column) => column.isMain);
+      const mainRow = table.rows.find((column) => column.isMain || column.isUncategorized);
       return mainRow ? mainRow.columns : [];
     });
 


### PR DESCRIPTION
## Ticket
[<!--- Your Ticket Link -->](https://trello.com/c/MKKLmwnP/395-qa-issues-bug-findings-fusion-v6)

## Description
Add the totals of the uncategorized sub-table to the global table header

## What solved
- [X] ALL SCREENS / Breakdown Table: “Uncategorized” in breakdown table - everything shows as 0. Does not distribute subcategories. // UPDATE: 1. Totals are missing for uncategorized columns. 2. If the uncategorized is the only one for the table or subsections of the table, then hide it and include it in the totals row for that specific table and/or subsection of the table. 3. If uncategorized is not the only one then show it with other line items. 
