### PR TITLE
[Reskin-446]: new select component

### DIFF
--- a/src/components/CustomSelect/CustomSelect.stories.tsx
+++ b/src/components/CustomSelect/CustomSelect.stories.tsx
@@ -1,6 +1,11 @@
+import { Box, Typography } from '@mui/material';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import type { TeamRole } from '@/core/enums/teamRole';
 import { withThemeContext } from '@/core/utils/storybook/decorators';
+import RoleChip from '../RoleChip/RoleChip';
 import CustomSelect from './CustomSelect';
+import type { OptionItem } from './type';
+import type { Theme } from '@mui/material';
 import type { Meta } from '@storybook/react';
 
 const meta: Meta<typeof CustomSelect> = {
@@ -62,13 +67,165 @@ const variantsArgs = [
     ],
     selected: ['budget', 'forecast', 'actuals'],
     style: {
-      width: 200,
+      width: 300,
       menuWidth: 300,
+    },
+  },
+  {
+    label: 'Actor Role',
+    onChange: () => null,
+    options: [
+      {
+        label: 'All',
+        value: 'All',
+        extra: {
+          count: 17,
+        },
+      },
+      {
+        label: 'Active Ecosystem Actor',
+        value: 'ActiveEcosystemActor',
+        extra: {
+          count: 10,
+        },
+      },
+      {
+        label: 'Scope Facilitator',
+        value: 'ScopeFacilitator',
+        extra: {
+          count: 2,
+        },
+      },
+      {
+        label: 'Advisory Council Member',
+        value: 'AdvisoryCouncilMember',
+        extra: {
+          count: 5,
+        },
+      },
+      {
+        label: 'DataExpert',
+        value: 'DataExpert',
+        extra: {
+          count: 0,
+        },
+      },
+    ],
+    customOptionsRender: (option: OptionItem, isActive: boolean, theme: Theme) => {
+      const getColor = () => {
+        if (theme.palette.isLight) {
+          return isActive ? '#343839' : '#D7D8D9 ';
+        } else {
+          return isActive ? '#FCFCFC' : '#373E4D';
+        }
+      };
+      return (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            gap: '16px',
+          }}
+        >
+          <Typography sx={{ width: '24px' }} color={getColor()}>
+            {option.extra?.count || '0'}
+          </Typography>
+          <RoleChip status={option.value as TeamRole} />
+        </Box>
+      );
+    },
+    selected: 'ActiveEcosystemActor',
+    style: {
+      width: 350,
+      menuWidth: 350,
+    },
+  },
+  {
+    label: 'Actor Role',
+    onChange: () => null,
+    options: [
+      {
+        label: 'All',
+        value: 'All',
+        extra: {
+          count: 17,
+        },
+      },
+      {
+        label: 'Active Ecosystem Actor',
+        value: 'ActiveEcosystemActor',
+        extra: {
+          count: 10,
+        },
+      },
+      {
+        label: 'Scope Facilitator',
+        value: 'ScopeFacilitator',
+        extra: {
+          count: 2,
+        },
+      },
+      {
+        label: 'Advisory Council Member',
+        value: 'AdvisoryCouncilMember',
+        extra: {
+          count: 5,
+        },
+      },
+      {
+        label: 'Data Expert',
+        value: 'DataExpert',
+        extra: {
+          count: 0,
+        },
+      },
+    ],
+    customOptionsRender: (option: OptionItem, isActive: boolean, theme: Theme) => {
+      const getColor = () => {
+        if (theme.palette.isLight) {
+          return isActive ? '#343839' : '#D7D8D9 ';
+        } else {
+          return isActive ? '#FCFCFC' : '#373E4D';
+        }
+      };
+      return (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            gap: '16px',
+          }}
+        >
+          <Typography sx={{ width: '24px' }} color={getColor()}>
+            {option.extra?.count || '0'}
+          </Typography>
+          <RoleChip status={option.value as TeamRole} />
+        </Box>
+      );
+    },
+    selected: ['ActiveEcosystemActor', 'AdvisoryCouncilMember'],
+    multiple: true,
+    style: {
+      width: 350,
+      menuWidth: 350,
     },
   },
 ];
 
