### PR TITLE
[T-450] Fix reset button statuses

### DIFF
--- a/pages/ecosystem-actors/index.tsx
+++ b/pages/ecosystem-actors/index.tsx
@@ -1,6 +1,6 @@
 import { ResourceType } from '@ses/core/models/interfaces/types';
 import React from 'react';
-import ActorsContainer from '@/views/Actors/ActorsContainer';
+import ActorsView from '@/views/Actors/ActorsView';
 import { fetchActors } from '@/views/Actors/api/queries';
 import type { Team } from '@ses/core/models/interfaces/team';
 import type { GetServerSideProps, NextPage } from 'next';
@@ -9,7 +9,7 @@ interface Props {
   actors: Team[];
 }
 
-const EcosystemActors: NextPage<Props> = ({ actors }) => <ActorsContainer actors={actors} />;
+const EcosystemActors: NextPage<Props> = ({ actors }) => <ActorsView actors={actors} />;
 
 export default EcosystemActors;
 

--- a/src/components/FiltersBundle/FilterDesktop.tsx
+++ b/src/components/FiltersBundle/FilterDesktop.tsx
@@ -70,7 +70,7 @@ const FilterDesktop: React.FC<FilterDesktopProps> = ({ filters, searchFilter, re
 export default FilterDesktop;
 
 const ResetButton = styled(Button)(({ theme }) => ({
-  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[800],
+  color: theme.palette.isLight ? theme.palette.colors.gray[600] : theme.palette.colors.gray[500],
   fontSize: 16,
   fontWeight: 600,
   lineHeight: '24px',
@@ -78,6 +78,11 @@ const ResetButton = styled(Button)(({ theme }) => ({
   background: 'transparent',
   padding: '4px 16px',
   textTransform: 'none',
+
+  '&:disabled': {
+    color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[800],
+  },
+
   '&:hover': {
     background: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.slate[900],
   },

--- a/src/components/FiltersBundle/FilterTablet.tsx
+++ b/src/components/FiltersBundle/FilterTablet.tsx
@@ -71,7 +71,7 @@ const FilterTitle = styled('p')(({ theme }) => ({
 }));
 
 const ResetButton = styled(Button)(({ theme }) => ({
-  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[800],
+  color: theme.palette.isLight ? theme.palette.colors.gray[600] : theme.palette.colors.gray[500],
   fontSize: '16px',
   fontWeight: 600,
   lineHeight: '22px',
@@ -79,6 +79,11 @@ const ResetButton = styled(Button)(({ theme }) => ({
   background: 'transparent',
   padding: '4px 16px',
   textTransform: 'none',
+
+  '&:disabled': {
+    color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[800],
+  },
+
   '&:hover': {
     background: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.slate[900],
   },

--- a/src/views/Actors/ActorsView.stories.tsx
+++ b/src/views/Actors/ActorsView.stories.tsx
@@ -7,15 +7,15 @@ import { FeatureFlagsProvider } from '@/core/context/FeatureFlagsProvider';
 import { TeamScopeEnum } from '@/core/enums/actorScopeEnum';
 import { TeamRole } from '@/core/enums/teamRole';
 import AppLayout from '@/stories/containers/AppLayout/AppLayout';
-import ActorsContainer from './ActorsContainer';
+import ActorsView from './ActorsView';
 import { defaultSocials } from './utils/utils';
 import type { Team } from '@ses/core/models/interfaces/team';
 import type { Meta } from '@storybook/react';
 import type { FigmaParams } from 'sb-figma-comparator';
 
-const meta: Meta<typeof ActorsContainer> = {
+const meta: Meta<typeof ActorsView> = {
   title: 'Fusion/Pages/Actors',
-  component: ActorsContainer,
+  component: ActorsView,
   parameters: {
     layout: 'fullscreen',
     nextjs: {
@@ -275,7 +275,7 @@ const [[LightMode, DarkMode]] = createThemeModeVariants(
   (props) => (
     <FeatureFlagsProvider enabledFeatures={featureFlags[CURRENT_ENVIRONMENT]}>
       <AppLayout>
-        <ActorsContainer {...props} />
+        <ActorsView {...props} />
       </AppLayout>
     </FeatureFlagsProvider>
   ),

--- a/src/views/Actors/ActorsView.tsx
+++ b/src/views/Actors/ActorsView.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import FiltersBundle from '@/components/FiltersBundle/FiltersBundle';
 import { TablePlaceholder } from '../CUTable/components/CustomTable/TablePlaceholder';
 import ActorTable from './components/ActorTable/ActorTable';
-import { useActors } from './useActors';
+import { useActorsView } from './useActorsView';
 import type { Team } from '@ses/core/models/interfaces/team';
 
 interface Props {
@@ -16,7 +16,7 @@ interface Props {
   stories?: boolean;
 }
 
-const ActorsContainer: React.FC<Props> = ({ actors, stories = false }) => {
+const ActorsView: React.FC<Props> = ({ actors, stories = false }) => {
   const {
     readMore,
     handleRead,
@@ -30,7 +30,7 @@ const ActorsContainer: React.FC<Props> = ({ actors, stories = false }) => {
     canReset,
     onReset,
     searchFilters,
-  } = useActors(actors, stories);
+  } = useActorsView(actors, stories);
 
   return (
     <ExtendedPageContainer>
@@ -103,7 +103,7 @@ const ActorsContainer: React.FC<Props> = ({ actors, stories = false }) => {
   );
 };
 
-export default ActorsContainer;
+export default ActorsView;
 
 const ExtendedPageContainer = styled(PageContainer)(({ theme }) => ({
   background: theme.palette.isLight ? theme.palette.colors.gray[50] : '#1B1E24',

--- a/src/views/Actors/useActorsView.tsx
+++ b/src/views/Actors/useActorsView.tsx
@@ -53,7 +53,7 @@ const scopesDefinitions: Scope[] = [
   },
 ];
 
-export const useActors = (actors: Team[], stories = false) => {
+export const useActorsView = (actors: Team[], stories = false) => {
   const router = useRouter();
   const debounce = useDebounce();
   const isLessPhone = useMediaQuery(lightTheme.breakpoints.down(376));
@@ -386,7 +386,7 @@ export const useActors = (actors: Team[], stories = false) => {
     },
   ];
 
-  const canReset = searchText !== '' || filteredCategories.length > 0;
+  const canReset = searchText !== '' || filteredCategories.length > 0 || filteredScopes.length > 0;
   const onReset = () => {
     const newQuery = { ...router.query };
     delete newQuery.searchText;

--- a/src/views/Actors/useActorsView.tsx
+++ b/src/views/Actors/useActorsView.tsx
@@ -311,7 +311,7 @@ export const useActorsView = (actors: Team[], stories = false) => {
       count: `${scopeCount[`${scope.name}`]}`,
     },
   }));
-  console.log('filteredScopes', scopeOptions, filteredScopes);
+
   const filter: Filter[] = [
     {
       type: 'select',

--- a/src/views/Actors/utils/utils.ts
+++ b/src/views/Actors/utils/utils.ts
@@ -116,7 +116,6 @@ export const filterDataScopeActors = ({
 
 export const filterActorsText = ({ text = '', data = [] }: { text?: string; data: Team[] }) => {
   const lowerCase = text.toLowerCase();
-  console.log(lowerCase);
   return data?.filter((data) => filterText(lowerCase, data)) ?? [];
 };
 export const defaultSocials = {


### PR DESCRIPTION
## Ticket
https://trello.com/c/bCYXNh4O/450-update-the-filter-component-for-the-ea-and-cu-views

## Description
Show the reset filter button with the enable/disable statuses. Also renamed the actors container to ActorsView to follow the naming convention

## What solved
- [X]  **Expected Output:** The Reset Filter option should be active when at least one element is selected from the filter or text has been inserted on the Search component. **Current Output:** The Reset Filters option is never enabled. 
