### PR TITLE
[Fix-435] links open in a new tab

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = () => (
             <FooterColumnTitle>{name}</FooterColumnTitle>
             <FooterLinkWrapper>
               {links.map(({ label, link, Icon }) => (
-                <FooterLink key={label} href={link}>
+                <FooterLink key={label} href={link} target="_blank">
                   {Icon && <Icon width="16" height="16" />}
                   {label}
                 </FooterLink>

--- a/src/components/Footer/data.ts
+++ b/src/components/Footer/data.ts
@@ -59,7 +59,7 @@ const linkCategory: LinkCategory[] = [
     links: [
       {
         label: 'Connect',
-        link: '#',
+        link: 'https://powerhouse-connect.vercel.app/d/My Local Device',
         Icon: ConnectIcon,
       },
       {


### PR DESCRIPTION
## Ticket
https://trello.com/c/6o1WKifL/435-feature-fdf-1-fusion-dashboard-footer

## What solved
- [X] Should the links open in a new tab.