-const [[DefaultCustomSelectLightMode, DefaultCustomSelectDarkMode], [MultiSelectLightMode, MultiSelectDarkMode]] =
-  createThemeModeVariants(CustomSelect, variantsArgs);
+const [
+  [DefaultCustomSelectLightMode, DefaultCustomSelectDarkMode],
+  [MultiSelectLightMode, MultiSelectDarkMode],
+  [SingleSelectWithCustomRenderLightMode, SingleSelectWithCustomRenderDarkMode],
+  [MultiSelectWithCustomRenderLightMode, MultiSelectWithCustomRenderDarkMode],
+] = createThemeModeVariants(CustomSelect, variantsArgs);
 
-export { DefaultCustomSelectLightMode, DefaultCustomSelectDarkMode, MultiSelectLightMode, MultiSelectDarkMode };
+export {
+  DefaultCustomSelectLightMode,
+  DefaultCustomSelectDarkMode,
+  MultiSelectLightMode,
+  MultiSelectDarkMode,
+  SingleSelectWithCustomRenderLightMode,
+  SingleSelectWithCustomRenderDarkMode,
+  MultiSelectWithCustomRenderLightMode,
+  MultiSelectWithCustomRenderDarkMode,
+};

--- a/src/components/CustomSelect/CustomSelect.stories.tsx
+++ b/src/components/CustomSelect/CustomSelect.stories.tsx
@@ -1,0 +1,74 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+import { withThemeContext } from '@/core/utils/storybook/decorators';
+import CustomSelect from './CustomSelect';
+import type { Meta } from '@storybook/react';
+
+const meta: Meta<typeof CustomSelect> = {
+  title: 'Fusion/Components/CustomSelect',
+  component: CustomSelect,
+  decorators: [withThemeContext(true, false)],
+};
+
+export default meta;
+
+const variantsArgs = [
+  {
+    label: 'Year',
+    onChange: () => null,
+    options: [
+      {
+        label: '2022',
+        value: '2022',
+      },
+      {
+        label: '2023',
+        value: '2023',
+      },
+      {
+        label: '2024',
+        value: '2024',
+      },
+    ],
+    selected: '2024',
+    style: {
+      width: 97,
+    },
+  },
+  {
+    label: 'Metrics',
+    multiple: true,
+    onChange: () => null,
+    options: [
+      {
+        label: 'Budget',
+        value: 'budget',
+      },
+      {
+        label: 'Forecast',
+        value: 'forecast',
+      },
+      {
+        label: 'Net Protocol Outflow',
+        value: 'net_protocol_outflow',
+      },
+      {
+        label: 'Net Expenses On-Chain',
+        value: 'net_expenses_on_chain',
+      },
+      {
+        label: 'Actuals',
+        value: 'actuals',
+      },
+    ],
+    selected: ['budget', 'forecast', 'actuals'],
+    style: {
+      width: 200,
+      menuWidth: 300,
+    },
+  },
+];
+
+const [[DefaultCustomSelectLightMode, DefaultCustomSelectDarkMode], [MultiSelectLightMode, MultiSelectDarkMode]] =
+  createThemeModeVariants(CustomSelect, variantsArgs);
+
+export { DefaultCustomSelectLightMode, DefaultCustomSelectDarkMode, MultiSelectLightMode, MultiSelectDarkMode };

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -1,7 +1,7 @@
 import { ExpandMore, Check } from '@mui/icons-material';
 import { Select, MenuItem, FormControl, styled, Box, Typography, useTheme } from '@mui/material';
 import React from 'react';
