### PR TITLE
[MET-1.5] Add latest updates section

### DIFF
--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -162,6 +162,7 @@ const dictionary = [
   'Uncategorized',
   'coord',
   'dataset',
+  'Lockstake',
 ];
 
 module.exports = dictionary;

--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -163,6 +163,9 @@ const dictionary = [
   'coord',
   'dataset',
   'Lockstake',
+  'Ethereum',
+  'scalability',
+  'foundational',
 ];
 
 module.exports = dictionary;

--- a/src/stories/components/ExternalLink/ExternalLink.tsx
+++ b/src/stories/components/ExternalLink/ExternalLink.tsx
@@ -7,6 +7,7 @@ interface ExternalLinkProps extends React.PropsWithChildren {
   target?: string;
   className?: string;
   showArrow?: boolean;
+  wrapText?: boolean;
 }
 
 const ExternalLink: React.FC<ExternalLinkProps> = ({
@@ -15,9 +16,10 @@ const ExternalLink: React.FC<ExternalLinkProps> = ({
   target = '_blank',
   className,
   showArrow = true,
+  wrapText = false,
 }) => (
   <Link href={href} target={target} className={className}>
-    {children}
+    {wrapText ? <span>{children}</span> : children}
     {showArrow && <ExternalLinkArrow renderLinkTag={false} />}
   </Link>
 );

--- a/src/stories/containers/Endgame/EndgameContainer.tsx
+++ b/src/stories/containers/Endgame/EndgameContainer.tsx
@@ -73,7 +73,6 @@ const EndgameContainer: React.FC<EndgameContainerProps> = ({ budgetTransitionAna
           <KeyChangesSections />
         </Container>
       </div>
-      {/* TODO: fix spacing between sections */}
 
       <Container>
         <SectionSpacing>

--- a/src/stories/containers/Endgame/EndgameContainer.tsx
+++ b/src/stories/containers/Endgame/EndgameContainer.tsx
@@ -12,6 +12,7 @@ import EndgameIntroductionBanner from './components/EndgameIntroductionBanner/En
 import IntroductoryHeadline from './components/IntroductoryHeadline/IntroductoryHeadline';
 import KeyChangesBudgetTransitionStatusSection from './components/KeyChangesBudgetTransitionStatusSection/KeyChangesBudgetTransitionStatusSection';
 import KeyChangesSections from './components/KeyChangesSections/KeyChangesSections';
+import LatestUpdatesSection from './components/LatestUpdatesSection/LatestUpdatesSection';
 import NavigationTabs from './components/NavigationTabs/NavigationTabs';
 import useEndgameContainer from './useEndgameContainer';
 import type { Analytic } from '@ses/core/models/interfaces/analytic';
@@ -26,6 +27,7 @@ interface EndgameContainerProps {
 const EndgameContainer: React.FC<EndgameContainerProps> = ({ budgetTransitionAnalytics, yearsRange, initialYear }) => {
   const {
     isLight,
+    updatesChangesRef,
     keyChangesRef,
     structureRef,
     transitionStatusRef,
@@ -57,16 +59,23 @@ const EndgameContainer: React.FC<EndgameContainerProps> = ({ budgetTransitionAna
       </Container>
       <NavigationTabs activeTab={activeTab} handlePauseUrlUpdate={handlePauseUrlUpdate} />
 
-      <BannerContainer id="section-key-changes">
-        <EndgameIntroductionBanner isKeyChanges />
-      </BannerContainer>
+      <Container>
+        <div ref={updatesChangesRef}>
+          <LatestUpdatesSection />
+        </div>
+      </Container>
+
+      <div ref={keyChangesRef}>
+        <BannerContainer id="section-key-changes">
+          <EndgameIntroductionBanner isKeyChanges />
+        </BannerContainer>
+        <Container>
+          <KeyChangesSections />
+        </Container>
+      </div>
 
       <Container>
         <SectionSpacing>
-          <div ref={keyChangesRef}>
-            <KeyChangesSections />
-          </div>
-
           <div ref={structureRef}>
             <BudgetStructureSection
               totalBudgetCap={budgetStructureData.totalBudgetCap}

--- a/src/stories/containers/Endgame/EndgameContainer.tsx
+++ b/src/stories/containers/Endgame/EndgameContainer.tsx
@@ -73,6 +73,7 @@ const EndgameContainer: React.FC<EndgameContainerProps> = ({ budgetTransitionAna
           <KeyChangesSections />
         </Container>
       </div>
+      {/* TODO: fix spacing between sections */}
 
       <Container>
         <SectionSpacing>

--- a/src/stories/containers/Endgame/components/KeyChangesSections/KeyChangesSections.tsx
+++ b/src/stories/containers/Endgame/components/KeyChangesSections/KeyChangesSections.tsx
@@ -70,6 +70,11 @@ const KeyChangesSectionsContainer = styled.section({
   display: 'flex',
   flexDirection: 'column',
   gap: 32,
+  marginBottom: 48,
+
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    marginBottom: 80,
+  },
 });
 
 export const SectionContainer = styled.div({

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/ImportantLinks.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/ImportantLinks.tsx
@@ -1,6 +1,5 @@
-import { styled, useMediaQuery } from '@mui/material';
+import { styled } from '@mui/material';
 import ExternalLink from '@ses/components/ExternalLink/ExternalLink';
-import type { Theme } from '@mui/material';
 
 export interface ImportantLink {
   href: string;
@@ -12,9 +11,7 @@ export interface ImportantLinksProps {
 }
 
 const ImportantLinks: React.FC<ImportantLinksProps> = ({ links }) => {
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
-
-  if (isMobile && links.length === 0) return null;
+  if (links.length === 0) return null;
 
   return (
     <Content>

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/ImportantLinks.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/ImportantLinks.tsx
@@ -48,7 +48,7 @@ const Content = styled('div')(({ theme }) => ({
   borderRadius: 6,
   padding: '0 8px 8px',
   overflow: 'hidden',
-  background: theme.palette.mode === 'light' ? 'rgba(246, 248, 249, 0.5)' : 'red',
+  background: theme.palette.mode === 'light' ? 'rgba(246, 248, 249, 0.5)' : 'rgba(16, 25, 31, 0.2)',
 
   [theme.breakpoints.up('desktop_1024')]: {
     minWidth: 344,
@@ -57,8 +57,8 @@ const Content = styled('div')(({ theme }) => ({
 }));
 
 const Header = styled('div')(({ theme }) => ({
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
-  background: theme.palette.mode === 'light' ? 'rgba(236, 239, 249, 0.5)' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
+  background: theme.palette.mode === 'light' ? 'rgba(236, 239, 249, 0.5)' : 'rgba(49, 66, 78, 0.8)',
   fontSize: 14,
   fontWeight: 500,
   lineHeight: '18px',

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/ImportantLinks.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/ImportantLinks.tsx
@@ -1,0 +1,145 @@
+import { styled, useMediaQuery } from '@mui/material';
+import ExternalLink from '@ses/components/ExternalLink/ExternalLink';
+import type { Theme } from '@mui/material';
+
+export interface ImportantLink {
+  href: string;
+  label: string;
+}
+
+export interface ImportantLinksProps {
+  links: ImportantLink[];
+}
+
+const ImportantLinks: React.FC<ImportantLinksProps> = ({ links }) => {
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
+
+  if (isMobile && links.length === 0) return null;
+
+  return (
+    <Content>
+      <Header>Important Links</Header>
+
+      {links.length === 0 ? (
+        <NoKeyContainer>
+          <NoKeyResults>No Key Results</NoKeyResults>
+        </NoKeyContainer>
+      ) : (
+        <LinksList>
+          {links.map((link, index) => (
+            <LinkItem key={index}>
+              <ImportantLink href={link.href} target="_blank" wrapText>
+                {link.label}
+              </ImportantLink>
+            </LinkItem>
+          ))}
+        </LinksList>
+      )}
+    </Content>
+  );
+};
+
+export default ImportantLinks;
+
+const Content = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  borderRadius: 6,
+  padding: '0 8px 8px',
+  overflow: 'hidden',
+  background: theme.palette.mode === 'light' ? 'rgba(246, 248, 249, 0.5)' : 'red',
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    minWidth: 344,
+    padding: '0 16px 16px',
+  },
+}));
+
+const Header = styled('div')(({ theme }) => ({
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  background: theme.palette.mode === 'light' ? 'rgba(236, 239, 249, 0.5)' : 'red',
+  fontSize: 14,
+  fontWeight: 500,
+  lineHeight: '18px',
+  padding: '2px 16px',
+  margin: '0 -8px',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 16,
+    padding: '2px 24px',
+    margin: '0 -16px',
+  },
+}));
+
+const NoKeyContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  alignSelf: 'stretch',
+  height: '100%',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    paddingBottom: 8,
+  },
+}));
+
+const NoKeyResults = styled('span')({
+  color: '#546978',
+  fontSize: 16,
+  fontStyle: 'italic',
+  lineHeight: '18px',
+  padding: '16px 0',
+});
+
+const LinksList = styled('ul')({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  margin: 0,
+  padding: 0,
+  height: '100%',
+});
+
+const LinkItem = styled('li')(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  listStyle: 'none',
+  position: 'relative',
+}));
+
+const ImportantLink = styled(ExternalLink)(({ theme }) => ({
+  fontSize: 14,
+  fontWeight: 500,
+  lineHeight: '18px',
+  paddingLeft: 22,
+  position: 'relative',
+  gap: 6,
+  display: 'flex',
+  width: '100%',
+  whiteSpace: 'nowrap',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 16,
+    lineHeight: '18px',
+  },
+
+  '& > span': {
+    flex: 1,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    maxWidth: 'fit-content',
+  },
+
+  '&:before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    left: 8,
+    top: 6,
+    width: 6,
+    height: 6,
+    borderRadius: '50%',
+    background: '#447AFB',
+  },
+}));

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
@@ -1,3 +1,29 @@
-const LatestUpdatesSection: React.FC = () => <div>latest updates</div>;
+import { styled } from '@mui/material';
+import SectionHeader from '../SectionHeader/SectionHeader';
+
+const LatestUpdatesSection: React.FC = () => (
+  <Content id="latest-updates">
+    <SectionHeader
+      title="Latest Updates"
+      subtitle="MakerDAO’s Endgame is transforming to enhance growth, resilience, and accessibility, aiming to expand the Dai supply significantly. It introduces sustainable yield farming through SubDAO tokens, creating a dynamic and adaptable ecosystem. The plan includes launching new tokens, enhancing user experience with a new website and app, and initiating a Lockstake Engine for governance engagement."
+    />
+  </Content>
+);
 
 export default LatestUpdatesSection;
+
+const Content = styled('section')(({ theme }) => ({
+  marginTop: 32,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    marginTop: 40,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    marginTop: 64,
+  },
+
+  [theme.breakpoints.up('desktop_1440')]: {
+    marginTop: 32,
+  },
+}));

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material';
+import { ProjectStatus } from '@ses/core/models/interfaces/projects';
 import SectionHeader from '../SectionHeader/SectionHeader';
 import PhaseCard from './PhaseCard';
 
@@ -10,10 +11,112 @@ const LatestUpdatesSection: React.FC = () => (
     />
 
     <Timeline>
-      <PhaseCard />
-      <PhaseCard />
-      <PhaseCard />
-      <PhaseCard />
+      <PhaseCard
+        phase="Phase 1"
+        title="Launch Season"
+        status={ProjectStatus.INPROGRESS}
+        description={{
+          paragraph:
+            'Introduction of new tokens (NewStable and NewGovToken) and a new brand focusing on user-friendly access and sustainable yield farming through the SubDAO ecosystem. This phase aims for rapid deployment of core features to drive Dai usage growth.',
+          list: [
+            {
+              bold: 'New Beginnings',
+              text: 'Unveiling a vibrant new brand and the revolutionary NewStable and NewFovToken.',
+            },
+            {
+              bold: 'Access Simplified',
+              text: 'Launch of a user-centric website and app, making navigation through our ecosystem seamless.',
+            },
+            {
+              bold: 'Lock in Value',
+              text: 'Introduction of the Lockstake Engine, fostering long-term participation and governance.',
+            },
+          ],
+        }}
+        importantLinks={[
+          {
+            href: 'https://www.google.com',
+            label: 'MakerDAO Endgame: Launch Season',
+          },
+          {
+            href: 'https://www.google.com',
+            label: 'Governance changes to prepare for Launch Season',
+          },
+          {
+            href: 'https://www.google.com',
+            label: 'Maker Alignment Artifacts',
+          },
+        ]}
+      />
+      <PhaseCard
+        phase="Phase 2"
+        title="Scaling Up"
+        status={ProjectStatus.TODO}
+        description={{
+          paragraph:
+            'After the successful launch of key components, this phase focuses on vertical and horizontal expansion, including more SubDAOs catering to diverse interests and bridging to major L2s and L1s enhancing the ecosystem’s reach and capabilities.',
+          list: [
+            {
+              bold: 'Diverse Ecosystem',
+              text: 'Expansion with more SubDAOs, each addressing unique market need and interests.',
+            },
+            {
+              bold: 'Enhance Connectivity',
+              text: 'Implementation of bridges to popular L2s and L1s, widening our reach.',
+            },
+            {
+              bold: 'Governance Evolution',
+              text: 'SubDAOs gain autonomy, supported by innovative UI adn AI tools.',
+            },
+          ],
+        }}
+      />
+      <PhaseCard
+        phase="Phase 3"
+        title="NewChain"
+        status={ProjectStatus.TODO}
+        description={{
+          paragraph:
+            'The transition to a standalone L1 blockchain, hosting core tokenomics and govenance, marks a pivotal point for scalability and integration of real-world assets, DeFi, and corss-blockchain operations.',
+          list: [
+            {
+              bold: 'Introducing NewChain',
+              text: 'Laung of a dedicated L1 blockchain to inhance the Maker ecosystem.',
+            },
+            {
+              bold: 'Ethereum and Beyond',
+              text: "NewChain's coexistence with Ethereum, supporting continuity and expansion.",
+            },
+            {
+              bold: 'Foundation for the Future',
+              text: 'Strategic development of New Chain to ensure scalability and innovation.',
+            },
+          ],
+        }}
+      />
+      <PhaseCard
+        phase="Phase 4"
+        title="Final Endgame"
+        status={ProjectStatus.TODO}
+        description={{
+          paragraph:
+            'This phase signifies the completion of foundational governance mechanisms, leading to an immutable, dynamic, and ever-growing ecosystem, embodying the ultimate vision of MakerDAO’s Endgame.',
+          list: [
+            {
+              bold: 'Completion of Governance Mechanisms',
+              text: 'Finalization and immutability of foundational governance structures.',
+            },
+            {
+              bold: 'Achievement of Ultimate Vision',
+              text: 'Realization of dynamic, ever-expanding ecosystem with a stable financial foundation.',
+            },
+            {
+              bold: 'Permanent Infrastructure',
+              text: 'Establishment of a reliable, unchangeable infrastructure for future growth.',
+            },
+          ],
+        }}
+      />
     </Timeline>
   </Content>
 );

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
@@ -1,5 +1,6 @@
 import { styled } from '@mui/material';
 import SectionHeader from '../SectionHeader/SectionHeader';
+import PhaseCard from './PhaseCard';
 
 const LatestUpdatesSection: React.FC = () => (
   <Content id="section-latest-updates">
@@ -7,13 +8,23 @@ const LatestUpdatesSection: React.FC = () => (
       title="Latest Updates"
       subtitle="MakerDAO’s Endgame is transforming to enhance growth, resilience, and accessibility, aiming to expand the Dai supply significantly. It introduces sustainable yield farming through SubDAO tokens, creating a dynamic and adaptable ecosystem. The plan includes launching new tokens, enhancing user experience with a new website and app, and initiating a Lockstake Engine for governance engagement."
     />
+
+    <Timeline>
+      <PhaseCard />
+      <PhaseCard />
+      <PhaseCard />
+      <PhaseCard />
+    </Timeline>
   </Content>
 );
 
 export default LatestUpdatesSection;
 
 const Content = styled('section')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
   marginTop: 32,
+  gap: 24,
   scrollMarginTop: 130,
 
   [theme.breakpoints.up('tablet_768')]: {
@@ -27,4 +38,10 @@ const Content = styled('section')(({ theme }) => ({
   [theme.breakpoints.up('desktop_1440')]: {
     marginTop: 32,
   },
+}));
+
+const Timeline = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
 }));

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
@@ -2,7 +2,7 @@ import { styled } from '@mui/material';
 import SectionHeader from '../SectionHeader/SectionHeader';
 
 const LatestUpdatesSection: React.FC = () => (
-  <Content id="latest-updates">
+  <Content id="section-latest-updates">
     <SectionHeader
       title="Latest Updates"
       subtitle="MakerDAO’s Endgame is transforming to enhance growth, resilience, and accessibility, aiming to expand the Dai supply significantly. It introduces sustainable yield farming through SubDAO tokens, creating a dynamic and adaptable ecosystem. The plan includes launching new tokens, enhancing user experience with a new website and app, and initiating a Lockstake Engine for governance engagement."
@@ -14,6 +14,7 @@ export default LatestUpdatesSection;
 
 const Content = styled('section')(({ theme }) => ({
   marginTop: 32,
+  scrollMarginTop: 130,
 
   [theme.breakpoints.up('tablet_768')]: {
     marginTop: 40,

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
@@ -35,15 +35,15 @@ const LatestUpdatesSection: React.FC = () => (
         }}
         importantLinks={[
           {
-            href: 'https://www.google.com',
+            href: 'https://forum.makerdao.com/t/makerdao-endgame-launch-season/23857',
             label: 'MakerDAO Endgame: Launch Season',
           },
           {
-            href: 'https://www.google.com',
+            href: 'https://forum.makerdao.com/t/governance-changes-to-prepare-for-launch-season/23878',
             label: 'Governance changes to prepare for Launch Season',
           },
           {
-            href: 'https://www.google.com',
+            href: 'https://powerhouse.gitbook.io/maker-alignment-artifacts',
             label: 'Maker Alignment Artifacts',
           },
         ]}

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
@@ -1,0 +1,3 @@
+const LatestUpdatesSection: React.FC = () => <div>latest updates</div>;
+
+export default LatestUpdatesSection;

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/LatestUpdatesSection.tsx
@@ -46,6 +46,10 @@ const LatestUpdatesSection: React.FC = () => (
             href: 'https://powerhouse.gitbook.io/maker-alignment-artifacts',
             label: 'Maker Alignment Artifacts',
           },
+          {
+            href: 'https://forum.makerdao.com/t/preparing-to-decentralize-the-launch-project-after-launch-season/24193',
+            label: 'Decentralization of Launch Projects',
+          },
         ]}
       />
       <PhaseCard

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/PhaseCard.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/PhaseCard.tsx
@@ -1,0 +1,18 @@
+import { styled } from '@mui/material';
+
+const PhaseCard: React.FC = () => <Card>Phase X</Card>;
+
+export default PhaseCard;
+
+const Card = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  background: theme.palette.mode === 'light' ? 'white' : 'red',
+  padding: 8,
+  borderRadius: 6,
+  boxShadow:
+    theme.palette.mode === 'light'
+      ? '20px 20px 20px rgba(219, 227, 237, 0.4), 1px 1px 5px rgba(190, 190, 190, 0.25)'
+      : '20px 20px 20px red',
+}));

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/PhaseCard.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/PhaseCard.tsx
@@ -55,13 +55,13 @@ const Card = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: 8,
-  background: theme.palette.mode === 'light' ? 'white' : 'red',
+  background: theme.palette.mode === 'light' ? 'white' : '#1E2C37',
   padding: 8,
   borderRadius: 6,
   boxShadow:
     theme.palette.mode === 'light'
       ? '20px 20px 20px rgba(219, 227, 237, 0.4), 1px 1px 5px rgba(190, 190, 190, 0.25)'
-      : '20px 20px 20px red',
+      : '10px 15px 20px 6px rgba(20, 0, 141, 0.1)',
 
   [theme.breakpoints.up('tablet_768')]: {
     gap: 16,
@@ -86,14 +86,14 @@ const TitleContainer = styled('div')(() => ({
 }));
 
 const Phase = styled('span')(({ theme }) => ({
-  color: theme.palette.mode === 'light' ? '#708390' : 'red',
+  color: theme.palette.mode === 'light' ? '#708390' : '#546978',
   fontSize: 16,
   fontWeight: 700,
   lineHeight: '19px',
 }));
 
 const Title = styled('h3')(({ theme }) => ({
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
   fontSize: 16,
   fontWeight: 700,
   lineHeight: '19px',
@@ -119,11 +119,12 @@ const DescriptionContainer = styled('div')(({ theme }) => ({
   gap: 8,
   padding: 8,
   borderRadius: 6,
-  background: theme.palette.mode === 'light' ? 'rgba(246, 248, 249, 0.5)' : 'red',
-  boxShadow: '1px 3px 7px rgba(0, 0, 0, 0.05) inset',
+  background: theme.palette.mode === 'light' ? 'rgba(246, 248, 249, 0.5)' : 'rgba(16, 25, 31, 0.3)',
+  boxShadow:
+    theme.palette.mode === 'light' ? '1px 3px 7px rgba(0, 0, 0, 0.05) inset' : '1px 3px 7px rgba(0, 0, 0, 0.15) inset',
   fontSize: 14,
   lineHeight: '17px',
-  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
 
   [theme.breakpoints.up('tablet_768')]: {
     padding: 16,

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/PhaseCard.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/PhaseCard.tsx
@@ -1,6 +1,53 @@
 import { styled } from '@mui/material';
+import ProjectStatusChip from '@ses/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip';
+import ImportantLinks from './ImportantLinks';
+import type { ImportantLink } from './ImportantLinks';
+import type { ProjectStatus } from '@ses/core/models/interfaces/projects';
 
-const PhaseCard: React.FC = () => <Card>Phase X</Card>;
+export interface Description {
+  paragraph: string;
+  list: {
+    bold: string;
+    text: string;
+  }[];
+}
+
+interface PhaseCardProps {
+  phase: string;
+  title: string;
+  status: ProjectStatus;
+  description: Description;
+  importantLinks?: ImportantLink[];
+}
+
+const PhaseCard: React.FC<PhaseCardProps> = ({ phase, title, status, description, importantLinks = [] }) => (
+  <Card>
+    <Header>
+      <TitleContainer>
+        <Phase>{phase}</Phase>
+        <Title>{title}</Title>
+      </TitleContainer>
+
+      <ProjectStatusChip status={status} />
+    </Header>
+
+    <Body>
+      <DescriptionContainer>
+        <Paragraph>{description.paragraph}</Paragraph>
+
+        <List>
+          {description.list.map(({ bold, text }, index) => (
+            <ListItem key={index}>
+              <Bold>{bold}:</Bold>
+              <Text>{text}</Text>
+            </ListItem>
+          ))}
+        </List>
+      </DescriptionContainer>
+      <ImportantLinks links={importantLinks} />
+    </Body>
+  </Card>
+);
 
 export default PhaseCard;
 
@@ -15,4 +62,90 @@ const Card = styled('div')(({ theme }) => ({
     theme.palette.mode === 'light'
       ? '20px 20px 20px rgba(219, 227, 237, 0.4), 1px 1px 5px rgba(190, 190, 190, 0.25)'
       : '20px 20px 20px red',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    gap: 16,
+  },
 }));
+
+const Header = styled('header')(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    justifyContent: 'flex-start',
+    gap: 24,
+  },
+}));
+
+const TitleContainer = styled('div')(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+}));
+
+const Phase = styled('span')(({ theme }) => ({
+  color: theme.palette.mode === 'light' ? '#708390' : 'red',
+  fontSize: 16,
+  fontWeight: 700,
+  lineHeight: '19px',
+}));
+
+const Title = styled('h3')(({ theme }) => ({
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+  fontSize: 16,
+  fontWeight: 700,
+  lineHeight: '19px',
+}));
+
+const Body = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    gap: 16,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    flexDirection: 'row',
+  },
+}));
+
+const DescriptionContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  padding: 8,
+  borderRadius: 6,
+  background: theme.palette.mode === 'light' ? 'rgba(246, 248, 249, 0.5)' : 'red',
+  boxShadow: '1px 3px 7px rgba(0, 0, 0, 0.05) inset',
+  fontSize: 14,
+  lineHeight: '17px',
+  color: theme.palette.mode === 'light' ? '#231536' : 'red',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    padding: 16,
+    fontSize: 16,
+    lineHeight: '22px',
+  },
+}));
+
+const Paragraph = styled('p')(() => ({
+  margin: 0,
+}));
+
+const List = styled('ul')(() => ({
+  paddingLeft: 22,
+  marginBottom: 0,
+}));
+
+const ListItem = styled('li')(() => ({}));
+
+const Bold = styled('b')(() => ({
+  fontWeight: 600,
+  marginRight: 4,
+}));
+
+const Text = styled('span')(() => ({}));

--- a/src/stories/containers/Endgame/components/NavigationTabs/NavigationTabs.tsx
+++ b/src/stories/containers/Endgame/components/NavigationTabs/NavigationTabs.tsx
@@ -30,6 +30,13 @@ const NavigationTabs: React.FC<NavigationTabsProps> = ({ activeTab, handlePauseU
           <Navigation isLight={isLight}>
             <Tab
               isLight={isLight}
+              active={activeTab === NavigationTabEnum.LATESTS_UPDATES}
+              onClick={handleOnClick(NavigationTabEnum.LATESTS_UPDATES)}
+            >
+              Latest Updates
+            </Tab>
+            <Tab
+              isLight={isLight}
               active={activeTab === NavigationTabEnum.KEY_CHANGES}
               onClick={handleOnClick(NavigationTabEnum.KEY_CHANGES)}
             >

--- a/src/stories/containers/Endgame/useEndgameContainer.ts
+++ b/src/stories/containers/Endgame/useEndgameContainer.ts
@@ -32,12 +32,15 @@ const useEndgameContainer = (budgetTransitionAnalytics: Analytic, yearsRange: st
     // scroll into a section on page load
     if (typeof window !== 'undefined') {
       const hash = window.location.hash.replace('#', '');
-      if (hash === NavigationTabEnum.BUDGET_STRUCTURE) {
-        document.getElementById(`section-${NavigationTabEnum.BUDGET_STRUCTURE}`)?.scrollIntoView({
-          behavior: 'smooth',
-        });
-      } else if (hash === NavigationTabEnum.BUDGET_TRANSITION_STATUS) {
-        document.getElementById(`section-${NavigationTabEnum.BUDGET_TRANSITION_STATUS}`)?.scrollIntoView({
+      if (
+        [
+          NavigationTabEnum.KEY_CHANGES,
+          NavigationTabEnum.BUDGET_STRUCTURE,
+          NavigationTabEnum.BUDGET_TRANSITION_STATUS,
+        ].includes(hash as NavigationTabEnum)
+      ) {
+        // scroll to the section
+        document.getElementById(`section-${hash}`)?.scrollIntoView({
           behavior: 'smooth',
         });
       }
@@ -82,10 +85,9 @@ const useEndgameContainer = (budgetTransitionAnalytics: Analytic, yearsRange: st
         // it's scrolling, don't update the url yet
         return;
       }
-      updateUrl(tab === NavigationTabEnum.KEY_CHANGES ? undefined : tab);
+      updateUrl(tab === NavigationTabEnum.LATESTS_UPDATES ? undefined : tab);
     };
 
-    console.log(updatesInView, keyInView, structureInView, transitionInView);
     if (keyInView) {
       activate(NavigationTabEnum.KEY_CHANGES);
     } else if (transitionInView) {


### PR DESCRIPTION
## Ticket
https://trello.com/c/ikyCL3Ex/393-user-story-met-15-endgame-latest-updates

## Description
Add the latest updates section to the endgame transition page

## What solved
- [X] Should a new section with the tab's name: "Latest Updates" be added.
- [X] Should the section have the title: "Latest Updates"
- [X] Should the section contain a description below the title.
- [X] Should the section contain a visual timeline (roadmap/phases) represented by cards.
- [X] Should each card contain Phase #, phase's name, status (to do, In Progress, Finished)
- [X] Should the status be represented with the defined color: To do: yellow, In Progress: blue, Finished: green.
- [X] Should the card contain two subsections.
- [X] Should the left section display a description (Desktop resolutions). 
- [X] Should the right section named "Important links" display a list of the external links (Desktop resolutions)
- [X] Should the description section be represented first and the Important Links section below (Small resolutions)
- [X] Should the list contain the following names/links:  1- MakerDAO Endgame: Launch Season (https://forum.makerdao.com/t/makerdao-endgame-launch-season/23857), 2- Governance changes to prepare for Launch Season (https://forum.makerdao.com/t/governance-changes-to-prepare-for-launch-season/23878), 3- Maker Alignment Artifacts (https://powerhouse.gitbook.io/maker-alignment-artifacts/)
- [X] Should the "*No Key Results* " message  be displayed if there is no key result to show in the Important Links section (Desktop resoution)[image.png](https://trello.com/1/cards/662105a321639a2bd128cc9e/attachments/662f82595ed8ee8a9c8e03be/previews/662f82595ed8ee8a9c8e0574/download/image.png)
- [X] Should not show the Important Links section if there are no links to show (Mobile resolution)
- [X] Should implement the responsive view
- [x] Should implement the Dark mode.