### PR TITLE
[Reskin-496] Fix hidden content below the header on mobile devices

### DIFF
--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -173,6 +173,7 @@ const dictionary = [
   'mouseout',
   'resized',
   'stablecoin',
+  'unobserve',
 ];
 
 module.exports = dictionary;


### PR DESCRIPTION
## Ticket
https://trello.com/c/ZmnYYI8X/496-content-is-not-visible-on-mobile-when-scrolling-up-down

## Description
Fix the height issue that hides the page content

## What solved

- [X] Should fix the scrolling behavior.
- [X] Should make it possible to hide the content behind the header when scrolling up.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [ ] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
