### PR TITLE
[Fix-440] Fix the background in the filter when its open

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -138,6 +138,7 @@ const MenuItemDefault = styled(MenuItem)<{ borderTop: boolean; borderBottom: boo
     borderTopRightRadius: borderTop ? 12 : 0,
     borderBottomLeftRadius: borderBottom ? 12 : 0,
     borderBottomRightRadius: borderBottom ? 12 : 0,
+    backgroundColor: 'transparent!important',
     minHeight: 32,
     margin: '4px 0',
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/ftwQpXA8/440-apply-reskin-design-to-the-cu-index

## What solved
- [X] :Filters. **Expected Output:** The filters should be displayed as Ecosystem Actors shows. **Current Output:** By default the "All" option is displayed with dark background. 