### PR TITLE
[Reskin-431] Add the tooltip to endgame pie chart page

### DIFF
--- a/src/stories/containers/Finances/utils/types.ts
+++ b/src/stories/containers/Finances/utils/types.ts
@@ -34,6 +34,8 @@ export interface DoughnutSeries {
   isVisible?: boolean;
   originalColor?: string;
   originalValue?: number;
+  actuals?: number;
+  budgetCap?: number;
 }
 
 export interface BarChartSeries {


### PR DESCRIPTION
## Ticket
https://trello.com/c/ySUDvo2c/431-apply-reskin-design-to-the-endgame-budget-structure-section-met

## What solved
- [X]  Should update the pie chart tooltip-copy with the new styles.[image.png]
