### PR TITLE
[PH24-1] Improve milestones card title and mocked data

### DIFF
--- a/src/views/RoadmapMilestones/components/MilestoneCard/MilestoneCard.tsx
+++ b/src/views/RoadmapMilestones/components/MilestoneCard/MilestoneCard.tsx
@@ -11,22 +11,23 @@ interface MilestoneCardProps {
 
 const MilestoneCard: React.FC<MilestoneCardProps> = ({ milestone }) => {
   const router = useRouter();
+  const handleView = () => router.replace(`#${milestone.code}`);
 
   return (
     <Card>
       <TitleBox>
         <TitleContainer>
-          <CodeBox>
+          <NameBox>
             <MilestoneNumber>{milestone.id}</MilestoneNumber>
             <Code>{milestone.code}</Code>
-          </CodeBox>
-          <NameBox>
             <Name>{milestone.title}</Name>
+          </NameBox>
+          <QuarterBox>
             <Quarter>
               {/* target date should be printed out with the format: Q4’23 */}
               {`${milestone.targetDate.split('-')[1]}'${milestone.targetDate.split('-')[0].slice(-2)}`}
             </Quarter>
-          </NameBox>
+          </QuarterBox>
         </TitleContainer>
       </TitleBox>
       <MobileOnlyBox>
@@ -38,7 +39,7 @@ const MilestoneCard: React.FC<MilestoneCardProps> = ({ milestone }) => {
           <ProgressContainer>
             <MobileProgressBar value={55} />
           </ProgressContainer>
-          <ViewButton label="View" />
+          <ViewButton label="View" onClick={handleView} />
         </MobileProgressBox>
       </MobileOnlyBox>
 
@@ -59,7 +60,7 @@ const MilestoneCard: React.FC<MilestoneCardProps> = ({ milestone }) => {
             </ProgressBox>
           </XBox>
 
-          <ViewButton label="View" onClick={() => router.replace(`#${milestone.code}`)} />
+          <ViewButton label="View" onClick={handleView} />
         </BottomBox>
       </TabletAndDesktopOnlyBox>
     </Card>
@@ -114,14 +115,8 @@ const TitleContainer = styled('div')({
   width: '100%',
 });
 
-const CodeBox = styled('div')(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  gap: 4,
-
-  [theme.breakpoints.up('tablet_768')]: {
-    gap: 8,
-  },
+const NameBox = styled('div')(() => ({
+  display: 'block',
 }));
 
 const MilestoneNumber = styled('span')(({ theme }) => ({
@@ -144,6 +139,7 @@ const Code = styled('span')(({ theme }) => ({
   fontSize: 14,
   fontWeight: 600,
   lineHeight: 'normal',
+  marginLeft: 4,
 
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
@@ -151,12 +147,9 @@ const Code = styled('span')(({ theme }) => ({
   },
 }));
 
-const NameBox = styled('div')(({ theme }) => ({
-  display: 'flex',
+const QuarterBox = styled('div')(({ theme }) => ({
   padding: '0 4px',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  width: '100%',
+  alignSelf: 'baseline',
   borderRadius: 4,
   background: theme.palette.isLight ? 'rgba(236, 239, 249, 0.50)' : '#1F2537',
 
@@ -172,6 +165,7 @@ const Name = styled('span')(({ theme }) => ({
   fontSize: 16,
   fontWeight: 600,
   lineHeight: 'normal',
+  marginLeft: 8,
 
   [theme.breakpoints.up('tablet_768')]: {
     display: 'none',

--- a/src/views/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
+++ b/src/views/RoadmapMilestones/components/MilestoneDetailsCard/MilestoneDetailsCard.tsx
@@ -99,6 +99,7 @@ const Card = styled('article')(({ theme }) => ({
   border: `1px solid ${theme.palette.mode === 'light' ? '#D1DEE6' : '#31424E'}`,
   borderRadius: 6,
   padding: '16px 16px 24px 16px',
+  scrollMarginTop: 140,
 
   [theme.breakpoints.up('tablet_768')]: {
     padding: 24,

--- a/src/views/RoadmapMilestones/staticData.ts
+++ b/src/views/RoadmapMilestones/staticData.ts
@@ -215,10 +215,64 @@ export const PowerhouseRoadmap2024: Roadmap = {
   ],
 };
 
+const CommonDefaultMilestone = {
+  id: 'M1',
+  code: 'BASE',
+  title: 'Exploration Base',
+  abstract:
+    'A first deployment that integrates the different deliverables. Focus is on exploration of open design questions (removing uncertainty).',
+  description:
+    'Feature exploration and open design questions, smart contracts project, chatbot, UI intergration, marcomms project.\nMilestone 1, set for August 1, marks the initial phase of Exploration Base. Projects include Smart Contracts, focused on establishing foundations and addressing design questions. The Chatbot Project aims to enhance the conversational UX with low hanging fruit execution, prioritizing clarity and correctness. Overall, this milestone lays the groundwork, explores design possibilities, and strives to improve the user experience in the MakerDAO ecosystem.',
+  targetDate: '2023-Q4',
+  coordinators,
+  contributors,
+  scope: [
+    {
+      deliverables: [
+        {
+          id: '1',
+          code: '1',
+          title: 'First technical integration of RWA Portfolio (Connect & Switchboard)',
+          description:
+            'Technical integration demo showcasing for the first time the RWA Portfolio Editor in Connect and the data synchronization with Switchboard.',
+          owner: contributors[0],
+          status: DeliverableStatus.DELIVERED,
+          workProgress: {
+            value: 100,
+          },
+          budgetAnchor: {
+            project: 'RWA Portfolio',
+            workUnitBudget: 1000,
+            deliverableBudget: 1000,
+          },
+          keyResults: [],
+        },
+      ],
+      status: DeliverableSetStatus.FINISHED,
+      progress: {
+        value: 100,
+      },
+      deliverablesCompleted: {
+        total: 3,
+        completed: 3,
+      },
+    },
+  ],
+};
+
 export const DefaultRoadmap: Roadmap = {
   id: 'default',
   slug: 'default',
   title: 'Phase 1 Progress',
   description: 'Unleashing Potential: MakerDAO’s result-driven road map for unlocking tangible results.',
-  milestones: [],
+  milestones: [
+    { ...CommonDefaultMilestone },
+    { ...CommonDefaultMilestone },
+    { ...CommonDefaultMilestone },
+    { ...CommonDefaultMilestone },
+    { ...CommonDefaultMilestone },
+    { ...CommonDefaultMilestone },
+    { ...CommonDefaultMilestone },
+    { ...CommonDefaultMilestone },
+  ],
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/CJmEHdII/484-ph24-1-demo-powerhouse-team-roadmap-page

## Description
Improved the card title to show it in only one line, at the same level as the code adding better support for longer titles. Also improved the mocked data for the default view (no ph roadmap)

## What solved

- [X] Should show the milestones card title in the same line with the code in the timeline

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook
