### PR TITLE
[QA] Fix expenses card in about page

### DIFF
--- a/src/stories/components/LinkButton/LinkButton.tsx
+++ b/src/stories/components/LinkButton/LinkButton.tsx
@@ -147,8 +147,10 @@ const Text = styled.div<{
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
   fontWeight: 500,
-  whiteSpace: 'nowrap',
   width,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
   color: isLight
     ? disabled
       ? ' #9FAFB9'

--- a/src/stories/components/NavigationCard/CardExpenses.tsx
+++ b/src/stories/components/NavigationCard/CardExpenses.tsx
@@ -27,6 +27,7 @@ interface Props {
   titleCard?: string;
   auditorMessage?: string;
   makerburnCustomMessage?: string;
+  showMakerburnLink?: boolean;
 }
 
 const CardExpenses = ({
@@ -42,18 +43,19 @@ const CardExpenses = ({
   titleCard,
   auditorMessage,
   makerburnCustomMessage,
+  showMakerburnLink = true,
 }: Props) => {
   const { isLight } = useThemeContext();
   const title = titleCard ?? `View all expenses of the ${shortCode} Core Unit`;
   const textLink = resource === ResourceType.CoreUnit ? 'Core Unit' : 'Ecosystem Actor';
-  const auditorTitle = auditorMessage ?? `The ${shortCode} Core Unit is currently working without auditor`;
+  const auditorTitle = auditorMessage ?? `${shortCode} Core Unit is currently working without auditor`;
   const isPhone = useMediaQuery(lightTheme.breakpoints.between('mobile_375', 'table_834'));
   const isTable = useMediaQuery(lightTheme.breakpoints.between('table_834', 'desktop_1194'));
 
   return (
     <InformationCard
       fontWeight={600}
-      title="Expenses"
+      title="Finances"
       fontSize="24px"
       lineHeight="29px"
       style={style}
@@ -82,7 +84,7 @@ const CardExpenses = ({
               style={{
                 textAlign: 'center',
                 borderRadius: '22px',
-                height: ' 34px',
+                height: '34px',
                 fontFamily: 'Inter, sans serif',
                 fontStyle: 'normal',
                 fontWeight: 500,
@@ -91,14 +93,14 @@ const CardExpenses = ({
                 width: buttonWidth,
                 marginRight: '12px',
                 flexGrow: 1,
-                padding: isPhone || isTable ? '8px 25.75px' : '8px 43.25px',
+                padding: isPhone || isTable ? '8px 12.75px' : '8px 43.25px',
               }}
             />
           )}
           <LinkButton
             buttonType={ButtonType.Primary}
             widthText="100%"
-            label="Expense Reports"
+            label="Budget Statements"
             style={{
               textAlign: 'center',
               borderRadius: '22px',
@@ -110,7 +112,6 @@ const CardExpenses = ({
               lineHeight: '18px',
               letterSpacing: '0px',
               width: buttonWidth,
-              // TODO: let this as `marginLeft: 12` when the Activity feed for ecosystem actor is implemented
               marginLeft: resource === ResourceType.CoreUnit ? 12 : 0,
               flexGrow: 1,
               padding: isPhone || isTable ? '8px 12.75px' : '8px 30.25px',
@@ -130,24 +131,28 @@ const CardExpenses = ({
           marginBottom: '16px',
         }}
       />
-      <ContainerLinks>
-        <CustomLink
-          href={`${MAKER_BURN_LINK}/${code}`}
-          style={{
-            marginLeft: '0px',
-            paddingRight: '0px',
-            fontFamily: 'Inter, sans-serif',
-            fontStyle: 'normal',
-            fontWeight: 500,
-            fontSize: '16px',
-            lineHeight: '18px',
-            whiteSpace: 'normal',
-            display: 'inline-block',
-          }}
-          target="_blank"
-          children={makerburnCustomMessage ?? `View On-Chain transfers to ${shortCode} ${textLink} on makerburn.com`}
-        />
-      </ContainerLinks>
+      {showMakerburnLink ? (
+        <ContainerLinks>
+          <CustomLink
+            href={`${MAKER_BURN_LINK}/${code}`}
+            style={{
+              marginLeft: '0px',
+              paddingRight: '0px',
+              fontFamily: 'Inter, sans-serif',
+              fontStyle: 'normal',
+              fontWeight: 500,
+              fontSize: '16px',
+              lineHeight: '18px',
+              whiteSpace: 'normal',
+              display: 'inline-block',
+            }}
+            target="_blank"
+            children={makerburnCustomMessage ?? `View On-Chain transfers to ${shortCode} ${textLink} on makerburn.com`}
+          />
+        </ContainerLinks>
+      ) : (
+        ''
+      )}
 
       {(auditors || []).length > 0 ? (
         <AuditorsContainer>

--- a/src/stories/containers/ActorsAbout/ActorAboutContainer.tsx
+++ b/src/stories/containers/ActorsAbout/ActorAboutContainer.tsx
@@ -79,13 +79,14 @@ export const ActorAboutContainer: React.FC<Props> = ({ actors, actor }) => {
                   <CardProjects actorName={actor.name} shortCode={actor.shortCode} />
                 )}
                 <CardExpenses
+                  showMakerburnLink={false}
                   resource={ResourceType.EcosystemActor}
                   queryStrings={queryStrings}
                   code={actor.code}
                   shortCode={actor.shortCode}
                   auditors={actor.auditors}
                   titleCard={`View all expenses of the ${actor.name} Ecosystem Actor`}
-                  auditorMessage={`The ${actor.name} is working without auditor`}
+                  auditorMessage={`${actor.name} is working without auditor`}
                   makerburnCustomMessage={`View On-Chain transfers to ${actor.name} on makerburn.com`}
                 />
               </ContainerCard>


### PR DESCRIPTION
## Ticket
https://trello.com/c/42azojmG/407-apply-new-changes-to-the-ecosystem-actors-details-view

## Description
Change copies in the expenses (now finances) card

## What solved
- [X] ALL SCREEN // Team Details Page: Change Expenses to Finances, Change Expense Reports button to Budget Statements and add a link to the aggregated finances page for that specific Team (finances/SUP/INC — for Powerhouse). Remove the Makerburn link since it does not have a page for every team. Remove the “The” infront of EA name.
