### PR TITLE
[Reskin-448] Update mobile dropdown behavior

### DIFF
--- a/src/components/Breadcrumb/DotsSegment.tsx
+++ b/src/components/Breadcrumb/DotsSegment.tsx
@@ -2,6 +2,7 @@ import { Menu, MenuItem, styled, useMediaQuery } from '@mui/material';
 import Link from 'next/link';
 import Ellipsis from 'public/assets/svg/ellipsis.svg';
 import { useEffect, useId, useState } from 'react';
+import CustomSheet from '../CustomSheet/CustomSheet';
 import type { BreadcrumbItem } from './Breadcrumb';
 import type { Theme } from '@mui/material';
 
@@ -13,6 +14,7 @@ interface DotsSegmentProps {
 const DotsSegment: React.FC<DotsSegmentProps> = ({ items, defaultOpen = false }) => {
   const iconId = useId();
   const menuId = useId();
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
   const isMobileOrTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('desktop_1024'));
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = defaultOpen || Boolean(anchorEl);
@@ -42,26 +44,43 @@ const DotsSegment: React.FC<DotsSegmentProps> = ({ items, defaultOpen = false })
         <Ellipsis />
       </Icon>
 
-      <StyledMenu
-        id={menuId}
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
-        MenuListProps={{
-          'aria-labelledby': iconId,
-        }}
-        autoFocus={false}
-      >
-        {items.map((item, index) => (
-          <MenuItem key={index} onClick={handleClose} autoFocus={false}>
-            {isMobileOrTablet && index === items.length - 1 ? (
-              <span>{item.label}</span>
-            ) : (
-              <Link href={item.href}>{item.label}</Link>
-            )}
-          </MenuItem>
-        ))}
-      </StyledMenu>
+      {isMobile ? (
+        <CustomSheet
+          isOpen={open}
+          handleClose={handleClose}
+          snapPoints={[64 + items.length * 34 + (items.length - 1) * 10, 0]}
+          initialSnap={0}
+        >
+          <SheetContent>
+            {[...items].reverse().map((item, index) => (
+              <SheetItem key={index} onClick={handleClose} autoFocus={false} className={index === 0 ? 'active' : ''}>
+                {index === 0 ? <span>{item.label}</span> : <Link href={item.href}>{item.label}</Link>}
+              </SheetItem>
+            ))}
+          </SheetContent>
+        </CustomSheet>
+      ) : (
+        <StyledMenu
+          id={menuId}
+          anchorEl={anchorEl}
+          open={open}
+          onClose={handleClose}
+          MenuListProps={{
+            'aria-labelledby': iconId,
+          }}
+          autoFocus={false}
+        >
+          {items.map((item, index) => (
+            <MenuItem key={index} onClick={handleClose} autoFocus={false}>
+              {isMobileOrTablet && index === items.length - 1 ? (
+                <span>{item.label}</span>
+              ) : (
+                <Link href={item.href}>{item.label}</Link>
+              )}
+            </MenuItem>
+          ))}
+        </StyledMenu>
+      )}
     </>
   );
 };
@@ -136,5 +155,38 @@ const StyledMenu = styled(Menu)(({ theme }) => ({
     '&:hover': {
       background: theme.palette.isLight ? theme.palette.colors.slate[50] : 'rgba(37, 42, 52, 0.2)',
     },
+  },
+}));
+
+const SheetContent = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  margin: '0 16px 32px',
+  borderRadius: 12,
+  boxShadow: theme.fusionShadows.innerShadow,
+  background: theme.palette.isLight ? theme.palette.colors.gray[50] : 'rgba(55, 62, 77, 0.3)',
+  overflow: 'hidden',
+}));
+
+const SheetItem = styled('div')(({ theme }) => ({
+  display: 'flex',
+  padding: '8px 7.5px',
+  fontSize: 14,
+  lineHeight: '17px',
+  fontWeight: 400,
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.slate[100],
+  width: '100%',
+
+  '& a': {
+    width: '100%',
+  },
+
+  '& span': {
+    fontWeight: 600,
+  },
+
+  '&.active': {
+    background: theme.palette.isLight ? theme.palette.colors.slate[50] : 'rgba(37, 42, 52, 0.4)',
   },
 }));


### PR DESCRIPTION
## Ticket
https://trello.com/c/YiRim70Y/448-create-a-reusable-breadcrumb-for-cu-ea

## Description
The dropdown in mobile should be a modal sheet instead

## What solved
- [X]  Should update back dropdown for light/dark mode. Desktop/Small resolutions
