### PR TITLE
[T-450] Fix modal sheet scroll

### DIFF
--- a/src/components/CustomSheet/CustomSheet.tsx
+++ b/src/components/CustomSheet/CustomSheet.tsx
@@ -44,6 +44,7 @@ const SheetWrapper = styled(Sheet)(({ theme, isOpen }) => ({
     alignItems: 'flex-start !important',
     marginTop: 4,
     height: '10px !important',
+    marginBottom: 18,
   },
 
   '& .react-modal-sheet-drag-indicator': {

--- a/src/components/FiltersBundle/FilterMobile.tsx
+++ b/src/components/FiltersBundle/FilterMobile.tsx
@@ -53,7 +53,7 @@ const FilterMobile: React.FC<FilterMobileProps> = ({
 export default FilterMobile;
 
 const FullWidthSearch = styled('div')({
-  margin: '16px',
+  margin: '0 16px 16px',
 });
 
 const FullWidthReset = styled(Button)(({ theme }) => ({

--- a/src/components/FiltersBundle/FilterMobile.tsx
+++ b/src/components/FiltersBundle/FilterMobile.tsx
@@ -11,6 +11,7 @@ interface FilterMobileProps {
   filters: Filter[];
   searchFilter?: SearchFilter;
   resetFilters?: ResetFilter;
+  snapPoints?: number[];
   initialSnap?: number;
 }
 
@@ -20,9 +21,10 @@ const FilterMobile: React.FC<FilterMobileProps> = ({
   filters,
   searchFilter,
   resetFilters,
+  snapPoints = [600, 400, 250, 0],
   initialSnap,
 }) => (
-  <CustomSheet isOpen={isOpen} handleClose={handleClose} initialSnap={initialSnap} snapPoints={[600, 400, 250, 0]}>
+  <CustomSheet isOpen={isOpen} handleClose={handleClose} initialSnap={initialSnap} snapPoints={snapPoints}>
     {!!searchFilter && (
       <FullWidthSearch>
         <CustomSearch

--- a/src/components/FiltersBundle/FiltersBundle.tsx
+++ b/src/components/FiltersBundle/FiltersBundle.tsx
@@ -12,7 +12,8 @@ const FiltersBundle: FC<FiltersBundleOptions> = ({
   resetFilters,
   filters,
   order = {},
-  snap = 0,
+  snapPoints,
+  initialSnap = 0,
 }) => {
   const { orderedFilters, resolution, triggerRef, areFiltersOpen, handleToggleOpenFilters } = useFiltersBundle({
     filters,
@@ -31,7 +32,8 @@ const FiltersBundle: FC<FiltersBundleOptions> = ({
           filters={orderedFilters}
           searchFilter={searchFilters}
           resetFilters={resetFilters}
-          initialSnap={snap}
+          snapPoints={snapPoints}
+          initialSnap={initialSnap}
         />
       </>
     );

--- a/src/components/FiltersBundle/types.ts
+++ b/src/components/FiltersBundle/types.ts
@@ -74,5 +74,6 @@ export interface FiltersBundleOptions {
   resetFilters?: ResetFilter | undefined; // default undefined (no reset button)
   filters: Filter[];
   order?: Partial<Record<Breakpoint, string[]>>;
-  snap?: number;
+  snapPoints?: number[];
+  initialSnap?: number; // this is the index of the previous array
 }

--- a/src/views/Actors/ActorsView.tsx
+++ b/src/views/Actors/ActorsView.tsx
@@ -91,6 +91,7 @@ const ActorsView: React.FC<Props> = ({ actors, stories = false }) => {
               canReset,
               onReset,
             }}
+            snapPoints={[604, 400, 250, 0]}
           />
         </FilterContainer>
 

--- a/src/views/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
+++ b/src/views/Endgame/components/BudgetStructureSection/BudgetStructureSection.tsx
@@ -30,11 +30,8 @@ const BudgetStructureSection: React.FC<BudgetCompositionProps> = ({
   legacy,
   totalBudgetCap,
   isLoading,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   yearsRange,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   selectedYear,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   handleYearChange,
   ...totalBudgetProps
 }) => {
@@ -96,7 +93,7 @@ const BudgetStructureSection: React.FC<BudgetCompositionProps> = ({
             }
           />
 
-          <FiltersBundle filters={filter} snap={2} />
+          <FiltersBundle filters={filter} snapPoints={[246, 0]} />
         </Header>
 
         {isLoading ? (


### PR DESCRIPTION
## Ticket
https://trello.com/c/bCYXNh4O/450-update-the-filter-component-for-the-ea-and-cu-views

## Description
Fixed the scroll of the filter and improve the filter height in endgame budget structure section.

## What solved
- [X]   **Expected Output:** A proper scroll bar should be implemented allowing to show by default 6 elements (Desktop resolutions). Allow to show by default all the elements defined at the moment   (Small resolutions). **Current Output:** In the small resolutions the last element is not visible
