### PR TITLE
[BSS-1] Complete budget statement page integration

### DIFF
--- a/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
+++ b/src/stories/containers/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
@@ -14,6 +14,7 @@ import { DateTime } from 'luxon';
 import Link from 'next/link';
 import React, { useMemo } from 'react';
 import CircleAvatarWithIcon from '@/components/CircleAvatar/CircleAvatarWithIcon';
+import { AllowedOwnerType } from '@/views/BudgetStatement/types';
 import LastModifiedActorCoreUnit from '@/views/CoreUnits/LastModifiedActorCoreUnit/LastModifiedActorCoreUnit';
 import { getLastActivityDate } from '../../utils/utils';
 import ViewButton from '../ViewButton/ViewButton';
@@ -50,6 +51,21 @@ const DelegateExpenseTrendItem: React.FC<Props> = ({ budget, selectedMetric, now
 
       case 'Delegates':
         return `${siteRoutes.recognizedDelegateReport}?viewMonth=${DateTime.fromFormat(
+          budget.month,
+          'yyyy-LL-dd'
+        ).toFormat('LLLyyyy')}`;
+      case 'SpecialPurposeFund':
+        return `${siteRoutes.budgetStatements(AllowedOwnerType.SPFS)}?viewMonth=${DateTime.fromFormat(
+          budget.month,
+          'yyyy-LL-dd'
+        ).toFormat('LLLyyyy')}`;
+      case 'AlignedDelegates':
+        return `${siteRoutes.budgetStatements(AllowedOwnerType.ALIGNED_DELEGATES)}?viewMonth=${DateTime.fromFormat(
+          budget.month,
+          'yyyy-LL-dd'
+        ).toFormat('LLLyyyy')}`;
+      case 'Keepers':
+        return `${siteRoutes.budgetStatements(AllowedOwnerType.KEEPERS)}?viewMonth=${DateTime.fromFormat(
           budget.month,
           'yyyy-LL-dd'
         ).toFormat('LLLyyyy')}`;

--- a/src/views/BudgetStatement/BudgetStatementView.tsx
+++ b/src/views/BudgetStatement/BudgetStatementView.tsx
@@ -6,7 +6,6 @@ import { toAbsoluteURL } from '@ses/core/utils/urls';
 import AccountsSnapshotTabContainer from '@/components/AccountsSnapshot/AccountsSnapshotTabContainer';
 import type { SnapshotLimitPeriods } from '@/core/hooks/useBudgetStatementPager';
 import type { ResourceType } from '@/core/models/interfaces/types';
-import Tabs from '@/stories/components/Tabs/Tabs';
 import BudgetStatementSummary from './components/BudgetStatementSummary/BudgetStatementSummary';
 import useBudgetStatementView from './useBudgetStatementView';
 
@@ -97,28 +96,17 @@ const BudgetStatementView: React.FC<BudgetStatementViewProps> = ({ snapshotLimit
           </PagerBar>
         </ContainerPagerBar>
 
-        <TabsContainer>
-          <Tabs
-            tabs={[
-              {
-                item: 'Accounts Snapshot',
-                id: 'accounts-snapshots',
-              },
-            ]}
-            expandable={false}
-            tabQuery={'section'}
+        <Wrapper>
+          <AccountsSnapshotTabContainer
+            snapshotOwner={name}
+            currentMonth={currentMonth}
+            ownerId={null}
+            longCode={code}
+            shortCode={code}
+            resource={ownerType as unknown as ResourceType}
+            setSnapshotCreated={setSnapshotCreated}
           />
-        </TabsContainer>
-
-        <AccountsSnapshotTabContainer
-          snapshotOwner={name}
-          currentMonth={currentMonth}
-          ownerId={null}
-          longCode={code}
-          shortCode={code}
-          resource={ownerType as unknown as ResourceType}
-          setSnapshotCreated={setSnapshotCreated}
-        />
+        </Wrapper>
       </ContainerInside>
     </Container>
   );
@@ -181,14 +169,6 @@ const ContainerInside = styled('div')<{ marginTop: number }>(({ theme, marginTop
 const ContainerPagerBar = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('tablet_768')]: {
     marginTop: -3,
-  },
-}));
-
-const TabsContainer = styled('div')(({ theme }) => ({
-  margin: '32px 0 16px',
-
-  [theme.breakpoints.up('tablet_768')]: {
-    margin: '32px 0',
   },
 }));
 
@@ -302,5 +282,13 @@ const SinceDate = styled('div')(({ theme }) => ({
     fontSize: '12px',
     marginTop: '4px',
     letterSpacing: '1px',
+  },
+}));
+
+const Wrapper = styled('div')(({ theme }) => ({
+  marginTop: 24,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    marginTop: 32,
   },
 }));

