### PR TITLE
[MET-393] Fix the colors for background and fix the weight in the font

### DIFF
--- a/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
@@ -37,7 +37,7 @@ export default ProjectStatusChip;
 const StatusChip = styled(Chip)<{ textColor: string; background: string; isSmall: boolean }>(
   ({ textColor, background, isSmall }) => ({
     padding: '4px 16px',
-    borderRadius: 24,
+    borderRadius: 12,
     fontFamily: 'Inter, sans-serif',
     border: `1px solid ${textColor}`,
     background,

--- a/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
@@ -38,6 +38,7 @@ const StatusChip = styled(Chip)<{ textColor: string; background: string; isSmall
   ({ textColor, background, isSmall }) => ({
     padding: '4px 16px',
     borderRadius: 24,
+    fontFamily: 'Inter, sans-serif',
     border: `1px solid ${textColor}`,
     background,
     height: 'auto',

--- a/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
@@ -42,10 +42,10 @@ const StatusChip = styled(Chip)<{ textColor: string; background: string; isSmall
     background,
     height: 'auto',
     fontWeight: 500,
+    lineHeight: '18px',
 
     '.MuiChip-label': {
       fontSize: isSmall ? 11 : 14,
-      lineHeight: 'normal',
       color: textColor,
       padding: 0,
     },

--- a/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
@@ -23,7 +23,7 @@ const ProjectStatusChip: React.FC<ProjectStatusChipProps> = ({ status, customLab
       case ProjectStatus.FINISHED:
         return 'Finished';
       default:
-        return 'To do';
+        return 'To Do';
     }
   }, [customLabel, status]);
 
@@ -36,18 +36,18 @@ export default ProjectStatusChip;
 
 const StatusChip = styled(Chip)<{ textColor: string; background: string; isSmall: boolean }>(
   ({ textColor, background, isSmall }) => ({
-    padding: '4px 16px',
+    padding: isSmall ? '4px 8px' : '6.5px 15px',
     borderRadius: 24,
     fontFamily: 'Inter, sans-serif',
     border: `1px solid ${textColor}`,
     background,
     height: 'auto',
     fontWeight: 500,
-    lineHeight: '18px',
 
     '.MuiChip-label': {
       fontSize: isSmall ? 11 : 14,
       color: textColor,
+      lineHeight: 'normal',
       padding: 0,
     },
   })

--- a/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
@@ -23,7 +23,7 @@ const ProjectStatusChip: React.FC<ProjectStatusChipProps> = ({ status, customLab
       case ProjectStatus.FINISHED:
         return 'Finished';
       default:
-        return 'To Do';
+        return 'To do';
     }
   }, [customLabel, status]);
 
@@ -36,11 +36,12 @@ export default ProjectStatusChip;
 
 const StatusChip = styled(Chip)<{ textColor: string; background: string; isSmall: boolean }>(
   ({ textColor, background, isSmall }) => ({
-    padding: isSmall ? '4px 8px' : '6.5px 15px',
+    padding: '4px 16px',
     borderRadius: 24,
     border: `1px solid ${textColor}`,
     background,
     height: 'auto',
+    fontWeight: 500,
 
     '.MuiChip-label': {
       fontSize: isSmall ? 11 : 14,

--- a/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
+++ b/src/stories/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip.tsx
@@ -37,7 +37,7 @@ export default ProjectStatusChip;
 const StatusChip = styled(Chip)<{ textColor: string; background: string; isSmall: boolean }>(
   ({ textColor, background, isSmall }) => ({
     padding: '4px 16px',
-    borderRadius: 12,
+    borderRadius: 24,
     fontFamily: 'Inter, sans-serif',
     border: `1px solid ${textColor}`,
     background,

--- a/src/stories/containers/ActorProjects/utils/colors.ts
+++ b/src/stories/containers/ActorProjects/utils/colors.ts
@@ -14,11 +14,17 @@ export const getChipColors = (status: ProjectStatus | DeliverableStatus, isLight
         color: '#1AAB9B',
         background: isLight ? 'rgba(245, 255, 246, 0.50)' : 'rgba(26, 171, 155, 0.15)',
       };
+    case ProjectStatus.TODO:
+    case DeliverableStatus.TODO:
+      return {
+        color: '#F08B04',
+        background: isLight ? 'rgba(255, 249, 237, 1)' : 'rgba(83, 57, 5, 1)',
+      };
     default:
       // to do
       return {
         color: '#F08B04',
-        background: isLight ? 'rgba(255, 251, 245, 0.50)' : 'rgba(240, 139, 4, 0.15)',
+        background: isLight ? 'rgba(255, 251, 245, 0.50)' : 'rgba(83, 57, 5, 1)',
       };
   }
 };

--- a/src/stories/containers/Endgame/components/EndgameStatusChip/EndgameStatusChip.tsx
+++ b/src/stories/containers/Endgame/components/EndgameStatusChip/EndgameStatusChip.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+import Chip from '@mui/material/Chip';
+import { getChipColors } from '@ses/containers/ActorProjects/utils/colors';
+import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { ProjectStatus } from '@ses/core/models/interfaces/projects';
+import React, { useMemo } from 'react';
+
+interface ProjectStatusChipProps {
+  status: ProjectStatus;
+  customLabel?: string;
+  isSmall?: boolean;
+}
+
+const EndgameStatusChip: React.FC<ProjectStatusChipProps> = ({ status, customLabel }) => {
+  const { isLight } = useThemeContext();
+  const label = useMemo(() => {
+    if (customLabel) {
+      return customLabel;
+    }
+    switch (status) {
+      case ProjectStatus.INPROGRESS:
+        return 'In Progress';
+      case ProjectStatus.FINISHED:
+        return 'Finished';
+      default:
+        return 'To do';
+    }
+  }, [customLabel, status]);
+
+  const { color, background } = useMemo(() => getChipColors(status, isLight), [isLight, status]);
+
+  return <StatusChip label={label} textColor={color} background={background} />;
+};
+
+export default EndgameStatusChip;
+
+const StatusChip = styled(Chip)<{ textColor: string; background: string }>(({ textColor, background }) => ({
+  padding: '4px 16px',
+  borderRadius: 12,
+  height: 26,
+
+  fontFamily: 'Inter, sans-serif',
+  border: `1px solid ${textColor}`,
+  background,
+  fontWeight: 500,
+  lineHeight: '18px',
+  '.MuiChip-label': {
+    verticalAlign: 'center',
+    fontSize: 14,
+    color: textColor,
+    padding: 0,
+  },
+}));

--- a/src/stories/containers/Endgame/components/LatestUpdatesSection/PhaseCard.tsx
+++ b/src/stories/containers/Endgame/components/LatestUpdatesSection/PhaseCard.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material';
-import ProjectStatusChip from '@ses/containers/ActorProjects/components/ProjectStatusChip/ProjectStatusChip';
+import EndgameStatusChip from '../EndgameStatusChip/EndgameStatusChip';
 import ImportantLinks from './ImportantLinks';
 import type { ImportantLink } from './ImportantLinks';
 import type { ProjectStatus } from '@ses/core/models/interfaces/projects';
@@ -28,7 +28,7 @@ const PhaseCard: React.FC<PhaseCardProps> = ({ phase, title, status, description
         <Title>{title}</Title>
       </TitleContainer>
 
-      <ProjectStatusChip status={status} />
+      <EndgameStatusChip status={status} />
     </Header>
 
     <Body>


### PR DESCRIPTION
## Ticket
https://trello.com/c/ikyCL3Ex/393-user-story-met-15-endgame-latest-updates

## Description
Fix the background and font weight in the last update endgame page

## What solved
The background should have color: rgba(255, 249, 237, 1). **Current Output:** The status displays background color:     rgba(255, 251, 245, 0.50). 

The status component should display the height defined in the design.  **Current Output:** The view displays the status   component higher than the design shows.  ** Visual Proof:** [design.png]

## Screenshots (if apply)
