### PR TITLE
[MET] Endgame nav hover

### DIFF
--- a/src/views/Endgame/components/NavigationTabs/NavigationTabs.tsx
+++ b/src/views/Endgame/components/NavigationTabs/NavigationTabs.tsx
@@ -95,8 +95,8 @@ const Navigation = styled('nav')(({ theme }) => ({
 }));
 
 const Tab = styled('div')<{ active?: boolean }>(({ theme, active = false }) => {
-  const activeColor = theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.slate[50];
-  const defaultColor = theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[400];
+  const activeColor = theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50];
+  const defaultColor = theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[600];
 
   return {
     fontSize: 14,
@@ -108,6 +108,10 @@ const Tab = styled('div')<{ active?: boolean }>(({ theme, active = false }) => {
     borderBottom: `2px solid ${active ? activeColor : 'transparent'}`,
     whiteSpace: 'nowrap',
     cursor: 'pointer',
+
+    '&:hover': {
+      color: theme.palette.isLight ? theme.palette.colors.slate[200] : theme.palette.colors.slate[100],
+    },
 
     [theme.breakpoints.up('tablet_768')]: {
       fontSize: 14,


### PR DESCRIPTION
## Ticket
https://trello.com/c/04eKxJok/426-apply-reskin-design-to-the-key-changes-section-met

## Description
Updated the hover statuses in the endgame navbar

## What solved
- [X] Should apply hover to the menu of the first section.