### PR TITLE
[T-450] Fix reset button colors in mobile

### DIFF
--- a/src/components/FiltersBundle/FilterMobile.tsx
+++ b/src/components/FiltersBundle/FilterMobile.tsx
@@ -60,8 +60,8 @@ const FullWidthReset = styled(Button)(({ theme }) => ({
   padding: '6px 8px 6px 4px',
   margin: '16px',
   borderRadius: 8,
+  color: theme.palette.isLight ? theme.palette.colors.gray[600] : theme.palette.colors.charcoal[100],
   backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
-  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[300],
   fontSize: 12,
   fontWeight: 500,
   lineHeight: '150%',
@@ -70,6 +70,11 @@ const FullWidthReset = styled(Button)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   gap: 4,
+
+  '&:disabled': {
+    color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[300],
+  },
+
   '&:hover': {
     boxShadow: 'none',
     color: theme.palette.isLight ? theme.palette.colors.gray[600] : theme.palette.colors.charcoal[100],

--- a/src/views/Actors/ActorsView.tsx
+++ b/src/views/Actors/ActorsView.tsx
@@ -91,7 +91,7 @@ const ActorsView: React.FC<Props> = ({ actors, stories = false }) => {
               canReset,
               onReset,
             }}
-            snapPoints={[604, 400, 250, 0]}
+            snapPoints={[610, 400, 250, 0]}
           />
         </FilterContainer>
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/bCYXNh4O/450-update-the-filter-component-for-the-ea-and-cu-views

## Description
Updated the colors of the reset filter on mobile

## What solved
- [X] **Steps to Reproduce:** Reset option. **Expected Output:** **Default state** - Ligth mode -> text: #B6BCC2, background: #F3F5F7.  Dark mode->  text: #9DA6B9, background:  #373E4D. **Enable state** - Ligth mode -> text: #6C7275, background: #F3F5F7. Dark mode->  text: #E6E9ED,  background: #373E4D.  **Current Output:** **Default state** - Ligth mode -> text: #00000042, background: #0000001f. Dark mode-> text: #ffffff4d, background: #ffffff1f. **Enable state**- Ligth mode -> text:  #b6bcc2, background: #f3f5f7. Dark mode-> text: #9da6b9, background: #373e4d
