### PR TITLE
[QA-422] Change the name of the "Expense Reports" view to Budget Statements in EA and CU

### DIFF
--- a/src/stories/components/Markdown/MdViewerPage.tsx
+++ b/src/stories/components/Markdown/MdViewerPage.tsx
@@ -66,7 +66,7 @@ const MdViewerPage = ({
             active={open}
             widthText="100%"
             allowsHover={!isPhoneAndTable}
-            label="Expenses"
+            label="Budget Statements"
             style={{
               textAlign: 'center',
               borderRadius: '22px',

--- a/src/stories/components/NavigationCard/CardExpenses.tsx
+++ b/src/stories/components/NavigationCard/CardExpenses.tsx
@@ -46,9 +46,9 @@ const CardExpenses = ({
   showMakerburnLink = true,
 }: Props) => {
   const { isLight } = useThemeContext();
-  const title = titleCard ?? `View all expenses of the ${shortCode} Core Unit`;
+  const title = titleCard ?? `View all expenses of the ${shortCode} Core Unit.`;
   const textLink = resource === ResourceType.CoreUnit ? 'Core Unit' : 'Ecosystem Actor';
-  const auditorTitle = auditorMessage ?? `${shortCode} Core Unit is currently working without auditor`;
+  const auditorTitle = auditorMessage ?? `${shortCode} Core Unit is currently working without auditor.`;
   const isPhone = useMediaQuery(lightTheme.breakpoints.between('mobile_375', 'table_834'));
   const isTable = useMediaQuery(lightTheme.breakpoints.between('table_834', 'desktop_1194'));
 

--- a/src/stories/containers/ActorsAbout/ActorAboutContainer.tsx
+++ b/src/stories/containers/ActorsAbout/ActorAboutContainer.tsx
@@ -85,8 +85,8 @@ export const ActorAboutContainer: React.FC<Props> = ({ actors, actor }) => {
                   code={actor.code}
                   shortCode={actor.shortCode}
                   auditors={actor.auditors}
-                  titleCard={`View all expenses of the ${actor.name} Ecosystem Actor`}
-                  auditorMessage={`${actor.name} is working without auditor`}
+                  titleCard={`View all expenses of the ${actor.name} Ecosystem Actor.`}
+                  auditorMessage={`${actor.name} is working without auditor.`}
                   makerburnCustomMessage={`View On-Chain transfers to ${actor.name} on makerburn.com`}
                 />
               </ContainerCard>

--- a/src/stories/containers/ActorsAbout/components/ActorMdViewer/ActorMdViewPage.tsx
+++ b/src/stories/containers/ActorsAbout/components/ActorMdViewer/ActorMdViewPage.tsx
@@ -127,8 +127,8 @@ const ActorMdViewPage = ({
                     minHeight: '190px',
                     overflowY: 'hidden',
                   }}
-                  titleCard={`View all expenses of the ${actorName} Ecosystem Actor`}
-                  auditorMessage={`The ${actorName} is working without auditor`}
+                  titleCard={`View all expenses of the ${actorName} Ecosystem Actor.`}
+                  auditorMessage={`The ${actorName} is working without auditor.`}
                   makerburnCustomMessage={`View On-Chain transfers to ${actorName} on makerburn.com`}
                 />
               </Popover>
@@ -160,8 +160,8 @@ const ActorMdViewPage = ({
                 auditors={auditors}
                 isTitlePresent={isEnabled('FEATURE_TEAM_PROJECTS')}
                 buttonWidth="139.5px"
-                titleCard={`View all expenses of the ${actorName} Ecosystem Actor`}
-                auditorMessage={`The ${actorName} is working without auditor`}
+                titleCard={`View all expenses of the ${actorName} Ecosystem Actor.`}
+                auditorMessage={`The ${actorName} is working without auditor.`}
                 makerburnCustomMessage={`View On-Chain transfers to ${actorName} on makerburn.com`}
               />
             </div>

--- a/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
@@ -80,8 +80,8 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
       />
       <ActorSummary
         actors={actors}
-        trailingAddress={['Expense Reports']}
-        breadcrumbTitle="Expense Reports"
+        trailingAddress={['Budget Statements']}
+        breadcrumbTitle="Budget Statements"
         ref={ref}
         showHeader={showHeader}
       />

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -86,8 +86,8 @@ export const TransparencyReport = ({
       />
       <CoreUnitSummary
         coreUnits={coreUnits}
-        trailingAddress={['Expense Reports']}
-        breadcrumbTitle="Expense Reports"
+        trailingAddress={['Budget Statements']}
+        breadcrumbTitle="Budget Statements"
         showHeader={showHeader}
         ref={ref}
       />


### PR DESCRIPTION

## Ticket
https://trello.com/c/tTURGnnV/422-change-the-name-of-the-expense-reports-view-to-budget-statements

## Description
Change the name of the "Expense Reports" view to Budget Statements

## What solved
- [X] Should apply the change in the Expense Reports view (CU, EA)
- [X] Should add "." at the end of the sentences
