### PR TITLE
[Reskin-440] Add mobile padding for category and status

### DIFF
--- a/src/components/CategoryChip/CategoryChip.tsx
+++ b/src/components/CategoryChip/CategoryChip.tsx
@@ -21,13 +21,18 @@ const CategoryChip: React.FC<StatusChipProps> = ({ category, className }) => {
 export default CategoryChip;
 const Chip = styled('div')<{ colors: CustomColors; category: TeamCategory }>(({ theme, colors, category }) => ({
   display: 'flex',
+  alignItems: 'center',
   fontFamily: 'Inter, sans-serif',
   fontSize: 14,
   lineHeight: '22px',
   fontWeight: 600,
   width: 'fit-content',
   borderRadius: 6,
-  padding: '1px 16px 1px 16px',
+  padding: '1px 8px 1px 8px',
   color: theme.palette.isLight ? theme.palette.colors.slate[200] : theme.palette.colors.slate[100],
   border: `1.5px solid ${theme.palette.isLight ? colors[`${category}`]?.border : colors[`${category}`]?.borderDark}`,
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    padding: '1px 16px 1px 16px',
+  },
 }));

--- a/src/components/StatusChip/StatusChip.tsx
+++ b/src/components/StatusChip/StatusChip.tsx
@@ -29,11 +29,14 @@ const Chip = styled('div')<{ colors: CustomColors; status: TeamStatus }>(({ them
   fontSize: 12,
   lineHeight: '18px',
   borderRadius: 6,
-  padding: '1px 16px 1px 16px',
+  padding: '1px 8px 1px 8px',
   color: theme.palette.isLight ? colors[status]?.color : colors[status]?.colorDark,
   background: theme.palette.isLight ? colors[status]?.background : colors[status]?.backgroundDark,
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 14,
     lineHeight: '22px',
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    padding: '1px 16px 1px 16px',
   },
 }));

--- a/src/core/enums/cuCategoryEnum.ts
+++ b/src/core/enums/cuCategoryEnum.ts
@@ -7,5 +7,5 @@ export enum CuCategoryEnum {
   Growth = 'Growth',
   Finance = 'Finance',
   Legal = 'Legal',
-  ScopeFacilitator = 'ScopeFacilitator ',
+  ScopeFacilitator = 'ScopeFacilitator',
 }


### PR DESCRIPTION
## Ticket
https://trello.com/c/ftwQpXA8/440-apply-reskin-design-to-the-cu-index


## What solved
- [X] Should change the chip's properties (categories, scopes) to small resolutions.
- [X] All categories should have the defined border. **Current Output:** Scope Facilitator is visible without border.

## Screenshots (if apply)
