### PR TITLE
[QA] Hide uncategorized subtables/rows where all values are zero

### DIFF
--- a/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -524,7 +524,12 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
           } as ItemRow
         );
 
-        table.rows = [...rows, othersTotal];
+        // check if the others total has any non-zero value to hide it if it is all zeros
+        const isOthersNonZero = othersTotal.columns.some((column) =>
+          activeMetrics.some((metric) => column[metric as keyof MetricValues] !== 0)
+        );
+
+        table.rows = [...rows, ...(isOthersNonZero ? [othersTotal] : [])];
       }
     });
 
@@ -533,15 +538,42 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
       tables = [];
     }
 
+    // hide/remove uncategorized sub-tables that where all the values for the selected metrics are zero
+    const activeMetricsKeys = activeMetrics.map(
+      (metric) =>
+        // translate the selected metrics to columns keys
+        (metric === 'Net Expenses On-Chain'
+          ? 'PaymentsOnChain'
+          : metric === 'Net Protocol Outflow'
+          ? 'ProtocolNetOutflow'
+          : metric) as keyof MetricValues
+    );
+    tables = tables.filter((table) => {
+      if (table.rows[0].isUncategorized) {
+        return table.rows[0].columns.some((column) => activeMetricsKeys.some((metric) => column[metric] !== 0));
+      } else {
+        // it's not uncategorized but may have uncategorized rows
+        table.rows = table.rows.filter((row) => {
+          if (row.isUncategorized) {
+            // uncategorized only
+            return row.columns.some((column) => activeMetricsKeys.some((metric) => column[metric] !== 0));
+          }
+          return true;
+        });
+      }
+
+      return true; // it's not uncategorized so should be included
+    });
+
     // sort final tables by the amount of rows
     const sortedTables = tables.sort((a, b) => {
       // uncategorized should be the first
-      if (b.rows[0]?.isUncategorized) return 1;
+      if (b.rows[0]?.isUncategorized || a.rows[0]?.isUncategorized) return 1;
 
       return b.rows.length - a.rows.length;
     });
     return [tableHeader, sortedTables];
-  }, [allBudgets, analytics, budgets, codePath, error, isMobile, lod, selectedGranularity]);
+  }, [activeMetrics, allBudgets, analytics, budgets, codePath, error, isMobile, lod, selectedGranularity]);
 
   const isLoading = !analytics && !error && (tableHeader === null || tableBody === null);
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/MRjfL60I/430-hide-line-items-with-0-value

## Description
Hide all the "uncategorized" subtables and the uncategorized rows which have all the values of the selected metrics zero

## What solved
- [X] ALL SCREENS // Breakdown table: hide line items with 0 value including the uncategorized row.
