### PR TITLE
[QA] Fix uncategorized rules

### DIFF
--- a/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
+++ b/src/stories/containers/Finances/components/FinacesTable/FinancesTable.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import React from 'react';
 import { defaultOrder, orderMetrics } from '../HeaderTable/utils';
 import LinkCellComponent from '../LinkCellComponent/LinkCellComponent';
+import { removePatternAfterSlash } from '../SectionPages/BreakdownTable/utils';
 import CellTable from './CellTable';
 import type { TableFinances, MetricValues, PeriodicSelectionFilter, ItemRow } from '../../utils/types';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
@@ -46,7 +47,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
           <TableBody isLight={isLight} isAnnual={isAnnual}>
             {table.rows.map((row: ItemRow, index) => {
               const href = `${siteRoutes.finances(
-                (row.codePath ?? '').replace('atlas/', '')
+                removePatternAfterSlash(row.codePath ?? '').replace('atlas/', '')
               )}?year=${year}&period=${period}${metrics.map((metric) => `&metric=${metric}`).join('')}#breakdown-table`;
 
               return (
@@ -57,7 +58,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
                     isHeader={!!row.isMain}
                     isUncategorized={!!row.isUncategorized}
                   >
-                    {row.isSummaryRow || row.isUncategorized ? (
+                    {row.isSummaryRow || (row.isUncategorized && !row.isMain) ? (
                       row.name
                     ) : (
                       <Link href={href} scroll={false}>
@@ -73,7 +74,10 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
                       if (!value) {
                         return (
                           <Cell key={index} isLight={isLight}>
-                            <LinkCellComponent href={href} isSummaryRow={row.isSummaryRow || row.isUncategorized}>
+                            <LinkCellComponent
+                              href={href}
+                              isSummaryRow={row.isSummaryRow || (row.isUncategorized && !row.isMain)}
+                            >
                               0
                             </LinkCellComponent>
                           </Cell>
@@ -81,7 +85,10 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
                       }
                       return (
                         <Cell key={index} isLight={isLight}>
-                          <LinkCellComponent href={href} isSummaryRow={row.isSummaryRow || row.isUncategorized}>
+                          <LinkCellComponent
+                            href={href}
+                            isSummaryRow={row.isSummaryRow || (row.isUncategorized && !row.isMain)}
+                          >
                             {usLocalizedNumber(row.columns[0][metric as keyof MetricValues], 0)}
                           </LinkCellComponent>
                         </Cell>
@@ -95,7 +102,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
                         metrics={newMetrics}
                         value={row.columns[index]}
                         href={href}
-                        isSummaryRow={row.isSummaryRow || row.isUncategorized}
+                        isSummaryRow={row.isSummaryRow || (row.isUncategorized && !row.isMain)}
                       />
                     ))}
                   {showSemiAnnual &&
@@ -105,7 +112,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
                         metrics={newMetrics}
                         value={row.columns[index]}
                         href={href}
-                        isSummaryRow={row.isSummaryRow || row.isUncategorized}
+                        isSummaryRow={row.isSummaryRow || (row.isUncategorized && !row.isMain)}
                       />
                     ))}
                   {showMonthly &&
@@ -115,7 +122,7 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
                         metrics={newMetrics}
                         value={row.columns[index]}
                         href={href}
-                        isSummaryRow={row.isSummaryRow || row.isUncategorized}
+                        isSummaryRow={row.isSummaryRow || (row.isUncategorized && !row.isMain)}
                       />
                     ))}
                 </TableRow>

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -256,52 +256,10 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
           ],
         } as TableFinances;
         uncategorizedSubTables.push(subTable);
-
-        // if (uncategorizedSubTable === null) {
-        //   // it is empty so we create it
-        //   const row = {
-        //     name: array.length === 1 ? 'Uncategorized' : name,
-        //     codePath: path,
-        //     isUncategorized: true,
-        //     columns,
-        //   } as ItemRow;
-        //   uncategorizedSubTable = {
-        //     tableName: 'Uncategorized',
-        //     rows:
-        //       array.length === 1
-        //         ? [row]
-        //         : [
-        //             // the first row is the is the header of the sub-table
-        //             {
-        //               ...row,
-        //               name: 'Uncategorized',
-        //               isMain: true,
-        //             },
-        //             row,
-        //           ],
-        //   } as TableFinances;
-        // } else {
-        //   // there's more than one uncategorized budget so we add it to the existing table as a new row
-        //   uncategorizedSubTable.rows.push({
-        //     name,
-        //     codePath: path,
-        //     isUncategorized: true,
-        //     columns,
-        //   } as ItemRow);
-
-        //   // update the header of the sub-table
-        //   uncategorizedSubTable.rows[0].columns = uncategorizedSubTable.rows[0].columns.map((headerColumn, index) => ({
-        //     Actuals: headerColumn.Actuals + columns[index].Actuals,
-        //     Budget: headerColumn.Budget + columns[index].Budget,
-        //     PaymentsOnChain: headerColumn.PaymentsOnChain + columns[index].PaymentsOnChain,
-        //     Forecast: headerColumn.Forecast + columns[index].Forecast,
-        //     ProtocolNetOutflow: headerColumn.ProtocolNetOutflow + columns[index].ProtocolNetOutflow,
-        //   }));
-        // }
       });
 
     // create a table for each budget for the current level
