### PR TITLE
[PH24-1] Disabled some milestone elements

### DIFF
--- a/src/stories/containers/ActorProjects/components/DeliverableCard/DeliverableCard.tsx
+++ b/src/stories/containers/ActorProjects/components/DeliverableCard/DeliverableCard.tsx
@@ -84,7 +84,7 @@ const Card = styled('div')<{ fitContent: boolean }>(({ theme, fitContent }) => (
   background: theme.palette.isLight ? '#fff' : '#1E2C37',
   border: `1px solid ${theme.palette.isLight ? '#D1DEE6' : '#31424E'}`,
   boxShadow: theme.palette.isLight
-    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 5px 10px 0px rgba(219, 227, 237, 0.40)'
+    ? '0px 3px 10px 0px rgba(88, 88, 88, 0.2)'
     : '10px 15px 20px 6px rgba(20, 0, 141, 0.10)',
   padding: 15,
   height: fitContent ? 'fit-content' : 'auto',

--- a/src/stories/containers/ActorProjects/components/DeliverableCard/DeliverableCard.tsx
+++ b/src/stories/containers/ActorProjects/components/DeliverableCard/DeliverableCard.tsx
@@ -1,9 +1,6 @@
-import styled from '@emotion/styled';
-import { useMediaQuery } from '@mui/material';
+import { styled, useMediaQuery } from '@mui/material';
 import Avatar from '@mui/material/Avatar';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { DeliverableStatus } from '@ses/core/models/interfaces/projects';
-import lightTheme from '@ses/styles/theme/themes';
 import React, { useState } from 'react';
 import SESTooltip from '@/stories/components/SESTooltipLegacy/SESTooltipLegacy';
 import DeliverablePercentageBar from '../DeliverablePercentageBar/DeliverablePercentageBar';
@@ -14,8 +11,8 @@ import MilestoneLink from '../MilestoneLink/MilestoneLink';
 import OwnerTooltipContent from '../OwnerTooltipContent/OwnerTooltipContent';
 import ProjectLink from '../ProjectLink/ProjectLink';
 import type { DeliverableViewMode } from '../ProjectCard/ProjectCard';
+import type { Theme } from '@mui/material';
 import type { Deliverable } from '@ses/core/models/interfaces/projects';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface DeliverableCardProps {
   deliverable: Deliverable;
@@ -30,18 +27,15 @@ const DeliverableCard: React.FC<DeliverableCardProps> = ({
   maxKeyResultsOnRow,
   isProjectCard = true,
 }) => {
-  const { isLight } = useThemeContext();
-  const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
   const [expanded, setExpanded] = useState<boolean>(false);
   const handleToggleExpand = () => setExpanded((prev) => !prev);
 
   return (
-    <Card isLight={isLight} fitContent={!isMobile && viewMode === 'compacted' && !expanded}>
+    <Card fitContent={!isMobile && viewMode === 'compacted' && !expanded}>
       <HeaderContainer>
         <TitleContainer>
-          <Title isLight={isLight} viewMode={viewMode}>
-            {deliverable.title}
-          </Title>
+          <Title viewMode={viewMode}>{deliverable.title}</Title>
         </TitleContainer>
         <DeliverableOwnerContainer>
           <SESTooltip content={<OwnerTooltipContent title="Deliverable Owner" items={[deliverable.owner]} />}>
@@ -61,7 +55,7 @@ const DeliverableCard: React.FC<DeliverableCardProps> = ({
       </ProgressContainer>
 
       {(viewMode === 'detailed' || expanded) && (
-        <Description isLight={isLight}>
+        <Description>
           Purely financial view of SPFs with generalized financial categories applicable across all budget categories.
         </Description>
       )}
@@ -81,28 +75,29 @@ const DeliverableCard: React.FC<DeliverableCardProps> = ({
 
 export default DeliverableCard;
 
-const Card = styled.div<WithIsLight & { fitContent: boolean }>(({ isLight, fitContent }) => ({
+const Card = styled('div')<{ fitContent: boolean }>(({ theme, fitContent }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
   gap: 7,
   borderRadius: 6,
-  background: isLight ? '#fff' : '#1E2C37',
-  boxShadow: isLight
+  background: theme.palette.isLight ? '#fff' : '#1E2C37',
+  border: `1px solid ${theme.palette.isLight ? '#D1DEE6' : '#31424E'}`,
+  boxShadow: theme.palette.isLight
     ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 5px 10px 0px rgba(219, 227, 237, 0.40)'
     : '10px 15px 20px 6px rgba(20, 0, 141, 0.10)',
-  padding: 16,
+  padding: 15,
   height: fitContent ? 'fit-content' : 'auto',
 }));
 
-const HeaderContainer = styled.div({
+const HeaderContainer = styled('div')({
   display: 'flex',
   alignItems: 'flex-start',
   gap: 24,
   alignSelf: 'stretch',
 });
 
-const TitleContainer = styled.div({
+const TitleContainer = styled('div')({
   maxWidth: 'calc(100% - 51px)',
   display: 'flex',
   flexDirection: 'column',
@@ -111,20 +106,20 @@ const TitleContainer = styled.div({
   marginBottom: 8,
 });
 
-const Title = styled.div<WithIsLight & { viewMode: DeliverableViewMode }>(({ isLight, viewMode }) => ({
+const Title = styled('div')<{ viewMode: DeliverableViewMode }>(({ theme, viewMode }) => ({
   ...(viewMode !== 'detailed' && {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
   }),
   alignSelf: 'stretch',
-  color: isLight ? '#25273D' : '#D2D4EF',
+  color: theme.palette.isLight ? '#25273D' : '#D2D4EF',
   fontSize: 16,
   fontWeight: 700,
   lineHeight: 'normal',
 }));
 
-const DeliverableOwnerContainer = styled.div({
+const DeliverableOwnerContainer = styled('div')({
   display: 'flex',
   alignItems: 'center',
 });
@@ -139,26 +134,26 @@ const OwnerImage = styled(Avatar)({
   fontFamily: 'Inter, sans-serif',
 });
 
-const ProgressContainer = styled.div({
+const ProgressContainer = styled('div')({
   display: 'flex',
   alignItems: 'center',
   width: '100%',
   gap: 16,
 });
 
-const Description = styled.p<WithIsLight>(({ isLight }) => ({
+const Description = styled('p')(({ theme }) => ({
   margin: 0,
   fontSize: 14,
   lineHeight: 'normal',
-  color: isLight ? '#231536' : '#D2D4EF',
+  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
 
-  [lightTheme.breakpoints.up('tablet_768')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
     lineHeight: '22px',
   },
 }));
 
-const KeyBox = styled.div({
+const KeyBox = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',

--- a/src/views/RoadmapMilestones/components/MilestoneDetailsCard/DeliverablesSection.tsx
+++ b/src/views/RoadmapMilestones/components/MilestoneDetailsCard/DeliverablesSection.tsx
@@ -9,9 +9,11 @@ import { DeliverableStatus } from '@ses/core/models/interfaces/projects';
 import { useState } from 'react';
 import type { DeliverableViewMode } from '@ses/containers/ActorProjects/components/ProjectCard/ProjectCard';
 
+const FEATURE_ENABLED = false;
+
 const DeliverablesSection: React.FC = () => {
   const [deliverableViewMode, setDeliverableViewMode] = useState<DeliverableViewMode>('compacted');
-  const [showAllDeliverables, setShowAllDeliverables] = useState<boolean>(false);
+  const [showAllDeliverables, setShowAllDeliverables] = useState<boolean>(true);
 
   // mocked deliverables
   const deliverables = [
@@ -129,20 +131,23 @@ const DeliverablesSection: React.FC = () => {
     <DeliverablesContainer>
       <Header>
         <TitleBox>
-          <Title>{showAllDeliverables ? 'All' : 'Highlighted'} Deliverables</Title>
+          <Title>Deliverables</Title>
           <Count>{deliverables.length}</Count>
         </TitleBox>
 
-        <DeliverableViewModeToggle
-          deliverableViewMode={deliverableViewMode}
-          onChangeDeliverableViewMode={(mode: DeliverableViewMode) => setDeliverableViewMode(mode)}
-        />
+        {FEATURE_ENABLED && (
+          <DeliverableViewModeToggle
+            deliverableViewMode={deliverableViewMode}
+            onChangeDeliverableViewMode={(mode: DeliverableViewMode) => setDeliverableViewMode(mode)}
+          />
+        )}
       </Header>
 
-      {/* Disable temporary the search */}
-      {/* <SearchContainer>
-        <CustomSearchInput placeholder="Search" legacyBreakpoints={false} />
-      </SearchContainer> */}
+      {FEATURE_ENABLED && (
+        <SearchContainer>
+          <CustomSearchInput placeholder="Search" legacyBreakpoints={false} />
+        </SearchContainer>
+      )}
 
       <BackgroundContainer>
         <DeliverablesGrid showDeliverablesBelow={false}>
@@ -152,13 +157,13 @@ const DeliverablesSection: React.FC = () => {
                 key={deliverable.id}
                 isProjectCard={false}
                 deliverable={deliverable}
-                viewMode={deliverableViewMode}
+                viewMode={'detailed'}
                 maxKeyResultsOnRow={row.map((d) => d.keyResults.length).reduce((a, b) => Math.max(a, b), 0)}
               />
             ))
           )}
         </DeliverablesGrid>
-        {deliverables.length > 6 && (
+        {FEATURE_ENABLED && deliverables.length > 6 && (
           <ViewAllButton viewAll={showAllDeliverables} onClick={() => setShowAllDeliverables((prev) => !prev)}>
             View {showAllDeliverables ? 'less' : 'all'} Deliverables
           </ViewAllButton>

--- a/src/views/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
+++ b/src/views/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneProgress.tsx
@@ -1,14 +1,18 @@
 import { styled } from '@mui/material';
 import PercentageProgressBar from './PercentageProgressBar';
 
+const FEATURE_ENABLED = false;
+
 const MilestoneProgress: React.FC = () => (
   <OutlinedCard>
     <PercentageProgressBar value={75.0} />
 
     <TextProgressBox>
-      <TextProgress>
-        <span>55</span>/<span>74</span> Story Points Completed
-      </TextProgress>
+      {FEATURE_ENABLED && (
+        <TextProgress>
+          <span>55</span>/<span>74</span> Story Points Completed
+        </TextProgress>
+      )}
 
       <TextProgress>
         <span>1</span>/<span>6</span> Deliverables Completed
@@ -28,7 +32,7 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   alignSelf: 'stretch',
   padding: '16px 0',
   borderRadius: 6,
-  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : '#31424E'}`,
+  border: `1px solid ${theme.palette.isLight ? '#D4D9E1' : '#31424E'}`,
 
   [theme.breakpoints.up('tablet_768')]: {
     borderRadius: 16,
@@ -55,14 +59,14 @@ const TextProgress = styled('span')(({ theme }) => ({
   fontSize: 14,
   fontWeight: 500,
   lineHeight: '18px',
-  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
+  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
 
   '& span:nth-child(1)': {
     color: '#1AAB9B',
   },
 
   '& span:nth-child(2)': {
-    color: theme.palette.mode === 'light' ? '#708390' : '#B6BCC2',
+    color: theme.palette.isLight ? '#708390' : '#B6BCC2',
     fontWeight: 700,
   },
 }));

--- a/src/views/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
+++ b/src/views/RoadmapMilestones/components/MilestoneDetailsCard/StatsData.tsx
@@ -6,6 +6,8 @@ import Information from '@/components/icons/information';
 import SESTooltip from '@/stories/components/SESTooltipLegacy/SESTooltipLegacy';
 import type { Theme } from '@mui/material';
 
+const FEATURE_ENABLED = false;
+
 const StatsData: React.FC = () => {
   const { isLight } = useThemeContext();
   const is1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
@@ -25,33 +27,37 @@ const StatsData: React.FC = () => {
         </Label>
         <Value>Q4 2023</Value>
       </Row>
-      <Row>
-        <Label>{is1024 ? 'Est.' : 'Estimated'} Budget Cap</Label>
-        <Value>
-          {usLocalizedNumber(12927312, 0)} <span>DAI</span>
-        </Value>
-      </Row>
+      {FEATURE_ENABLED && (
+        <Row>
+          <Label>{is1024 ? 'Est.' : 'Estimated'} Budget Cap</Label>
+          <Value>
+            {usLocalizedNumber(12927312, 0)} <span>DAI</span>
+          </Value>
+        </Row>
+      )}
 
-      <BudgetBox>
-        <Percentage>58%</Percentage>
-        <ExtendedHorizontalBudgetBar actuals={200} prediction={250} budgetCap={300} />
-        <Legend>
-          <LegendItem dotColor={isLight ? '#2DC1B1' : '#1AAB9B'}>
-            <LegendNumberWrapper>
-              <LegendNumber>{humanizedActuals.value}</LegendNumber>
-              <LegendNumberSuffix>{humanizedActuals.suffix}</LegendNumberSuffix>
-            </LegendNumberWrapper>
-            <LegendLabel>Actuals</LegendLabel>
-          </LegendItem>
-          <LegendItem dotColor={'#F75524'}>
-            <LegendNumberWrapper>
-              <LegendNumber>{humanizedBudgetCap.value}</LegendNumber>
-              <LegendNumberSuffix>{humanizedBudgetCap.suffix}</LegendNumberSuffix>
-            </LegendNumberWrapper>
-            <LegendLabel>Cap</LegendLabel>
-          </LegendItem>
-        </Legend>
-      </BudgetBox>
+      {FEATURE_ENABLED && (
+        <BudgetBox>
+          <Percentage>58%</Percentage>
+          <ExtendedHorizontalBudgetBar actuals={200} prediction={250} budgetCap={300} />
+          <Legend>
+            <LegendItem dotColor={isLight ? '#2DC1B1' : '#1AAB9B'}>
+              <LegendNumberWrapper>
+                <LegendNumber>{humanizedActuals.value}</LegendNumber>
+                <LegendNumberSuffix>{humanizedActuals.suffix}</LegendNumberSuffix>
+              </LegendNumberWrapper>
+              <LegendLabel>Actuals</LegendLabel>
+            </LegendItem>
+            <LegendItem dotColor={'#F75524'}>
+              <LegendNumberWrapper>
+                <LegendNumber>{humanizedBudgetCap.value}</LegendNumber>
+                <LegendNumberSuffix>{humanizedBudgetCap.suffix}</LegendNumberSuffix>
+              </LegendNumberWrapper>
+              <LegendLabel>Cap</LegendLabel>
+            </LegendItem>
+          </Legend>
+        </BudgetBox>
+      )}
     </OutlinedCard>
   );
 };
@@ -66,7 +72,7 @@ const OutlinedCard = styled('div')(({ theme }) => ({
   alignSelf: 'stretch',
   padding: 15,
   borderRadius: 6,
-  border: `1px solid ${theme.palette.mode === 'light' ? '#D4D9E1' : '#31424E'}`,
+  border: `1px solid ${theme.palette.isLight ? '#D4D9E1' : '#31424E'}`,
 
   [theme.breakpoints.up('tablet_768')]: {
     borderRadius: 16,
@@ -96,7 +102,7 @@ const Label = styled('div')(({ theme }) => ({
   fontWeight: 600,
   letterSpacing: 1,
   textTransform: 'uppercase',
-  color: theme.palette.mode === 'light' ? '#434358' : '#B6BCC2',
+  color: theme.palette.isLight ? '#434358' : '#B6BCC2',
   alignSelf: 'normal',
 }));
 
@@ -122,7 +128,7 @@ const Value = styled('div')(({ theme }) => ({
   gap: 4,
   fontSize: 14,
   fontWeight: 700,
-  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
+  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
 
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
@@ -131,7 +137,7 @@ const Value = styled('div')(({ theme }) => ({
   '& span': {
     fontSize: 16,
     fontWeight: 700,
-    color: theme.palette.mode === 'light' ? '#9FAFB9' : '#B6BCC2',
+    color: theme.palette.isLight ? '#9FAFB9' : '#B6BCC2',
   },
 }));
 
@@ -148,7 +154,7 @@ const Percentage = styled('div')(({ theme }) => ({
   fontWeight: 600,
   lineHeight: 'normal',
   letterSpacing: 0.4,
-  color: theme.palette.mode === 'light' ? '#231536' : '#D2D4EF',
+  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
   fontVariantNumeric: 'lining-nums tabular-nums',
 
   [theme.breakpoints.up('desktop_1024')]: {
@@ -176,7 +182,7 @@ const LegendItem = styled('div')<{ dotColor: string }>(({ theme, dotColor }) => 
   position: 'relative',
   fontSize: 14,
   lineHeight: 'normal',
-  color: theme.palette.mode === 'light' ? '#231536' : '#EDEFFF',
+  color: theme.palette.isLight ? '#231536' : '#EDEFFF',
   paddingRight: 10,
   display: 'flex',
   alignItems: 'baseline',


### PR DESCRIPTION
## Ticket
https://trello.com/c/CJmEHdII/484-ph24-1-demo-powerhouse-team-roadmap-page

## Description
<!--- What is new in this PR -->

## What solved

- [X] Should the Milestone Details sticky section on the left.
- [X] Should remove budget information and story points progress information.
- [X] Should all of the milestone deliverables are surfaced (no highlighted, no search bar, no different view mode options) 
- [X] Should all of Deliverables content be surfaced as well (the default and only Deliverable card view is the one with 2-row title space and description texts present).
- [X] Should apply a new shadow to the deliverables cards.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
