### PR TITLE
[Reskin-440] Add style for button in light mode and links in dark mode in summary tooltip

### DIFF
--- a/src/core/enums/expenditureLevelEnum.ts
+++ b/src/core/enums/expenditureLevelEnum.ts
@@ -1,6 +1,6 @@
 export enum ExpenditureLevel {
-  LOW = 'LOW',
-  OPTIMAL = 'OPTIMAL',
-  STRETCHED = 'STRETCHED',
-  OVERBUDGET = 'OVER BUDGET',
+  low = 'Low',
+  optimal = 'Optimal',
+  stretched = 'Stretched',
+  overBudget = 'Over Budget',
 }

--- a/src/stories/components/CustomBarChart/CustomBarChart.tsx
+++ b/src/stories/components/CustomBarChart/CustomBarChart.tsx
@@ -100,18 +100,18 @@ export const CustomBarChart = (props: CustomBarChartProps) => {
     const percent = (valueActual * 100) / budgetCapActual;
     let expenditureLevel = '';
     if (percent > 0 && percent <= 75) {
-      expenditureLevel = ExpenditureLevel.LOW;
+      expenditureLevel = ExpenditureLevel.low;
     }
 
     if (percent > 75 && percent <= 90) {
-      expenditureLevel = ExpenditureLevel.OPTIMAL;
+      expenditureLevel = ExpenditureLevel.optimal;
     }
 
     if (percent > 90 && percent <= 100) {
-      expenditureLevel = ExpenditureLevel.STRETCHED;
+      expenditureLevel = ExpenditureLevel.stretched;
     }
     if (percent > 100) {
-      expenditureLevel = ExpenditureLevel.OVERBUDGET;
+      expenditureLevel = ExpenditureLevel.overBudget;
     }
 
     return expenditureLevel;
@@ -280,18 +280,18 @@ const Container = styled('div')<{ levelExpenditure?: ExpenditureLevel }>(({ leve
   height: 94,
   gap: 8,
   border: theme.palette.isLight
-    ? levelExpenditure === ExpenditureLevel.LOW || levelExpenditure === ExpenditureLevel.OPTIMAL
+    ? levelExpenditure === ExpenditureLevel.low || levelExpenditure === ExpenditureLevel.optimal
       ? `2px solid ${theme.palette.colors.green[200]}`
-      : levelExpenditure === ExpenditureLevel.STRETCHED
+      : levelExpenditure === ExpenditureLevel.stretched
       ? `2px solid ${theme.palette.colors.orange[200]}`
-      : levelExpenditure === ExpenditureLevel.OVERBUDGET
+      : levelExpenditure === ExpenditureLevel.overBudget
       ? `2px solid ${theme.palette.colors.red[200]}`
       : `2px solid ${theme.palette.colors.charcoal[100]}`
-    : levelExpenditure === ExpenditureLevel.LOW || levelExpenditure === ExpenditureLevel.OPTIMAL
+    : levelExpenditure === ExpenditureLevel.low || levelExpenditure === ExpenditureLevel.optimal
     ? '2px solid #27633B'
-    : levelExpenditure === ExpenditureLevel.STRETCHED
+    : levelExpenditure === ExpenditureLevel.stretched
     ? '1px solid #8C5412'
-    : levelExpenditure === ExpenditureLevel.OVERBUDGET
+    : levelExpenditure === ExpenditureLevel.overBudget
     ? '1px solid #82302C'
     : `2px solid ${theme.palette.colors.charcoal[700]}`,
 }));
@@ -325,14 +325,14 @@ const StyleLevelExpenditure = styled(Typography)<{ levelExpenditure: Expenditure
     fontSize: '14px',
     lineHeight: '22px',
     color: theme.palette.isLight
-      ? levelExpenditure === ExpenditureLevel.LOW || levelExpenditure === ExpenditureLevel.OPTIMAL
+      ? levelExpenditure === ExpenditureLevel.low || levelExpenditure === ExpenditureLevel.optimal
         ? theme.palette.colors.green[700]
-        : levelExpenditure === ExpenditureLevel.STRETCHED
+        : levelExpenditure === ExpenditureLevel.stretched
         ? theme.palette.colors.orange[700]
         : theme.palette.colors.red[700]
-      : levelExpenditure === ExpenditureLevel.LOW || levelExpenditure === ExpenditureLevel.OPTIMAL
+      : levelExpenditure === ExpenditureLevel.low || levelExpenditure === ExpenditureLevel.optimal
       ? theme.palette.colors.green[900]
-      : levelExpenditure === ExpenditureLevel.STRETCHED
+      : levelExpenditure === ExpenditureLevel.stretched
       ? theme.palette.colors.orange[900]
       : theme.palette.colors.red[900],
   })