-import type { CustomSelectProps } from './type';
+import type { CustomSelectProps, OptionItem } from './type';
 import type { SelectChangeEvent, Theme } from '@mui/material';
 
 const CustomSelect: React.FC<CustomSelectProps> = ({
@@ -36,6 +36,12 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
 
   const isAllSelected = withAll && Array.isArray(selected) && selected.length === options.length;
 
+  const isActive = (option: OptionItem) => {
+    if (multiple) {
+      return (selected as (string | number)[]).includes(option.value);
+    }
+    return selected === option.value;
+  };
   const menuProps = StyledMenuProps(theme, style?.menuWidth || 200);
 
   return (
@@ -77,12 +83,12 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
               {customOptionsRender ? (
                 customOptionsRender(option)
               ) : (
-                <MenuItemTypography theme={theme} active={(selected as (string | number)[]).indexOf(option.value) > -1}>
+                <MenuItemTypography theme={theme} active={isActive(option)}>
                   {option.label}
                 </MenuItemTypography>
               )}
             </Box>
-            {!multiple || ((selected as (string | number)[]).indexOf(option.value) > -1 && <CheckIcon />)}
+            {multiple && isActive(option) && <CheckIcon />}
           </MenuItemDefault>
         ))}
       </StyledSelect>

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -1,8 +1,9 @@
 import { ExpandMore, Check } from '@mui/icons-material';
-import { Select, MenuItem, FormControl, styled, Box, Typography, useTheme } from '@mui/material';
+import { Select, MenuItem, FormControl, styled, Box, Typography } from '@mui/material';
 import React from 'react';
