### PR TITLE
[Reskin-448] Compact breadcrumb if needed

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -36,24 +36,24 @@ const variantsArgs = [
   {
     items: [
       {
-        label: 'Home',
+        label: '1- Home',
         href: '/',
         number: 15,
       },
       {
-        label: 'Lorem ipsum',
+        label: '2- Lorem ipsum',
         href: '/a1',
       },
       {
-        label: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+        label: '3- Lorem ipsum dolor sit amet, consectetur adipiscing elit',
         href: '/a2',
       },
       {
-        label: 'Lorem ipsum dolor',
+        label: '4- Lorem ipsum dolor',
         href: '/a3',
       },
       {
-        label: 'A very long text that should be truncated',
+        label: '5- A very long text that should be truncated',
         href: '/long',
       },
     ],

--- a/src/components/Breadcrumb/DotsSegment.tsx
+++ b/src/components/Breadcrumb/DotsSegment.tsx
@@ -1,11 +1,55 @@
-import { styled } from '@mui/material';
+import { Menu, MenuItem, styled } from '@mui/material';
+import Link from 'next/link';
 import Ellipsis from 'public/assets/svg/ellipsis.svg';
+import { useId, useState } from 'react';
+import type { BreadcrumbItem } from './Breadcrumb';
 
-const DotsSegment: React.FC = () => (
-  <Icon>
-    <Ellipsis />
-  </Icon>
-);
+interface DotsSegmentProps {
+  items: BreadcrumbItem[];
+}
+
+const DotsSegment: React.FC<DotsSegmentProps> = ({ items }) => {
+  const iconId = useId();
+  const menuId = useId();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <Icon
+        id={iconId}
+        aria-controls={open ? menuId : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+      >
+        <Ellipsis />
+      </Icon>
+
+      <Menu
+        id={menuId}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': iconId,
+        }}
+      >
+        {items.map((item, index) => (
+          <MenuItem key={index} onClick={handleClose}>
+            <Link href={item.href}>{item.label}</Link>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
 
 export default DotsSegment;
 
@@ -15,6 +59,7 @@ const Icon = styled('div')(({ theme }) => ({
   alignItems: 'center',
   borderRadius: 8,
   padding: '0 4px',
+  cursor: 'pointer',
 
   [theme.breakpoints.up('tablet_768')]: {
     background: theme.palette.isLight ? theme.palette.colors.gray[100] : 'red',


### PR DESCRIPTION
## Ticket
https://trello.com/c/YiRim70Y/448-create-a-reusable-breadcrumb-for-cu-ea

## Description
If the items doesn't fit in the breadcrumb container, then compress it in a three dots menu to allow them to fit

## What solved
- [X] Should show the starting and previous page along the current one when there are several levels
