### PR TITLE
[T-450] Fix the all option for the scopes filter

### DIFF
--- a/src/components/ScopeChip/useScopeColors.tsx
+++ b/src/components/ScopeChip/useScopeColors.tsx
@@ -23,7 +23,7 @@ const useScopeColors = (): ScopeColors => {
       color: theme.palette.colors.slate[200],
       borderColor: 'rgba(179, 179, 211, 1)',
       colorDark: 'rgba(111, 122, 133, 0.6)',
-      borderColorDark: 'rgba(50, 55, 59, 0.4)',
+      borderColorDark: 'rgba(179, 179, 211, 0.4)',
     },
     'Support Scope': {
       color: theme.palette.colors.blue[800],


### PR DESCRIPTION
## Ticket
https://trello.com/c/bCYXNh4O/450-update-the-filter-component-for-the-ea-and-cu-views

## Description
Fixed the all option border color

## What solved
- [X]  Scopes Filter. Dark Mode. **Expected Output:** The "All" element should have a border color: #B3B3D3 40%. **Current Output:** The system displays the ALL element with a border color: #32373b66.
