### PR TITLE
[T-450] Fix missing multiselect check icon

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -50,7 +50,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
             }}
           >
             {(customOptionsRenderAll && customOptionsRenderAll(isAllSelected || false, theme)) || 'Select All'}
-            {multiple && isAllSelected && <CheckIcon />}
+            {multiple && <CheckIcon className={`check ${isAllSelected ? 'active' : ''}`} />}
           </MenuItemDefault>
         )}
         {options.map((option, index) => (
@@ -73,7 +73,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
                 </MenuItemTypography>
               )}
             </Box>
-            {multiple && isActive(option) && <CheckIcon />}
+            {multiple && <CheckIcon className={`check ${isActive(option) ? 'active' : ''}`} />}
           </MenuItemDefault>
         ))}
       </StyledSelect>
@@ -116,24 +116,35 @@ const StyledSelect = styled(Select)(({ theme }) => ({
 }));
 
 const MenuItemLabel = styled(MenuItem)({
-  minHeight: '12px',
-  marginTop: '-40px',
+  minHeight: 12,
+  marginTop: -40,
   position: 'absolute',
   top: 0,
   left: 0,
+
   '&.Mui-disabled': {
     opacity: 1,
   },
 });
 
-const MenuItemDefault = styled(MenuItem)(
-  ({ borderTop, borderBottom }: { borderTop: boolean; borderBottom: boolean }) => ({
-    borderTopLeftRadius: borderTop ? '12px' : 0,
-    borderTopRightRadius: borderTop ? '12px' : 0,
-    borderBottomLeftRadius: borderBottom ? '12px' : 0,
-    borderBottomRightRadius: borderBottom ? '12px' : 0,
-    minHeight: '32px',
+const MenuItemDefault = styled(MenuItem)<{ borderTop: boolean; borderBottom: boolean }>(
+  ({ theme, borderTop, borderBottom }) => ({
+    borderTopLeftRadius: borderTop ? 12 : 0,
+    borderTopRightRadius: borderTop ? 12 : 0,
+    borderBottomLeftRadius: borderBottom ? 12 : 0,
+    borderBottomRightRadius: borderBottom ? 12 : 0,
+    minHeight: 32,
     margin: '4px 0',
+
+    '& .check path': {
+      fill: theme.palette.isLight ? theme.palette.colors.gray[300] : theme.palette.colors.charcoal[800],
+    },
+    '&:hover .check path': {
+      fill: theme.palette.colors.gray[500],
+    },
+    '& .check.active path': {
+      fill: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+    },
   })
 );
 
@@ -153,8 +164,7 @@ const MenuItemLabelTypography = styled(Typography)(({ theme }) => ({
   marginLeft: '-8px',
 }));
 
-const CheckIcon = styled(Check)(({ theme }) => ({
-  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+const CheckIcon = styled(Check)(() => ({
   width: 16,
   height: 16,
 }));
@@ -167,9 +177,11 @@ const StyledMenuProps = (theme: Theme, width: number) => ({
       backgroundImage: 'none',
       bgcolor: theme.palette.isLight ? '#ffffff' : theme.palette.colors.charcoal[900],
       boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1)',
+
       '&.MuiPaper-elevation.MuiPaper-rounded': {
         borderRadius: '12px',
       },
+
       '& .MuiMenu-list': {
         position: 'relative',
         borderRadius: '12px',
@@ -177,6 +189,7 @@ const StyledMenuProps = (theme: Theme, width: number) => ({
         margin: '50px 8px 8px',
         padding: 0,
       },
+
       '& .MuiMenuItem-root': {
         '&.Mui-selected': {
           bgcolor: `${theme.palette.isLight ? theme.palette.colors.slate[50] : 'rgba(37, 42, 52, 0.40)'} !important`,
@@ -190,6 +203,7 @@ const StyledMenuProps = (theme: Theme, width: number) => ({
             bgcolor: `${theme.palette.isLight ? theme.palette.colors.slate[50] : 'rgba(37, 42, 52, 0.40)'} !important`,
           },
         },
+
         '&:hover': {
           '.MuiTypography-root': {
             fontWeight: 600,
@@ -200,14 +214,17 @@ const StyledMenuProps = (theme: Theme, width: number) => ({
       },
     },
   },
+
   anchorOrigin: {
     vertical: 'bottom',
     horizontal: 'right',
   },
+
   transformOrigin: {
     vertical: 'top',
     horizontal: 'right',
   },
+
   sx: {
     mt: 0.5,
   },

--- a/src/components/FiltersBundle/defaults/Renderers.tsx
+++ b/src/components/FiltersBundle/defaults/Renderers.tsx
@@ -9,8 +9,8 @@ export const defaultTriggerRenderer: RenderTriggerFn = (onClick, ref) => (
 );
 
 const FilterContainer = styled('div')(({ theme }) => ({
-  width: '24px',
-  height: '24px',
+  width: 24,
+  height: 24,
   color: theme.palette.isLight ? theme.palette.colors.slate[300] : theme.palette.colors.slate[300],
   '&:hover': {
     color: theme.palette.isLight ? theme.palette.colors.slate[400] : theme.palette.colors.slate[200],

--- a/src/components/FiltersBundle/defaults/SelectAsList.tsx
+++ b/src/components/FiltersBundle/defaults/SelectAsList.tsx
@@ -45,13 +45,17 @@ const SelectAsList: React.FC<SelectAsListProps> = ({ filter, onClose }) => {
           <CustomOption onClick={handleChangeAll} isSelected={isAllSelected}>
             {(filter.customOptionsRenderAll && filter.customOptionsRenderAll(isAllSelected || false, theme)) ||
               'Select All'}
-            {filter.multiple && isAllSelected && <CheckIcon width={16} height={16} />}
+            {filter.multiple && (
+              <CheckIcon className={`check ${isAllSelected ? 'active' : ''}`} width={16} height={16} />
+            )}
           </CustomOption>
         )}
         {filter.options.map((option) => (
           <CustomOption key={option.value} onClick={() => handleChange(option.value)} isSelected={isActive(option)}>
             {filter.customOptionsRender ? filter.customOptionsRender(option, isActive(option), theme) : option.label}
-            {filter.multiple && isActive(option) && <CheckIcon width={16} height={16} />}
+            {filter.multiple && (
+              <CheckIcon className={`check ${isActive(option) ? 'active' : ''}`} width={16} height={16} />
+            )}
           </CustomOption>
         ))}
       </SelectContainer>
@@ -94,11 +98,20 @@ const CustomOption = styled('div')<{ isSelected: boolean }>(({ theme, isSelected
       ? `${theme.palette.isLight ? 'rgba(243, 245, 247, 0.50)' : 'rgba(37, 42, 52, 0.20)'} !important`
       : `${theme.palette.isLight ? theme.palette.colors.slate[50] : 'rgba(37, 42, 52, 0.40)'} !important`,
   },
+
+  '& .check path': {
+    fill: theme.palette.isLight ? theme.palette.colors.gray[300] : theme.palette.colors.charcoal[800],
+  },
+  '&:hover .check path': {
+    fill: theme.palette.colors.gray[500],
+  },
+  '& .check.active path': {
+    fill: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+  },
 }));
 
-const CheckIcon = styled(Check)(({ theme }) => ({
+const CheckIcon = styled(Check)(() => ({
   marginTop: 2,
-  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   width: 16,
   height: 16,
 }));


### PR DESCRIPTION
## Ticket
https://trello.com/c/bCYXNh4O/450-update-the-filter-component-for-the-ea-and-cu-views

## Description
The multi select filters in the filter bundle were hiding the check icon, except when the options were selected

## What solved
- [X] **Steps to Reproduce:** Scopes and Actor Role filters.  **Expected Output:** The filters should have the checkmark element (default and hover states). **Current Output:** The checkmark element is visible only when an element is selected. 
