### PR TITLE
[T-450] Fix modal sheet top margin

### DIFF
--- a/src/components/CustomSheet/CustomSheet.tsx
+++ b/src/components/CustomSheet/CustomSheet.tsx
@@ -42,9 +42,10 @@ const SheetWrapper = styled(Sheet)(({ theme, isOpen }) => ({
 
   '& .react-modal-sheet-header': {
     alignItems: 'flex-start !important',
-    marginTop: 6,
-    height: '32px !important',
+    marginTop: 4,
+    height: '10px !important',
   },
+
   '& .react-modal-sheet-drag-indicator': {
     backgroundColor: `${
       theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[800]


### PR DESCRIPTION
## Ticket
https://trello.com/c/bCYXNh4O/450-update-the-filter-component-for-the-ea-and-cu-views

## Description
Fixed the Modal sheet top padding

## What solved
- [X] **Steps to Reproduce:** Filters component  **Expected Output:** The space between the top indication and the Search component should be 32px.**Current Output:** The space is not reflected till the Search component. The padding is bigger than the 32 px. 