-    const tables = [...uncategorizedSubTables];
+    let tables = [...uncategorizedSubTables];
     if (budgets.length === 0) {
       const rows = Object.keys(data).map((path) => {
         const columns = Object.values(data[path]);
@@ -481,7 +439,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
         }
 
         table.rows.push({
-          name: path, // TODO: maybe we can get the name from the budget list
+          name: path,
           codePath: path,
           columns,
         } as ItemRow);
@@ -562,6 +520,11 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
         table.rows = [...rows, othersTotal];
       }
     });
+
+    // "hide"/remove the uncategorized table if it is the only one (it will be included just in the header)
+    if (tables.length === 1 && tables[0].rows[0].isUncategorized) {
+      tables = [];
+    }
 
     // sort final tables by the amount of rows
     const sortedTables = tables.sort((a, b) => {

--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -193,15 +193,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     // group data in an easier structure to manage
     analytics.series.forEach((series) => {
       series.rows.forEach((row) => {
-        let path = row.dimensions[0].path;
-
-        if (path.includes('*')) {
-          // it can be an uncategorized budget
-          const reducedPath = removePatternAfterSlash(path);
-          if (budgets.some((budget) => budget.codePath === reducedPath)) {
-            path = reducedPath; // it is not uncategorized
-          }
-        }
+        const path = row.dimensions[0].path;
 
         if (!data[path]) {
           // create the path as it does not exist
@@ -219,10 +211,14 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
 
     // create a sub-table for each budget that has * in the path
     // this sub-table will be used as the uncategorized table
-    let uncategorizedSubTable: TableFinances | null = null;
+    const uncategorizedSubTables = [] as TableFinances[];
     Object.keys(data)
-      .filter((path) => path.includes('*'))
-      .forEach((path, _, array) => {
+      .filter(
+        // if the path is uncategorized and it is not in the budgets list
+        // (if it is in the budget list then it should be in the sub-tables as uncategorized)
+        (path) => path.includes('*') && !budgets.some((budget) => budget.codePath === removePatternAfterSlash(path))
+      )
+      .forEach((path) => {
         const columns = Object.values(data[path]);
 
         if (selectedGranularity !== 'annual') {
@@ -247,51 +243,65 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
 
         const name = removePatternAfterSlash(path).substring(removePatternAfterSlash(path).lastIndexOf('/') + 1);
 
-        if (uncategorizedSubTable === null) {
-          // it is empty so we create it
-          const row = {
-            name: array.length === 1 ? 'Uncategorized' : name,
-            codePath: path,
-            isUncategorized: true,
-            columns,
-          } as ItemRow;
-          uncategorizedSubTable = {
-            tableName: 'Uncategorized',
-            rows:
-              array.length === 1
-                ? [row]
-                : [
-                    // the first row is the is the header of the sub-table
-                    {
-                      ...row,
-                      name: 'Uncategorized',
-                      isMain: true,
-                    },
-                    row,
-                  ],
-          } as TableFinances;
-        } else {
-          // there's more than one uncategorized budget so we add it to the existing table as a new row
-          uncategorizedSubTable.rows.push({
-            name,
-            codePath: path,
-            isUncategorized: true,
-            columns,
-          } as ItemRow);
+        const subTable = {
+          tableName: name,
+          rows: [
+            {
+              name,
+              codePath: path,
+              isMain: true,
+              isUncategorized: true,
+              columns,
+            },
+          ],
+        } as TableFinances;
+        uncategorizedSubTables.push(subTable);
 
-          // update the header of the sub-table
-          uncategorizedSubTable.rows[0].columns = uncategorizedSubTable.rows[0].columns.map((headerColumn, index) => ({
-            Actuals: headerColumn.Actuals + columns[index].Actuals,
-            Budget: headerColumn.Budget + columns[index].Budget,
-            PaymentsOnChain: headerColumn.PaymentsOnChain + columns[index].PaymentsOnChain,
-            Forecast: headerColumn.Forecast + columns[index].Forecast,
-            ProtocolNetOutflow: headerColumn.ProtocolNetOutflow + columns[index].ProtocolNetOutflow,
-          }));
-        }
+        // if (uncategorizedSubTable === null) {
+        //   // it is empty so we create it
+        //   const row = {
+        //     name: array.length === 1 ? 'Uncategorized' : name,
+        //     codePath: path,
+        //     isUncategorized: true,
+        //     columns,
+        //   } as ItemRow;
+        //   uncategorizedSubTable = {
+        //     tableName: 'Uncategorized',
+        //     rows:
+        //       array.length === 1
+        //         ? [row]
+        //         : [
+        //             // the first row is the is the header of the sub-table
+        //             {
+        //               ...row,
+        //               name: 'Uncategorized',
+        //               isMain: true,
+        //             },
+        //             row,
+        //           ],
+        //   } as TableFinances;
+        // } else {
+        //   // there's more than one uncategorized budget so we add it to the existing table as a new row
+        //   uncategorizedSubTable.rows.push({
+        //     name,
+        //     codePath: path,
+        //     isUncategorized: true,
+        //     columns,
+        //   } as ItemRow);
+
+        //   // update the header of the sub-table
+        //   uncategorizedSubTable.rows[0].columns = uncategorizedSubTable.rows[0].columns.map((headerColumn, index) => ({
+        //     Actuals: headerColumn.Actuals + columns[index].Actuals,
+        //     Budget: headerColumn.Budget + columns[index].Budget,
+        //     PaymentsOnChain: headerColumn.PaymentsOnChain + columns[index].PaymentsOnChain,
+        //     Forecast: headerColumn.Forecast + columns[index].Forecast,
+        //     ProtocolNetOutflow: headerColumn.ProtocolNetOutflow + columns[index].ProtocolNetOutflow,
+        //   }));
+        // }
       });
 
     // create a table for each budget for the current level
-    const tables = uncategorizedSubTable === null ? ([] as TableFinances[]) : [uncategorizedSubTable];
+    const tables = [...uncategorizedSubTables];
     if (budgets.length === 0) {
       const rows = Object.keys(data).map((path) => {
         const columns = Object.values(data[path]);
@@ -389,7 +399,11 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
       rows.forEach((row) => {
         const nameOrCode = subBudgets.filter((item) => item.codePath === row.name)[0];
         if (!nameOrCode) {
-          row.name = `${removePatternAfterSlash(row.name)}`;
+          if (row.name.includes('*')) {
+            // it is an uncategorized budget
+            row.name = 'Uncategorized';
+            row.isUncategorized = true;
+          }
         } else {
           row.name = isMobile ? nameOrCode.code : nameOrCode.name;
         }


### PR DESCRIPTION
## Ticket
https://trello.com/c/iDmNeoEO/434-qa-item

## Description
ALL SCREENS // Uncategorized should have no children. 1. If the uncategorized line item is the only one for the table or subsections of the table, then hide it and include it in the totals row for that specific table and/or subsection of the table. 1.1. So if Uncategorized line item is the only one for e.g., Support Scope, then include the values of the uncategorized in the Support Scope totals row. 2. If uncategorized is not the only one then show it with other line items. 2.1. If Support Scope has other line items on top of Uncategorized: it has e.g., Uncategorized, Incubation budget etc..., then show these all as line items under Support Scope. 3. Uncategorized as a line item subsumes every subline item, i.e., it does not have any children.
