### PR TITLE
[Reskin-503] Fix breadcrumb text on iOS devices

### DIFF
--- a/src/components/Breadcrumb/CustomContents/TeamBreadcrumbContent.tsx
+++ b/src/components/Breadcrumb/CustomContents/TeamBreadcrumbContent.tsx
@@ -43,6 +43,7 @@ const ContentContainer = styled('div')(() => ({
   alignItems: 'stretch',
   flexWrap: 'nowrap',
   textWrap: 'nowrap',
+  whiteSpace: 'nowrap',
   gap: 16,
   fontSize: 16,
   lineHeight: '18px',


### PR DESCRIPTION
## Ticket
https://trello.com/c/4weAM0uV/503-incorrect-visualization-of-ecosystem-actors-core-units-navigation-in-safari

## Description
Fix the breadcrumb on Apple devices 

## What solved

- [X] Should display the ecosystem actors' navigation in one line as the design shows.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