--- a/src/views/BudgetStatement/BudgetStatementView.tsx
+++ b/src/views/BudgetStatement/BudgetStatementView.tsx
@@ -22,6 +22,7 @@ const BudgetStatementView: React.FC<BudgetStatementViewProps> = ({ snapshotLimit
     showHeader,
     code,
     name,
+    breadcrumbItems,
     snapshotCreated,
     setSnapshotCreated,
     currentMonth,
@@ -53,16 +54,7 @@ const BudgetStatementView: React.FC<BudgetStatementViewProps> = ({ snapshotLimit
         showHeader={showHeader}
         code={code}
         name={name}
-        breadcrumbItems={[
-          {
-            label: 'Finances',
-            url: siteRoutes.financesOverview,
-          },
-          {
-            label: name,
-            url: siteRoutes.budgetStatements(ownerTypeQuery),
-          },
-        ]}
+        breadcrumbItems={breadcrumbItems}
       />
 
       <ContainerInside marginTop={height}>

--- a/src/views/BudgetStatement/components/BudgetStatementSummary/BudgetStatementSummary.tsx
+++ b/src/views/BudgetStatement/components/BudgetStatementSummary/BudgetStatementSummary.tsx
@@ -106,6 +106,7 @@ const ContainerRow = styled('div')({
 const ContainerDescription = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
+  alignSelf: 'center',
 
   [theme.breakpoints.up('tablet_768')]: {
     flexDirection: 'row',
@@ -124,7 +125,6 @@ const ContainerDescription = styled('div')(({ theme }) => ({
 
 const CircleContainer = styled('div')(({ theme }) => ({
   marginRight: 8,
-  marginTop: 3,
 
   [theme.breakpoints.up('tablet_768')]: {
     marginTop: -1,

--- a/src/views/BudgetStatement/useBudgetStatementView.ts
+++ b/src/views/BudgetStatement/useBudgetStatementView.ts
@@ -2,6 +2,7 @@ import { useHeaderSummary } from '@ses/core/hooks/useHeaderSummary';
 import { DateTime } from 'luxon';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { siteRoutes } from '@/config/routes';
 import type { SnapshotLimitPeriods } from '@/core/hooks/useBudgetStatementPager';
 import { useUrlAnchor } from '@/core/hooks/useUrlAnchor';
 import { AllowedOwnerType } from './types';
@@ -59,23 +60,69 @@ const useBudgetStatementView = (snapshotLimitPeriods: SnapshotLimitPeriods | und
     [anchor, router]
   );
 
-  const { code, name } = useMemo(() => {
+  const { code, name, breadcrumbItems } = useMemo(() => {
     // map the AllowedOwnerType to required data to show in the UI
     switch (ownerTypeQuery) {
       case AllowedOwnerType.KEEPERS:
         return {
           code: 'KEEPERS',
           name: 'Keepers',
+          breadcrumbItems: [
+            {
+              label: 'Finances',
+              url: siteRoutes.finances(),
+            },
+            {
+              label: 'Scope Framework Budget',
+              url: siteRoutes.finances('scopes'),
+            },
+            {
+              label: 'Protocol Scope',
+              url: siteRoutes.finances('scopes/PRO'),
+            },
+            {
+              label: 'Keepers',
+              url: siteRoutes.budgetStatements(ownerTypeQuery),
+            },
+          ],
         };
       case AllowedOwnerType.SPFS:
         return {
           code: 'SFPs',
           name: 'Special Purpose Funds',
+          breadcrumbItems: [
+            {
+              label: 'Finances',
+              url: siteRoutes.finances(),
+            },
+            {
+              label: 'MakerDAO Legacy Budget',
+              url: siteRoutes.finances('legacy'),
+            },
+            {
+              label: 'Special Purpose Funds',
+              url: siteRoutes.budgetStatements(ownerTypeQuery),
+            },
+          ],
         };
       case AllowedOwnerType.ALIGNED_DELEGATES:
         return {
           code: 'DEL',
           name: 'Aligned Delegates',
+          breadcrumbItems: [
+            {
+              label: 'Finances',
+              url: siteRoutes.finances(),
+            },
+            {
+              label: 'Atlas Immutable Budget',
+              url: siteRoutes.finances('immutable'),
+            },
+            {
+              label: 'Aligned Delegates',
+              url: siteRoutes.budgetStatements(ownerTypeQuery),
+            },
+          ],
         };
     }
   }, [ownerTypeQuery]);
@@ -121,6 +168,7 @@ const useBudgetStatementView = (snapshotLimitPeriods: SnapshotLimitPeriods | und
     showHeader,
     code,
     name,
+    breadcrumbItems,
     snapshotCreated,
     setSnapshotCreated,
     currentMonth,


### PR DESCRIPTION
## Ticket
https://trello.com/c/KoM0xita/406-bss-11-budget-statement-pages-for-keepers-legacy-design

## Description
Complete the header and page integration

## What solved

- [X] Should the  user  navigate to the e.g. “Keepers” page via: finances/scopes/PRO/Keepers. Related to https://trello.com/c/oZLyGuZX/401-ecosystem-actors-should-not-be-included-in-the-url
- [X] Should direct to the Budget Statements page for that budget category (e.g., similar behavior to that of CUs and EAs) when clicking on the View option

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
