### PR TITLE
[T-450] Fix EA filter labels

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -3,6 +3,7 @@ import { Select, MenuItem, FormControl, styled, Box, Typography } from '@mui/mat
 import useCustomSelect from './useCustomSelect';
 import type { CustomSelectProps } from './type';
 import type { Theme } from '@mui/material';
+import type { CSSProperties } from 'react';
 
 const CustomSelect: React.FC<CustomSelectProps> = ({
   label,
@@ -13,12 +14,14 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
   withAll = false,
   customOptionsRenderAll,
   multiple = false,
+  alwaysNumberedLabel = false,
   style,
 }) => {
   const { theme, isAllSelected, handleChange, handleChangeAll, renderValue, isActive } = useCustomSelect({
     label,
     options,
     multiple,
+    alwaysNumberedLabel,
     selected,
     withAll,
     onChange,
@@ -83,9 +86,11 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
 
 export default CustomSelect;
 
-const StyledFormControl = styled(FormControl)(({ fullWidth, width }: { fullWidth: boolean; width: number }) => ({
-  width: fullWidth ? '100%' : `${width}px`,
-}));
+const StyledFormControl = styled(FormControl)<{ fullWidth: boolean; width: CSSProperties['width'] }>(
+  ({ fullWidth, width }) => ({
+    width: fullWidth ? '100%' : `${width}px`,
+  })
+);
 
 const StyledSelect = styled(Select)(({ theme }) => ({
   backgroundColor: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.charcoal[800],

--- a/src/components/CustomSelect/type.ts
+++ b/src/components/CustomSelect/type.ts
@@ -1,4 +1,5 @@
 import type { Theme } from '@mui/material';
+import type { CSSProperties } from 'react';
 
 export interface OptionItem {
   label: string;
@@ -17,9 +18,10 @@ export interface CustomSelectProps {
   withAll?: boolean;
   customOptionsRenderAll?: (isActive: boolean, theme?: Theme) => React.ReactNode;
   multiple?: boolean;
+  alwaysNumberedLabel?: boolean;
   style?: {
     fullWidth?: boolean;
-    width?: number; // value in px
+    width?: CSSProperties['width']; // value in px
     menuWidth?: number; // value in px
   };
 }

--- a/src/components/CustomSelect/useCustomSelect.ts
+++ b/src/components/CustomSelect/useCustomSelect.ts
@@ -7,12 +7,21 @@ export interface Props {
   label: CustomSelectProps['label'];
   options: CustomSelectProps['options'];
   multiple?: CustomSelectProps['multiple'];
+  alwaysNumberedLabel?: CustomSelectProps['alwaysNumberedLabel'];
   selected: CustomSelectProps['selected'];
   withAll?: CustomSelectProps['withAll'];
   onChange: CustomSelectProps['onChange'];
 }
 
-export default function useCustomSelect({ label, options, multiple, selected, withAll, onChange }: Props) {
+export default function useCustomSelect({
+  label,
+  options,
+  multiple,
+  alwaysNumberedLabel,
+  selected,
+  withAll,
+  onChange,
+}: Props) {
   let isHandlingAll = false;
   const theme = useTheme();
   const isAllSelected = multiple && withAll && Array.isArray(selected) && selected.length === options.length;
@@ -33,7 +42,7 @@ export default function useCustomSelect({ label, options, multiple, selected, wi
     if ((value as string | string[]).length === 0) return `${label}`;
     if (multiple) {
       const selectedOptions = (value as string[]).map((v) => options.find((option) => option.value === v));
-      if (selectedOptions.length > 1) {
+      if (selectedOptions.length > 1 || (selectedOptions.length === 1 && alwaysNumberedLabel)) {
         return `${label} (${selectedOptions.length})`;
       }
       return selectedOptions[0]?.label;

--- a/src/components/FiltersBundle/FilterDesktop.tsx
+++ b/src/components/FiltersBundle/FilterDesktop.tsx
@@ -26,6 +26,7 @@ const FilterDesktop: React.FC<FilterDesktopProps> = ({ filters, searchFilter, re
             <CustomSelect
               label={filter.label}
               multiple={filter.multiple}
+              alwaysNumberedLabel={filter.alwaysNumberedLabel}
               selected={filter.selected as string | string[]}
               options={filter.options as CustomSelectProps['options']}
               onChange={filter.onChange as CustomSelectProps['onChange']}
@@ -41,12 +42,7 @@ const FilterDesktop: React.FC<FilterDesktopProps> = ({ filters, searchFilter, re
             <div key={filter.id}>
               {filter.options.map((option) => (
                 <label key={option.value}>
-                  <input
-                    type="radio"
-                    value={option.value}
-                    checked={option.selected}
-                    // onChange={() => filter.onChange(option.value)}
-                  />
+                  <input type="radio" value={option.value} checked={option.selected} />
                   {option.label}
                 </label>
               ))}

--- a/src/components/FiltersBundle/FiltersBundle.tsx
+++ b/src/components/FiltersBundle/FiltersBundle.tsx
@@ -8,7 +8,7 @@ import type { FC } from 'react';
 
 const FiltersBundle: FC<FiltersBundleOptions> = ({
   renderTrigger,
-  searchFilters,
+  searchFilter,
   resetFilters,
   filters,
   order = {},
@@ -30,7 +30,7 @@ const FiltersBundle: FC<FiltersBundleOptions> = ({
           isOpen={areFiltersOpen}
           handleClose={handleToggleOpenFilters}
           filters={orderedFilters}
-          searchFilter={searchFilters}
+          searchFilter={searchFilter}
           resetFilters={resetFilters}
           snapPoints={snapPoints}
           initialSnap={initialSnap}
@@ -47,7 +47,7 @@ const FiltersBundle: FC<FiltersBundleOptions> = ({
           isOpen={areFiltersOpen}
           handleClose={handleToggleOpenFilters}
           filters={orderedFilters}
-          searchFilter={searchFilters}
+          searchFilter={searchFilter}
           resetFilters={resetFilters}
           anchorEl={triggerRef}
         />
@@ -55,7 +55,7 @@ const FiltersBundle: FC<FiltersBundleOptions> = ({
     );
   }
 
-  return <FilterDesktop filters={orderedFilters} searchFilter={searchFilters} resetFilters={resetFilters} />;
+  return <FilterDesktop filters={orderedFilters} searchFilter={searchFilter} resetFilters={resetFilters} />;
 };
 
 export default FiltersBundle;

--- a/src/components/FiltersBundle/types.ts
+++ b/src/components/FiltersBundle/types.ts
@@ -1,5 +1,5 @@
 import type { Theme } from '@mui/material';
-import type { MutableRefObject } from 'react';
+import type { CSSProperties, MutableRefObject } from 'react';
 
 export type Breakpoint = 'mobile' | 'tablet' | 'desktop';
 export type FilterType = 'select' | 'radio'; // filter type identifier
@@ -38,6 +38,7 @@ export interface SelectFilter extends GenericFilter {
   type: 'select';
   selected: SelectOption['value'] | SelectOption['value'][];
   multiple?: boolean; // default is false
+  alwaysNumberedLabel?: boolean; // default is false
   options: SelectOption[];
   onChange: (value: SelectOption['value'] | SelectOption['value'][]) => void;
   customOptionsRender?: (option: SelectOption, isActive: boolean, theme?: Theme) => React.ReactNode;
@@ -45,7 +46,7 @@ export interface SelectFilter extends GenericFilter {
   customOptionsRenderAll?: (isActive: boolean, theme?: Theme) => React.ReactNode;
   widthStyles?: {
     fullWidth?: boolean;
-    width?: number; // value in px
+    width?: CSSProperties['width'];
     menuWidth?: number; // value in px
   };
 }
@@ -70,8 +71,8 @@ export type RenderTriggerFn = (onClick: () => void, ref: MutableRefObject<HTMLDi
 
 export interface FiltersBundleOptions {
   renderTrigger?: RenderTriggerFn; // default undefined (default trigger button is rendered)
-  searchFilters?: SearchFilter | undefined; // default undefined (no search)
-  resetFilters?: ResetFilter | undefined; // default undefined (no reset button)
+  searchFilter?: SearchFilter; // default undefined (no search)
+  resetFilters?: ResetFilter; // default undefined (no reset button)
   filters: Filter[];
   order?: Partial<Record<Breakpoint, string[]>>;
   snapPoints?: number[];

--- a/src/views/Actors/ActorsView.tsx
+++ b/src/views/Actors/ActorsView.tsx
@@ -80,7 +80,7 @@ const ActorsView: React.FC<Props> = ({ actors, stories = false }) => {
         <FilterContainer>
           <FiltersBundle
             filters={filter}
-            searchFilters={{
+            searchFilter={{
               value: searchText,
               onChange: searchFilters,
               widthStyles: {

--- a/src/views/Actors/useActorsView.tsx
+++ b/src/views/Actors/useActorsView.tsx
@@ -346,7 +346,7 @@ export const useActorsView = (actors: Team[], stories = false) => {
       ),
 
       widthStyles: {
-        width: 133,
+        width: 'fit-content',
         menuWidth: 350,
       },
     },
@@ -356,7 +356,7 @@ export const useActorsView = (actors: Team[], stories = false) => {
       label: 'Actor Role',
       selected: filteredCategories,
       multiple: true,
-
+      alwaysNumberedLabel: true,
       options: categoryOptions,
       onChange: (value: string | number | (string | number)[]) => {
         handleChangeUrl('filteredCategories')(value as string | string[]);
@@ -365,7 +365,7 @@ export const useActorsView = (actors: Team[], stories = false) => {
         <CustomItemRole isActive={isActive} role={option.value as TeamRole} count={option?.extra?.count} />
       ),
       widthStyles: {
-        width: 154,
+        width: 160,
         menuWidth: 350,
       },
       withAll: true,


### PR DESCRIPTION
## Ticket
https://trello.com/c/bCYXNh4O/450-update-the-filter-component-for-the-ea-and-cu-views

## Description
Allow to show the full width of the select on the filter bundle on certain occasions and allow to show correctly the labels of the selects 

## What solved
- [X]  Scopes Filter. **Expected Output:** When more than one scope is selected, the filter label should be "Scopes (#)". **Current Output:** The label is cut off therefore the number is not visible. 
- [X]  Scopes and Actor Role filters. **Expected Output:** When an element is selected, the element name should appear in full in the filter. **Current Output:** The name is cut off 
