### PR TITLE
[EA-454] Remove de duplicate name in budget path

### DIFF
--- a/src/stories/containers/ActorsAbout/ActorAboutContainer.tsx
+++ b/src/stories/containers/ActorsAbout/ActorAboutContainer.tsx
@@ -19,6 +19,7 @@ import ActorMdViewer from './components/ActorMdViewer/ActorMdViewer';
 import ActorSummary from './components/ActorSummary/ActorSummary';
 import CardProjects from './components/CardProjects/CardProjects';
 import useActorAbout from './useActorAbout';
+import { removeDuplicateNames } from './utils';
 import type { Team } from '@ses/core/models/interfaces/team';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
@@ -36,7 +37,7 @@ export const ActorAboutContainer: React.FC<Props> = ({ actors, actor }) => {
 
   const { height, showHeader } = useHeaderSummary(ref, router.query.code as string);
   const routeToFinances = removeAtlasFromPath(actor.budgetPath);
-
+  const removeDuplicateNamesBudgetPath = removeDuplicateNames(routeToFinances);
   return (
     <PageWrapper isLight={isLight}>
       <SEOHead
@@ -91,7 +92,7 @@ export const ActorAboutContainer: React.FC<Props> = ({ actors, actor }) => {
                   titleCard={`View all expenses of the ${actor.name} Ecosystem Actor.`}
                   auditorMessage={`${actor.name} is working without auditor.`}
                   makerburnCustomMessage={`View On-Chain transfers to ${actor.name} on makerburn.com`}
-                  budgetPath={routeToFinances}
+                  budgetPath={removeDuplicateNamesBudgetPath}
                 />
               </ContainerCard>
 

--- a/src/stories/containers/ActorsAbout/utils.ts
+++ b/src/stories/containers/ActorsAbout/utils.ts
@@ -1,0 +1,12 @@
+export const removeDuplicateNames = (path: string) => {
+  const parts = path.split('/');
+  const uniqueParts: string[] = [];
+
+  parts.forEach((part) => {
+    if (!uniqueParts.includes(part)) {
+      uniqueParts.push(part);
+    }
+  });
+
+  return uniqueParts.join('/');
+};


### PR DESCRIPTION
## Ticket
https://trello.com/c/8xXvI1fA/454-ea-about-finances-button-links-to-the-wrong-level



## What solved
- [X] Should the Powerhouse ecosystem actors Finances button link to the proper level on the Finances page. 