-import type { CustomSelectProps, OptionItem } from './type';
-import type { SelectChangeEvent, Theme } from '@mui/material';
+import useCustomSelect from './useCustomSelect';
+import type { CustomSelectProps } from './type';
+import type { Theme } from '@mui/material';
 
 const CustomSelect: React.FC<CustomSelectProps> = ({
   label,
@@ -15,44 +16,24 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
   multiple = false,
   style,
 }) => {
-  const theme = useTheme();
-
-  const handleChange = (event: SelectChangeEvent<unknown>) => {
-    onChange(event.target.value as CustomSelectProps['selected']);
-  };
-
-  const renderValue = (selected: unknown) => {
-    if (multiple) {
-      const selectedOptions = (selected as (string | number)[]).map((value) =>
-        options.find((option) => option.value === value)
-      );
-      if (selectedOptions.length > 1) {
-        return `${label} (${selectedOptions.length})`;
-      }
-      return selectedOptions[0]?.label;
-    }
-    return options.find((option) => option.value === selected)?.label;
-  };
-
-  const isAllSelected = withAll && Array.isArray(selected) && selected.length === options.length;
-
-  const isActive = (option: OptionItem) => {
-    if (multiple) {
-      return (selected as (string | number)[]).includes(option.value);
-    }
-    return selected === option.value;
-  };
-  const menuProps = StyledMenuProps(theme, style?.menuWidth || 200);
+  const { theme, handleChange, renderValue, isAllSelected, isActive } = useCustomSelect({
+    label,
+    options,
+    multiple,
+    selected,
+    withAll,
+    onChange,
+  });
 
   return (
-    <StyledFormControl variant="outlined" fullWidth={style?.fullWidth || false} width={style?.width || 100}>
+    <StyledFormControl variant="outlined" fullWidth={style?.fullWidth || false} width={style?.width || 97}>
       <StyledSelect
         multiple={multiple}
         value={selected}
         onChange={handleChange}
         renderValue={renderValue}
         IconComponent={ExpandMore}
-        MenuProps={menuProps as object}
+        MenuProps={StyledMenuProps(theme, style?.menuWidth || 200) as object}
       >
         <MenuItemLabel disabled>
           <MenuItemLabelTypography>{typeof label === 'string' ? label : label()}</MenuItemLabelTypography>
@@ -81,7 +62,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
           >
             <Box display="flex" alignItems="center">
               {customOptionsRender ? (
-                customOptionsRender(option)
+                customOptionsRender(option, isActive(option), theme)
               ) : (
                 <MenuItemTypography theme={theme} active={isActive(option)}>
                   {option.label}
@@ -108,16 +89,24 @@ const StyledSelect = styled(Select)(({ theme }) => ({
   borderRadius: 8,
   color: theme.palette.isLight ? theme.palette.colors.gray[700] : theme.palette.colors.gray[300],
   height: '32px',
+  fontWeight: 600,
+  padding: '0 2px',
   '& .MuiOutlinedInput-notchedOutline': {
     borderColor: 'transparent',
   },
   '&:hover .MuiOutlinedInput-notchedOutline': {
     borderColor: 'transparent',
   },
+  '&:hover': {
+    color: theme.palette.isLight ? theme.palette.colors.gray[800] : theme.palette.colors.gray[100],
+    border: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[400] : theme.palette.colors.charcoal[600]}`,
+    backgroundColor: theme.palette.isLight ? theme.palette.colors.gray[100] : theme.palette.colors.charcoal[700],
+  },
   '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
     borderColor: 'transparent',
   },
   '& .MuiSelect-icon': {
+    marginRight: 4,
     color: theme.palette.isLight ? '#404446' : '#EFEFEF',
   },
 }));
@@ -188,11 +177,11 @@ const StyledMenuProps = (theme: Theme, width: number) => ({
         '&.Mui-selected': {
           bgcolor: theme.palette.isLight ? theme.palette.colors.slate[50] : 'rgba(37, 42, 52, 0.40)',
           '&:hover': {
-            bgcolor: theme.palette.isLight ? theme.palette.colors.slate[50] : 'rgba(37, 42, 52, 0.40)',
+            bgcolor: theme.palette.isLight ? theme.palette.colors.gray[100] : theme.palette.colors.charcoal[700],
           },
         },
         '&:hover': {
-          bgcolor: 'transparent',
+          bgcolor: theme.palette.isLight ? theme.palette.colors.gray[100] : theme.palette.colors.charcoal[700],
         },
       },
     },

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -1,0 +1,205 @@
+import { ExpandMore, Check } from '@mui/icons-material';
+import { Select, MenuItem, FormControl, styled, Box, Typography, useTheme } from '@mui/material';
+import React from 'react';
+import type { CustomSelectProps } from './type';
+import type { SelectChangeEvent, Theme } from '@mui/material';
+
+const CustomSelect: React.FC<CustomSelectProps> = ({
+  label,
+  options,
+  onChange,
+  selected,
+  customOptionsRender,
+  withAll = false,
+  customOptionsRenderAll,
+  multiple = false,
+  style,
+}) => {
+  const theme = useTheme();
+
+  const handleChange = (event: SelectChangeEvent<unknown>) => {
+    onChange(event.target.value as CustomSelectProps['selected']);
+  };
+
+  const renderValue = (selected: unknown) => {
+    if (multiple) {
+      const selectedOptions = (selected as (string | number)[]).map((value) =>
+        options.find((option) => option.value === value)
+      );
+      if (selectedOptions.length > 1) {
+        return `${label} (${selectedOptions.length})`;
+      }
+      return selectedOptions[0]?.label;
+    }
+    return options.find((option) => option.value === selected)?.label;
+  };
+
+  const isAllSelected = withAll && Array.isArray(selected) && selected.length === options.length;
+
+  const menuProps = StyledMenuProps(theme, style?.menuWidth || 200);
+
+  return (
+    <StyledFormControl variant="outlined" fullWidth={style?.fullWidth || false} width={style?.width || 100}>
+      <StyledSelect
+        multiple={multiple}
+        value={selected}
+        onChange={handleChange}
+        renderValue={renderValue}
+        IconComponent={ExpandMore}
+        MenuProps={menuProps as object}
+      >
+        <MenuItemLabel disabled>
+          <MenuItemLabelTypography>{typeof label === 'string' ? label : label()}</MenuItemLabelTypography>
+        </MenuItemLabel>
+
+        {withAll && (
+          <MenuItemDefault
+            borderTop={true}
+            borderBottom={false}
+            value="all"
+            onClick={() => onChange(isAllSelected ? [] : options.map((option) => option.value))}
+          >
+            {customOptionsRenderAll || 'Select All'}
+          </MenuItemDefault>
+        )}
+        {options.map((option, index) => (
+          <MenuItemDefault
+            borderTop={!withAll && index === 0}
+            borderBottom={index === options.length - 1}
+            key={option.value}
+            value={option.value}
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Box display="flex" alignItems="center">
+              {customOptionsRender ? (
+                customOptionsRender(option)
+              ) : (
+                <MenuItemTypography theme={theme} active={(selected as (string | number)[]).indexOf(option.value) > -1}>
+                  {option.label}
+                </MenuItemTypography>
+              )}
+            </Box>
+            {!multiple || ((selected as (string | number)[]).indexOf(option.value) > -1 && <CheckIcon />)}
+          </MenuItemDefault>
+        ))}
+      </StyledSelect>
+    </StyledFormControl>
+  );
+};
+
+export default CustomSelect;
+
+const StyledFormControl = styled(FormControl)(({ fullWidth, width }: { fullWidth: boolean; width: number }) => ({
+  width: fullWidth ? '100%' : `${width}px`,
+}));
+
+const StyledSelect = styled(Select)(({ theme }) => ({
+  backgroundColor: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.charcoal[800],
+  border: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[300] : theme.palette.colors.charcoal[700]}`,
+  borderRadius: 8,
+  color: theme.palette.isLight ? theme.palette.colors.gray[700] : theme.palette.colors.gray[300],
+  height: '32px',
+  '& .MuiOutlinedInput-notchedOutline': {
+    borderColor: 'transparent',
+  },
+  '&:hover .MuiOutlinedInput-notchedOutline': {
+    borderColor: 'transparent',
+  },
+  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+    borderColor: 'transparent',
+  },
+  '& .MuiSelect-icon': {
+    color: theme.palette.isLight ? '#404446' : '#EFEFEF',
+  },
+}));
+
+const MenuItemLabel = styled(MenuItem)({
+  minHeight: '12px',
+  marginTop: '-40px',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  '&.Mui-disabled': {
+    opacity: 1,
+  },
+});
+
+const MenuItemDefault = styled(MenuItem)(
+  ({ borderTop, borderBottom }: { borderTop: boolean; borderBottom: boolean }) => ({
+    borderTopLeftRadius: borderTop ? '12px' : 0,
+    borderTopRightRadius: borderTop ? '12px' : 0,
+    borderBottomLeftRadius: borderBottom ? '12px' : 0,
+    borderBottomRightRadius: borderBottom ? '12px' : 0,
+    minHeight: '32px',
+    margin: '4px 0',
+  })
+);
+
+const MenuItemTypography = styled(Typography)(({ theme, active }: { theme: Theme; active: boolean }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.slate[600] : theme.palette.colors.gray[50],
+  fontSize: '14px',
+  fontWeight: active ? 600 : 400,
+  lineHeight: '22px',
+  marginLeft: '-8px',
+}));
+
+const MenuItemLabelTypography = styled(Typography)(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.slate[600] : theme.palette.colors.slate[50],
+  fontSize: '14px',
+  fontWeight: 700,
+  lineHeight: '22px',
+  marginLeft: '-8px',
+}));
+
+const CheckIcon = styled(Check)(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+  width: 16,
+  height: 16,
+}));
+
+const StyledMenuProps = (theme: Theme, width: number) => ({
+  PaperProps: {
+    sx: {
+      width: `${width}px`,
+      color: '#000',
+      backgroundImage: 'none',
+      bgcolor: theme.palette.isLight ? '#ffffff' : theme.palette.colors.charcoal[900],
+      boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1)',
+      '&.MuiPaper-elevation.MuiPaper-rounded': {
+        borderRadius: '12px',
+      },
+      '& .MuiMenu-list': {
+        position: 'relative',
+        borderRadius: '12px',
+        bgcolor: theme.palette.isLight ? theme.palette.colors.gray[50] : 'rgba(55, 62, 77, 0.30)',
+        margin: '50px 8px 8px',
+        padding: 0,
+      },
+      '& .MuiMenuItem-root': {
+        '&.Mui-selected': {
+          bgcolor: theme.palette.isLight ? theme.palette.colors.slate[50] : 'rgba(37, 42, 52, 0.40)',
+          '&:hover': {
+            bgcolor: theme.palette.isLight ? theme.palette.colors.slate[50] : 'rgba(37, 42, 52, 0.40)',
+          },
+        },
+        '&:hover': {
+          bgcolor: 'transparent',
+        },
+      },
+    },
+  },
+  anchorOrigin: {
+    vertical: 'bottom',
+    horizontal: 'right',
+  },
+  transformOrigin: {
+    vertical: 'top',
+    horizontal: 'right',
+  },
+  sx: {
+    mt: 0.5,
+  },
+});

