### PR TITLE
[Reskin-449] Add breadcrumb and header to the EA landing page

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,6 +1,6 @@
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import { ResourceType } from '@/core/models/interfaces/types';
-import { withoutSBPadding } from '@/core/utils/storybook/decorators';
+import { withFixedPositionRelative, withoutSBPadding } from '@/core/utils/storybook/decorators';
 import Breadcrumb from './Breadcrumb';
 import TeamBreadcrumbContent from './CustomContents/TeamBreadcrumbContent';
 import type { Meta } from '@storybook/react';
@@ -9,7 +9,7 @@ import type { FigmaParams } from 'sb-figma-comparator';
 const meta: Meta<typeof Breadcrumb> = {
   title: 'Fusion/Components/Breadcrumb',
   component: Breadcrumb,
-  decorators: [withoutSBPadding],
+  decorators: [withoutSBPadding, withFixedPositionRelative],
   parameters: {
     chromatic: {
       viewports: [375, 768, 1024, 1280, 1440],

--- a/src/components/Breadcrumb/CustomContents/TeamBreadcrumbContent.tsx
+++ b/src/components/Breadcrumb/CustomContents/TeamBreadcrumbContent.tsx
@@ -49,12 +49,14 @@ const ContentContainer = styled('div')(() => ({
   fontWeight: 400,
 }));
 
-const Wrapper = styled('div')(() => ({
+const Wrapper = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
+  color: theme.palette.isLight ? theme.palette.colors.gray[600] : theme.palette.colors.gray[500],
 }));
 
-const CurrentPage = styled('span')(() => ({
+const CurrentPage = styled('span')(({ theme }) => ({
   fontWeight: 700,
   marginRight: 8,
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
 }));

--- a/src/components/TeamHeader/TeamHeader.stories.tsx
+++ b/src/components/TeamHeader/TeamHeader.stories.tsx
@@ -1,12 +1,15 @@
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
-import { withoutSBPadding } from '@/core/utils/storybook/decorators';
+import { TeamRole } from '@/core/enums/teamRole';
+import type { Team } from '@/core/models/interfaces/team';
+import { TeamStatus } from '@/core/models/interfaces/types';
+import { withFixedPositionRelative, withoutSBPadding } from '@/core/utils/storybook/decorators';
 import TeamHeader from './TeamHeader';
 import type { Meta } from '@storybook/react';
 
 const meta: Meta<typeof TeamHeader> = {
   title: 'Fusion/Components/TeamHeader',
   component: TeamHeader,
-  decorators: [withoutSBPadding],
+  decorators: [withFixedPositionRelative, withoutSBPadding],
   parameters: {
     chromatic: {
       viewports: [375, 768, 1024, 1280, 1440],
@@ -18,10 +21,34 @@ export default meta;
 
 const variantsArgs = [
   {
-    code: 'PH',
-    name: 'Powerhouse',
-    description:
-      "The aim of SES is to sustainably grow the Maker Protocol's moats by systematically removing barriers between the decentralized workforce, capital, and work.",
+    team: {
+      code: 'PH',
+      name: 'Powerhouse',
+      sentenceDescription:
+        "The aim of SES is to sustainably grow the Maker Protocol's moats by systematically removing barriers between the decentralized workforce, capital, and work.",
+      scopes: [
+        {
+          id: '1',
+          name: 'Support Scope',
+          code: 'SUP',
+        },
+        {
+          id: '2',
+          name: 'Stability Scope',
+          code: 'CTA',
+        },
+      ],
+      status: TeamStatus.Accepted,
+      category: [TeamRole.ActiveEcosystemActor],
+      socialMediaChannels: [
+        {
+          website: 'https://powerhouse.xyz/',
+          twitter: 'https://twitter.com/powerhouse_xyz',
+          linkedIn: 'https://www.linkedin.com/company/powerhouse-xyz',
+          github: 'https://github.com/powerhouse',
+        },
+      ],
+    } as Team,
   },
 ];
 

--- a/src/components/TeamHeader/TeamHeader.tsx
+++ b/src/components/TeamHeader/TeamHeader.tsx
@@ -1,48 +1,26 @@
-import { Container, styled, useMediaQuery } from '@mui/material';
-import { TeamScopeEnum } from '@/core/enums/actorScopeEnum';
-import { TeamRole } from '@/core/enums/teamRole';
-import { TeamStatus } from '@/core/models/interfaces/types';
+import { styled, useMediaQuery } from '@mui/material';
+import type { TeamRole } from '@/core/enums/teamRole';
+import type { Team } from '@/core/models/interfaces/team';
+import type { TeamStatus } from '@/core/models/interfaces/types';
 import SocialMediaLinksButton from '../ButtonLink/SocialMediaLinksButton';
 import CircleAvatar from '../CircleAvatar/CircleAvatar';
+import Container from '../Container/Container';
 import RoleChip from '../RoleChip/RoleChip';
 import ScopeChip from '../ScopeChip/ScopeChip';
 import { StatusChip } from '../StatusChip/StatusChip';
 import type { Theme } from '@mui/material';
 
 interface TeamHeaderProps {
-  code: string;
-  name: string;
-  description: string;
+  team: Team;
 }
 
-const TeamHeader: React.FC<TeamHeaderProps> = ({ code, name, description }) => {
+const TeamHeader: React.FC<TeamHeaderProps> = ({ team }) => {
   const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
   const chips = (
     <ScopeList>
-      <ScopeChip
-        scope={{
-          id: '1',
-          code: 'GOV',
-          name: TeamScopeEnum.GovernanceScope,
-        }}
-        codeOnly={isMobile}
-      />
-      <ScopeChip
-        scope={{
-          id: '2',
-          code: 'ACC',
-          name: TeamScopeEnum.AccessibilityScope,
-        }}
-        codeOnly={isMobile}
-      />
-      <ScopeChip
-        scope={{
-          id: '3',
-          code: 'PRO',
-          name: TeamScopeEnum.ProtocolScope,
-        }}
-        codeOnly={isMobile}
-      />
+      {team.scopes?.map((item, index) => (
+        <ScopeChip scope={item} key={index} codeOnly={isMobile} />
+      ))}
     </ScopeList>
   );
 
@@ -51,32 +29,24 @@ const TeamHeader: React.FC<TeamHeaderProps> = ({ code, name, description }) => {
       <Container>
         <Content>
           <TeamBasicInfo>
-            <Avatar name="Team" />
+            <Avatar name={team.name} image={team.image} />
             <InfoContent>
               <TeamName>
-                <Code>{code}</Code> {name}
+                <Code>{team.shortCode}</Code> {team.name}
               </TeamName>
               <ChipsContainer>
-                <StatusChip status={TeamStatus.Accepted} />
-                <RoleChip status={TeamRole.AdvisoryCouncilMember} />
+                <StatusChip status={team.status as TeamStatus} />
+                <RoleChip status={(team.category?.[0] ?? '') as TeamRole} />
               </ChipsContainer>
               {chips}
             </InfoContent>
           </TeamBasicInfo>
 
           <LinksContainer>
-            <SocialMediaLinksButton
-              socialMedia={{
-                website: 'https://www.google.com',
-                twitter: 'https://twitter.com',
-                github: 'https://github.com',
-                linkedIn: 'https://www.linkedin.com',
-                discord: 'https://discord.com',
-              }}
-            />
+            <SocialMediaLinksButton socialMedia={team.socialMediaChannels?.[0]} />
           </LinksContainer>
         </Content>
-        <Description>{description}</Description>
+        <Description>{team.sentenceDescription}</Description>
       </Container>
     </MainContainer>
   );
@@ -85,6 +55,11 @@ const TeamHeader: React.FC<TeamHeaderProps> = ({ code, name, description }) => {
 export default TeamHeader;
 
 const MainContainer = styled('div')(({ theme }) => ({
+  position: 'fixed',
+  top: 105,
+  zIndex: 3,
+  width: '100%',
+  background: theme.palette.isLight ? theme.palette.colors.gray[50] : 'rgba(25, 29, 36, 1)',
   borderBottom: `1px solid ${
     theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[900]
   }`,
@@ -160,6 +135,7 @@ const Code = styled('span')(({ theme }) => ({
 
 const ScopeList = styled('div')(() => ({
   display: 'flex',
+  flexWrap: 'wrap',
   gap: 8,
   marginTop: 8,
   width: '100%',

--- a/src/views/EAAbout/EAAboutView.tsx
+++ b/src/views/EAAbout/EAAboutView.tsx
@@ -80,7 +80,7 @@ export const EAAboutView: React.FC<Props> = ({ actors, actor }) => {
         }
       />
       <TeamHeader team={actor} />
-      {/* <ActorSummary actors={actors} showHeader={showHeader} ref={ref} /> */}
+
       <Container>
         <ContainerAllData marginTop={height}>
           <ContainerResponsive>

--- a/src/views/EAAbout/EAAboutView.tsx
+++ b/src/views/EAAbout/EAAboutView.tsx
@@ -9,14 +9,16 @@ import { removeAtlasFromPath } from '@ses/core/utils/string';
 import { toAbsoluteURL } from '@ses/core/utils/urls';
 import { useRouter } from 'next/router';
 import React, { useRef } from 'react';
+import Breadcrumb from '@/components/Breadcrumb/Breadcrumb';
+import TeamBreadcrumbContent from '@/components/Breadcrumb/CustomContents/TeamBreadcrumbContent';
 import Container from '@/components/Container/Container';
 import PageContainer from '@/components/Container/PageContainer';
 import ExternalLinkButton from '@/components/ExternalLinkButton/ExternalLinkButton';
+import TeamHeader from '@/components/TeamHeader/TeamHeader';
 import { SES_DASHBOARD, TYPE_FORM } from '@/core/utils/const';
 import CardExpenses from '../CUAbout/NavigationCard/CardExpenses';
 import CardSomethingWrong from '../CUAbout/NavigationCard/CardSomethingWrong';
 import ActorMdViewer from './components/ActorMdViewer/ActorMdViewer';
-import ActorSummary from './components/ActorSummary/ActorSummary';
 import CardProjects from './components/CardProjects/CardProjects';
 import useEAAboutView from './useEAAboutView';
 import { removeDuplicateNames } from './utils';
@@ -32,7 +34,9 @@ export const EAAboutView: React.FC<Props> = ({ actors, actor }) => {
   const router = useRouter();
   const [isEnabled] = useFlagsActive();
   const ref = useRef<HTMLDivElement>(null);
-  const { queryStrings, phone, LessPhone, table834 } = useEAAboutView(router.query);
+  const { queryStrings, phone, LessPhone, table834, pager } = useEAAboutView(actors, actor);
+  // the next line is disable due to a work in progress
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { height, showHeader } = useHeaderSummary(ref, router.query.code as string);
   const routeToFinances = removeAtlasFromPath(actor.budgetPath);
   const removeDuplicateNamesBudgetPath = removeDuplicateNames(routeToFinances) ?? ' ';
@@ -49,7 +53,34 @@ export const EAAboutView: React.FC<Props> = ({ actors, actor }) => {
         }}
         canonicalURL={siteRoutes.ecosystemActorAbout(actor.shortCode)}
       />
-      <ActorSummary actors={actors} showHeader={showHeader} ref={ref} />
+      <Breadcrumb
+        items={[
+          {
+            label: 'Ecosystem Actors',
+            href: siteRoutes.ecosystemActors,
+            number: actors.length,
+          },
+          {
+            label: actor.name,
+            href: siteRoutes.ecosystemActorAbout(actor.shortCode),
+          },
+        ]}
+        rightContent={
+          <TeamBreadcrumbContent
+            team={ResourceType.EcosystemActor}
+            currentPage={pager.currentPage}
+            totalPages={pager.totalPages}
+            pagerProps={{
+              hasNext: pager.hasNext,
+              hasPrevious: pager.hasPrevious,
+              onNext: pager.onNext,
+              onPrevious: pager.onPrevious,
+            }}
+          />
+        }
+      />
+      <TeamHeader team={actor} />
+      {/* <ActorSummary actors={actors} showHeader={showHeader} ref={ref} /> */}
       <Container>
         <ContainerAllData marginTop={height}>
           <ContainerResponsive>

--- a/src/views/EAAbout/api/queries.ts
+++ b/src/views/EAAbout/api/queries.ts
@@ -13,6 +13,7 @@ export const getActorAbout = (teamType: ResourceType, code: string) => ({
         shortCode
         name
         type
+        status
         budgetPath
         paragraphDescription
         sentenceDescription

--- a/src/views/EAAbout/components/ActorSummary/ActorSummary.tsx
+++ b/src/views/EAAbout/components/ActorSummary/ActorSummary.tsx
@@ -20,6 +20,7 @@ interface ActorSummaryProps {
   showHeader?: boolean;
 }
 
+// TODO: delete this component once it is safe to do it
 const ActorSummary = forwardRef<HTMLDivElement, ActorSummaryProps>(
   ({ actors: data = [], breadcrumbTitle, trailingAddress = [], showHeader = true }, ref) => {
     const { isLight } = useThemeContext();

--- a/src/views/EAAbout/useEAAboutView.ts
+++ b/src/views/EAAbout/useEAAboutView.ts
@@ -65,7 +65,7 @@ const useEAAboutView = (actors: Team[], actor: Team) => {
         const queryStrings = buildQueryString({
           ...router.query,
           filteredCategories,
-          code: null, // override the Actors Code code to avoid add it to the query string as Core Unit
+          code: null, // override the Actors code to avoid add it to the query string
         });
 
         router.push(`${router.route.replace('[code]', filteredData[newIndex].shortCode)}${queryStrings}`);

--- a/src/views/EAAbout/useEAAboutView.ts
+++ b/src/views/EAAbout/useEAAboutView.ts
@@ -2,21 +2,76 @@ import { useMediaQuery } from '@mui/material';
 import { getArrayParam } from '@ses/core/utils/filters';
 import { buildQueryString } from '@ses/core/utils/urls';
 import lightTheme from '@ses/styles/theme/themes';
-import { useMemo } from 'react';
-import type { ParsedUrlQuery } from 'querystring';
+import { useRouter } from 'next/router';
+import { useCallback, useMemo } from 'react';
+import type { Team } from '@/core/models/interfaces/team';
 
-const useEAAboutView = (query: ParsedUrlQuery) => {
+const useEAAboutView = (actors: Team[], actor: Team) => {
+  const router = useRouter();
   const table834 = useMediaQuery(lightTheme.breakpoints.between('table_834', 'desktop_1194'));
   const phone = useMediaQuery(lightTheme.breakpoints.between('mobile_375', 'table_834'));
   const LessPhone = useMediaQuery(lightTheme.breakpoints.down('mobile_375'));
   // This is for the filter of Actors List
-  const filteredCategories = useMemo(() => getArrayParam('filteredCategories', query), [query]);
+  const filteredCategories = useMemo(() => getArrayParam('filteredCategories', router.query), [router.query]);
+  const filteredScopes = useMemo(() => getArrayParam('filteredScopes', router.query), [router.query]);
   const queryStrings = useMemo(
     () =>
       buildQueryString({
-        filteredCategories,
+        ...router.query,
+        code: null,
       }),
-    [filteredCategories]
+    [router.query]
+  );
+
+  // breadcrumb pager
+  const filteredData = useMemo(
+    // apply filters coming from the index page to the pagination
+    () =>
+      actors.filter((actor) => {
+        if (
+          filteredCategories.length > 0 &&
+          !actor.category.some((category) => filteredCategories.includes(category))
+        ) {
+          return false;
+        }
+        if (
+          filteredScopes.length > 0 &&
+          !actor.scopes?.some((scope) => filteredScopes.includes(scope.name.replace(' ', '')))
+        ) {
+          return false;
+        }
+        if (
+          !!router.query.searchText &&
+          !actor.name.toLowerCase().includes((router.query.searchText as string).toLowerCase())
+        ) {
+          return false;
+        }
+
+        return true;
+      }),
+    [actors, filteredCategories, filteredScopes, router.query.searchText]
+  );
+
+  const currentPage = filteredData.findIndex((item) => item.shortCode === actor.shortCode) + 1;
+  const totalPages = filteredData.length;
+  const hasPrevious = currentPage > 1;
+  const hasNext = currentPage < totalPages;
+
+  const changeTeam = useCallback(
+    (direction: -1 | 1) => () => {
+      const index = filteredData?.findIndex((item) => item.shortCode === actor.shortCode);
+      const newIndex = index + direction;
+      if (newIndex >= 0 && newIndex < filteredData?.length) {
+        const queryStrings = buildQueryString({
+          ...router.query,
+          filteredCategories,
+          code: null, // override the Actors Code code to avoid add it to the query string as Core Unit
+        });
+
+        router.push(`${router.route.replace('[code]', filteredData[newIndex].shortCode)}${queryStrings}`);
+      }
+    },
+    [actor.shortCode, filteredCategories, filteredData, router]
   );
 
   return {
@@ -24,6 +79,14 @@ const useEAAboutView = (query: ParsedUrlQuery) => {
     phone,
     LessPhone,
     queryStrings,
+    pager: {
+      currentPage,
+      totalPages,
+      hasPrevious,
+      hasNext,
+      onNext: changeTeam(1),
+      onPrevious: changeTeam(-1),
+    },
   };
 };
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/PM1BO2VY/449-apply-reskin-to-the-main-header-for-cu-ea-about

## Description
Added the breadcrumb and team header to the EA about page. Improved both components and integrated the header with the team object

## What solved

- [X] Should move the components to the new folder structure

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
