### PR TITLE
Fix remove scheduled release to staging

### DIFF
--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -1,7 +1,5 @@
 name: Staging deployment
 on:
-  schedule:
-    - cron: '0 0 * * *' # every day at 00:00
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Ticket
https://trello.com/c/wwVo7aTn/382-apply-new-setup-for-fusion-dashboard

## What solved
- [X] Should remove the scheduled deploy to staging
