### PR TITLE
[Reskin-447] Add sheet button for Finances and Project Cards

### DIFF
--- a/src/views/CUAbout/CustomSheetFinances.tsx
+++ b/src/views/CUAbout/CustomSheetFinances.tsx
@@ -9,7 +9,7 @@ import { siteRoutes } from '@/config/routes';
 import type { AuditorDto } from '@/core/models/dto/coreUnitDTO';
 import { ResourceType } from '@/core/models/interfaces/types';
 import { MAKER_BURN_LINK } from '@/core/utils/const';
-import InlineUser from '../EAAbout/components/InlineUser/InlineUser';
+import Auditors from '../EAAbout/components/Auditors/Auditors';
 import type { FC } from 'react';
 
 interface Props {
@@ -46,7 +46,7 @@ const CustomSheetFinances: FC<Props> = ({
     <Container type={type}>
       <ButtonOpenMenuStyled title="Finances" onClick={handleOpenSheet} />
       <CustomSheetStyled
-        snapPoints={type === ResourceType.CoreUnit ? [600, 350] : (auditors?.length || 0) > 0 ? [600, 280] : [600, 250]}
+        snapPoints={type === ResourceType.CoreUnit ? [600, 350] : (auditors?.length || 0) > 0 ? [600, 300] : [600, 250]}
         className={className}
         children={
           <CardSheetMobile title="Finances" description={`View all expenses of the ${shortCode} ${textDescription}`}>
@@ -58,12 +58,12 @@ const CustomSheetFinances: FC<Props> = ({
                   showIcon
                 />
               )}
-              <InternalLinkButton
+              <StyledBudgetButton
                 href={`${siteRoutes.coreUnitReports(shortCode)}${queryStrings}`}
                 label="Budget Statements"
                 showIcon
               />
-              <InternalLinkButton href={`/finances/${budgetPath}/${queryStrings}`} label="Finances" showIcon />
+              <StyledBudgetFinances href={`/finances/${budgetPath}/${queryStrings}`} label="Finances" showIcon />
 
               {type === ResourceType.CoreUnit && <Line />}
               {type === ResourceType.CoreUnit && (
@@ -75,13 +75,7 @@ const CustomSheetFinances: FC<Props> = ({
               {type === ResourceType.EcosystemActor ? (
                 (auditors || []).length > 0 ? (
                   <AuditorsContainer>
-                    <Auditors>
-                      {auditors?.map((auditor) => (
-                        <Auditor key={auditor.id}>
-                          <InlineUser username={auditor.username} />
-                        </Auditor>
-                      ))}
-                    </Auditors>
+                    <Auditors auditors={auditors || []} auditorTitle={auditorTitle ?? ''} />
                   </AuditorsContainer>
                 ) : (
                   <NoAuditorsMessage>{auditorTitle}</NoAuditorsMessage>
@@ -152,20 +146,9 @@ const ButtonLinkStyled = styled(ExternalLinkButton)(() => ({
 
 const AuditorsContainer = styled('div')({
   padding: '8px 16px 24px',
-});
-
-const Auditors = styled('div')({
-  display: 'flex',
-  flexWrap: 'wrap',
-});
-
-const Auditor = styled('div')({
   marginTop: 16,
-
-  '&:not(:last-of-type)': {
-    marginRight: 40,
-  },
 });
+
 const NoAuditorsMessage = styled('div')(({ theme }) => ({
   padding: '8px 16px 24px',
   fontFamily: 'Inter, sans serif',
@@ -186,3 +169,11 @@ const Container = styled('div')<{ type: ResourceType }>(({ type }) => ({
   display: 'flex',
   width: type === ResourceType.CoreUnit ? undefined : '100%',
 }));
+
+const StyledBudgetButton = styled(InternalLinkButton)({
+  padding: '4px 13px 4px 13px',
+});
+
+const StyledBudgetFinances = styled(InternalLinkButton)({
+  padding: '4px 14.5px 4px 14.5px',
+});

--- a/src/views/CUAbout/NavigationCard/CardExpenses.tsx
+++ b/src/views/CUAbout/NavigationCard/CardExpenses.tsx
@@ -31,7 +31,6 @@ const CardExpenses = ({
   resource = ResourceType.CoreUnit,
   auditors,
   isTitlePresent = true,
-
   queryStrings,
   titleCard,
   auditorMessage,
@@ -177,24 +176,31 @@ const ContainerAuditors = styled('div')(({ theme }) => ({
   },
 }));
 
-const ButtonLinkStyledCard = styled(InternalLinkButton)(() => ({
-  padding: '4px  15.5px 4px 15.5px',
+const ButtonLinkStyledCard = styled(InternalLinkButton)(({ theme }) => ({
+  padding: '4px 15.5px 4px 15.5px',
   height: 32,
   '& > div': {
     letterSpacing: '-0.32px',
   },
   ':hover': {
-    padding: '4px  15.5px 4px 15.5px',
+    padding: '4px 15.5px 4px 15.5px',
+    [theme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
+      padding: '4px 14px 4px 14px',
+    },
   },
 }));
 
-const StyledBudgetButton = styled(InternalLinkButton)({
-  padding: '4px  16px 4px 16px',
+const StyledBudgetButton = styled(InternalLinkButton)(({ theme }) => ({
+  padding: '4px 15.7px 4px 15.7px',
+
   height: 32,
   '& > div': {
     letterSpacing: '-0.32px',
   },
   ':hover': {
-    padding: '4px  16px 4px 16px',
+    padding: '4px 16px 4px 16px',
+    [theme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
+      padding: '4px 14px 4px 14px',
+    },
   },
-});
+}));

--- a/src/views/EAAbout/components/Auditors/Auditors.tsx
+++ b/src/views/EAAbout/components/Auditors/Auditors.tsx
@@ -59,11 +59,16 @@ const Label = styled('div')(({ theme }) => ({
   backgroundColor: theme.palette.isLight ? '#FFFFFF' : theme.palette.colors.charcoal[900],
 }));
 
-const AuditorsList = styled('div')({
+const AuditorsList = styled('div')(({ theme }) => ({
   display: 'flex',
   flexWrap: 'wrap',
-  gap: 24,
-});
+  [theme.breakpoints.up('tablet_768')]: {
+    gap: 20,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 24,
+  },
+}));
 
 const AuditorItem = styled('div')({});
 

--- a/src/views/EAAbout/components/CustomSheetProjects.tsx
+++ b/src/views/EAAbout/components/CustomSheetProjects.tsx
@@ -27,7 +27,7 @@ const CustomSheetProjects: FC<Props> = ({ className, shortCode }) => {
       <ButtonOpenMenuStyled title="Projects" onClick={handleOpenSheet} className={className} />
 
       <CustomSheetStyled
-        snapPoints={[200, 150]}
+        snapPoints={[230, 180]}
         className={className}
         children={
           <CardSheetMobile
@@ -35,7 +35,11 @@ const CustomSheetProjects: FC<Props> = ({ className, shortCode }) => {
             description={`View all the of the projects ${shortCode} is involved in and there status.`}
           >
             <ContainerChildren>
-              <InternalLinkButton href={siteRoutes.ecosystemActorProjects(shortCode)} label="View Projects" showIcon />
+              <InternalLinkButtonStyled
+                href={siteRoutes.ecosystemActorProjects(shortCode)}
+                label="View Projects"
+                showIcon
+              />
             </ContainerChildren>
           </CardSheetMobile>
         }
@@ -72,4 +76,9 @@ const ButtonOpenMenuStyled = styled(SecondaryButton)({
   display: 'flex',
   flex: 1,
   justifyContent: 'center',
+  padding: '4px 13.5px 4px 13.5px',
 });
+
+const InternalLinkButtonStyled = styled(InternalLinkButton)(() => ({
+  padding: '4px 13.5px 4px 13.5px',
+}));


### PR DESCRIPTION
## Ticket
https://trello.com/c/tmFwaqq8/447-apply-reskin-design-to-the-cu-ea-about

## What solved

- [X] Should update the text and View Projects button (status) for light/dark mode. Desktop resolutions.
- [X] Should update the Finances section (subtitle+card) for light/dark mode. Desktop resolutions. 
- [X] Should update the Finances section (toaster+ text+ buttons (status) + Auditor section) for light/dark mode. Mobile resolutions

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
