### PR TITLE
[Reskin-450] Fix reset button on disabled status in mobile

### DIFF
--- a/src/components/FiltersBundle/FilterMobile.tsx
+++ b/src/components/FiltersBundle/FilterMobile.tsx
@@ -71,13 +71,9 @@ const FullWidthReset = styled(Button)(({ theme }) => ({
   flexDirection: 'row',
   gap: 4,
 
-  '&:disabled': {
-    color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[300],
-  },
-
-  '&:hover': {
+  '&:disabled, &:hover': {
     boxShadow: 'none',
-    color: theme.palette.isLight ? theme.palette.colors.gray[600] : theme.palette.colors.charcoal[100],
+    color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[300],
     backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
   },
 }));


### PR DESCRIPTION
## Ticket
https://trello.com/c/bCYXNh4O/450-update-the-filter-component-for-the-ea-and-cu-views

## Description
Fixed the colors of the reset button under certain circumstances

## What solved
- [X] **Steps to Reproduce:** Reset option. **Expected Output:** Default background: light-> #F3F5F7,  dark->#373E4D. **Current Output:** The system shows default background for light: #0000001f, dark: #ffffff1f. 
- [X]  **Steps to Reproduce:** Reset option. Click on the Reset option with enable status. **Expected Output:** The option should take the default/disable status. **Current Output:** The option remains in the enable status.