--- a/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
+++ b/src/stories/containers/TransparencyReport/components/PopverForecastDescription/PopoverForecastDescription.tsx
@@ -25,7 +25,7 @@ const PopoverForecastDescription: React.FC<Props> = ({ value, relativeValue, mon
         <Month>{month}</Month>
         <SeverityDistinction
           isLight={isLight}
-          levelExpenditure={expenditureLevel === '0' ? ExpenditureLevel.OVERBUDGET : expenditureLevel}
+          levelExpenditure={expenditureLevel === '0' ? ExpenditureLevel.overBudget : expenditureLevel}
         >
           {expenditureLevel === '0' ? '' : expenditureLevel}
         </SeverityDistinction>
@@ -80,18 +80,18 @@ const SeverityDistinction = styled.div<WithIsLight & { levelExpenditure: string 
   lineHeight: '13px',
   textTransform: 'uppercase',
   color: isLight
-    ? levelExpenditure === ExpenditureLevel.LOW || levelExpenditure === ExpenditureLevel.OPTIMAL
+    ? levelExpenditure === ExpenditureLevel.low || levelExpenditure === ExpenditureLevel.optimal
       ? '#02CB9B'
-      : levelExpenditure === ExpenditureLevel.STRETCHED
+      : levelExpenditure === ExpenditureLevel.stretched
       ? '#F08B04'
-      : levelExpenditure === ExpenditureLevel.OVERBUDGET
+      : levelExpenditure === ExpenditureLevel.overBudget
       ? '#CB3A0D'
       : '#1E2C37'
-    : levelExpenditure === ExpenditureLevel.LOW || levelExpenditure === ExpenditureLevel.OPTIMAL
+    : levelExpenditure === ExpenditureLevel.low || levelExpenditure === ExpenditureLevel.optimal
     ? '#00ED18'
-    : levelExpenditure === ExpenditureLevel.STRETCHED
+    : levelExpenditure === ExpenditureLevel.stretched
     ? '#FF8237'
-    : levelExpenditure === ExpenditureLevel.OVERBUDGET
+    : levelExpenditure === ExpenditureLevel.overBudget
     ? '#FF4085'
     : '#ECF1F3',
 }));

--- a/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
+++ b/src/stories/containers/TransparencyReport/utils/forecastHelper.ts
@@ -101,18 +101,18 @@ export const getExpenditureLevelForecast = (valueActual: number, budgetCapActual
   const percent = (valueActual * 100) / budgetCapActual;
   let expenditureLevel = '';
   if (percent > 0 && percent <= 75) {
-    expenditureLevel = ExpenditureLevel.LOW;
+    expenditureLevel = ExpenditureLevel.low;
   }
 
   if (percent > 75 && percent <= 90) {
-    expenditureLevel = ExpenditureLevel.OPTIMAL;
+    expenditureLevel = ExpenditureLevel.optimal;
   }
 
   if (percent > 90 && percent <= 100) {
-    expenditureLevel = ExpenditureLevel.STRETCHED;
+    expenditureLevel = ExpenditureLevel.stretched;
   }
   if (percent > 100) {
-    expenditureLevel = ExpenditureLevel.OVERBUDGET;
+    expenditureLevel = ExpenditureLevel.overBudget;
   }
 
   return expenditureLevel;

--- a/src/views/CoreUnits/components/ToolTips/SummaryToolTip.tsx
+++ b/src/views/CoreUnits/components/ToolTips/SummaryToolTip.tsx
@@ -5,7 +5,8 @@ import CategoryChip from '@/components/CategoryChip/CategoryChip';
 import CircleAvatar from '@/components/CircleAvatar/CircleAvatar';
 import ExternalLinkButton from '@/components/ExternalLinkButton/ExternalLinkButton';
 import { StatusChip } from '@/components/StatusChip/StatusChip';
-import type { TeamCategory, TeamStatus } from '@/core/models/interfaces/types';
+import type { TeamCategory } from '@/core/models/interfaces/types';
+import { TeamStatus } from '@/core/models/interfaces/types';
 
 interface Props {
   code: string;
@@ -132,14 +133,16 @@ const CircleAvatarStyled = styled(CircleAvatar)(({ theme }) => ({
   boxShadow: theme.palette.isLight ? theme.fusionShadows.graphShadow : theme.fusionShadows.darkMode,
 }));
 
-const StatusStyled = styled(StatusChip)({
+const StatusStyled = styled(StatusChip)<{ status: TeamStatus }>(({ theme, status }) => ({
   padding: '1px 16px 1px 16px',
-});
+  backgroundColor: theme.palette.isLight && status === TeamStatus.Obsolete ? theme.palette.colors.charcoal[100] : '',
+}));
 
 const ExternalLinkButtonStyled = styled(ExternalLinkButton)(({ theme }) => ({
   padding: '0px 6px 0px 8px',
   borderWidth: 1.5,
   gap: 8,
+  borderColor: !theme.palette.isLight ? theme.palette.colors.charcoal[700] : '',
   alignItems: 'center',
   letterSpacing: '-2%',
   fontSize: 14,


### PR DESCRIPTION

## Ticket
https://trello.com/c/ftwQpXA8/440-apply-reskin-design-to-the-cu-index


## What solved
- [X] Add new style for summary tooltip status in dark mode and links in light mode