--- a/src/components/CustomSelect/type.ts
+++ b/src/components/CustomSelect/type.ts
@@ -1,0 +1,22 @@
+type Data = string | number;
+
+export interface OptionItem {
+  label: Data;
+  value: Data;
+}
+
+export interface CustomSelectProps {
+  label: string | (() => React.ReactNode);
+  options: OptionItem[];
+  onChange: (selected: Data | Data[]) => void;
+  selected: Data | Data[];
+  customOptionsRender?: (option: OptionItem) => React.ReactNode;
+  withAll?: boolean;
+  customOptionsRenderAll?: React.ReactNode;
+  multiple?: boolean;
+  style?: {
+    fullWidth: boolean;
+    width: number; // value in px
+    menuWidth: number; // value in px
+  };
+}

--- a/src/components/CustomSelect/type.ts
+++ b/src/components/CustomSelect/type.ts
@@ -1,8 +1,13 @@
+import type { Theme } from '@mui/material';
+
 type Data = string | number;
 
 export interface OptionItem {
   label: Data;
   value: Data;
+  extra?: {
+    [key: string]: string;
+  };
 }
 
 export interface CustomSelectProps {
@@ -10,7 +15,7 @@ export interface CustomSelectProps {
   options: OptionItem[];
   onChange: (selected: Data | Data[]) => void;
   selected: Data | Data[];
-  customOptionsRender?: (option: OptionItem) => React.ReactNode;
+  customOptionsRender?: (option: OptionItem, isActive: boolean, theme?: Theme) => React.ReactNode;
   withAll?: boolean;
   customOptionsRenderAll?: React.ReactNode;
   multiple?: boolean;

--- a/src/components/CustomSelect/useCustomSelect.ts
+++ b/src/components/CustomSelect/useCustomSelect.ts
@@ -1,0 +1,50 @@
+import { useTheme } from '@mui/material';
+import type { CustomSelectProps, OptionItem } from './type';
+import type { SelectChangeEvent } from '@mui/material';
+
+export interface Props {
+  label: CustomSelectProps['label'];
+  options: CustomSelectProps['options'];
+  multiple?: CustomSelectProps['multiple'];
+  selected: CustomSelectProps['selected'];
+  withAll?: CustomSelectProps['withAll'];
+  onChange: CustomSelectProps['onChange'];
+}
+
+export default function useCustomSelect({ label, options, multiple, selected, withAll, onChange }: Props) {
+  const theme = useTheme();
+
+  const handleChange = (event: SelectChangeEvent<unknown>) => {
+    onChange(event.target.value as CustomSelectProps['selected']);
+  };
+
+  const renderValue = (selected: unknown) => {
+    if (multiple) {
+      const selectedOptions = (selected as (string | number)[]).map((value) =>
+        options.find((option) => option.value === value)
+      );
+      if (selectedOptions.length > 1) {
+        return `${label} (${selectedOptions.length})`;
+      }
+      return selectedOptions[0]?.label;
+    }
+    return options.find((option) => option.value === selected)?.label;
+  };
+
+  const isAllSelected = withAll && Array.isArray(selected) && selected.length === options.length;
+
+  const isActive = (option: OptionItem) => {
+    if (multiple) {
+      return (selected as (string | number)[]).includes(option.value);
+    }
+    return selected === option.value;
+  };
+
+  return {
+    theme,
+    handleChange,
+    renderValue,
+    isAllSelected,
+    isActive,
+  };
+}

--- a/src/components/FiltersBundle/FilterSheet.tsx
+++ b/src/components/FiltersBundle/FilterSheet.tsx
@@ -43,9 +43,7 @@ const SheetWrapper = styled(Sheet)(({ theme, isOpen }) => ({
 const SheetContainer = styled(Sheet.Container)(({ theme }) => ({
   borderTopRightRadius: '12px !important',
   borderTopLeftRadius: '12px !important',
-  backgroundColor: `${
-    theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[900]
-  } !important`,
+  backgroundColor: `${theme.palette.isLight ? '#ffffff' : theme.palette.colors.charcoal[900]} !important`,
   boxShadow: theme.palette.isLight
     ? '0px -4px 15px 0px rgba(74, 88, 115, 0.25)  !important'
     : '0px -4px 15px 0px rgba(10, 12, 15, 0.25) !important',

--- a/src/components/FiltersBundle/FiltersBundle.tsx
+++ b/src/components/FiltersBundle/FiltersBundle.tsx
@@ -1,11 +1,11 @@
 import { TextField, useMediaQuery } from '@mui/material';
-import SingleItemSelect from '@ses/components/SingleItemSelect/SingleItemSelect';
 import { useState } from 'react';
+import CustomSelect from '../CustomSelect/CustomSelect';
 import FilterSheet from './FilterSheet';
 import { defaultTriggerRenderer } from './defaults/Renderers';
 import type { FiltersBundleOptions } from './types';
+import type { CustomSelectProps } from '../CustomSelect/type';
 import type { Theme } from '@mui/material';
-import type { SelectItem } from '@ses/components/SingleItemSelect/SingleItemSelect';
 import type { FC } from 'react';
 
 const FiltersBundle: FC<FiltersBundleOptions> = ({ renderTrigger, resetFilters, filters }) => {
@@ -64,14 +64,11 @@ const FiltersBundle: FC<FiltersBundleOptions> = ({ renderTrigger, resetFilters, 
           }
           case 'select': {
             return (
-              <SingleItemSelect
-                items={filter.options as SelectItem[]}
-                useSelectedAsLabel
-                onChange={filter.onChange}
-                selected={filter.selected as string}
-                PopperProps={{
-                  placement: 'bottom-end',
-                }}
+              <CustomSelect
+                label="Year"
+                options={filter.options as CustomSelectProps['options']}
+                onChange={filter.onChange as CustomSelectProps['onChange']}
+                selected={filter.selected}
               />
             );
           }

--- a/src/views/Endgame/components/BudgetStructureSection/BudgetStructureSection.stories.tsx
+++ b/src/views/Endgame/components/BudgetStructureSection/BudgetStructureSection.stories.tsx
@@ -17,6 +17,7 @@ export default meta;
 
 const variantsArgs = [
   {
+    selectedYear: '2023',
     yearsRange: [
       {
         label: '2023',


### PR DESCRIPTION
## Ticket
https://trello.com/c/UGndl7pm/446-create-a-reusable-year-component-filtersbundle-for-the-endgame-view

## What solved
- [X] Should create the year component with the default, hover, and pressed statuses.
- [X] Should create the year list (single select) with the hover, selected statuses. Desktop resolutions.
- [X] The years' list should have color