### PR TITLE
[Fix-447] Fix space in md for heading and fix container

### DIFF
--- a/src/views/CUAbout/CuAboutView.tsx
+++ b/src/views/CUAbout/CuAboutView.tsx
@@ -368,6 +368,8 @@ const CardRelateMipsContainer = styled('div')(({ theme }) => ({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
+  marginTop: '40px',
+  marginBottom: '40px',
   gap: 16,
   [theme.breakpoints.up('mobile_375')]: {
     width: '100%',

--- a/src/views/CUAbout/CuAboutView.tsx
+++ b/src/views/CUAbout/CuAboutView.tsx
@@ -368,10 +368,7 @@ const CardRelateMipsContainer = styled('div')(({ theme }) => ({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
-  marginTop: '40px',
-  marginBottom: '40px',
   gap: 16,
-
   [theme.breakpoints.up('mobile_375')]: {
     width: '100%',
   },
@@ -450,13 +447,10 @@ const ContainerAllData = styled('div')(({ theme }) => ({
     marginLeft: '32px',
   },
   [theme.breakpoints.up('desktop_1280')]: {
-    marginRight: '40px',
-    marginLeft: '40px',
+    marginRight: '0px',
+    marginLeft: '0px',
   },
-  [theme.breakpoints.up('desktop_1440')]: {
-    marginRight: '64px',
-    marginLeft: '64px',
-  },
+
   [theme.breakpoints.up('desktop_1920')]: {
     marginRight: '0px',
     marginLeft: '0px',
@@ -481,18 +475,18 @@ const Wrapper = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
-  maxWidth: '1440px',
-  margin: '0 auto',
 
-  [theme.breakpoints.up('desktop_1920')]: {
+  [theme.breakpoints.up('desktop_1440')]: {
     maxWidth: '1312px',
     marginLeft: '0px',
     marginRight: '0px',
     margin: '0 auto',
   },
   [theme.breakpoints.between('desktop_1280', 'desktop_1440')]: {
-    marginRight: '0px',
-    marginLeft: '0px',
+    marginRight: 'revert',
+    marginLeft: 'revert',
+    maxWidth: 1200,
+    margin: '0 auto',
   },
   [theme.breakpoints.down('mobile_375')]: {
     width: '100%',

--- a/src/views/CUAbout/Markdown/renderUtils.tsx
+++ b/src/views/CUAbout/Markdown/renderUtils.tsx
@@ -330,7 +330,7 @@ const HeadingResponsiveH2 = styled('h2')(({ theme }) => ({
   fontWeight: 700,
   lineHeight: 'normal',
   marginBottom: 0,
-  marginTop: 32,
+  marginTop: 16,
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
     fontWeight: 600,
@@ -342,7 +342,7 @@ const HeadingResponsiveH3 = styled('h3')(({ theme }) => ({
   fontWeight: 700,
   lineHeight: 'normal',
   marginBottom: 0,
-  marginTop: 32,
+  marginTop: 16,
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
     fontWeight: 600,

--- a/src/views/CUAbout/Markdown/renderUtils.tsx
+++ b/src/views/CUAbout/Markdown/renderUtils.tsx
@@ -316,7 +316,7 @@ const HeadingResponsiveH1 = styled('h1')(({ theme }) => ({
   fontSize: 16,
   fontWeight: 700,
   lineHeight: 'normal',
-  marginTop: 32,
+  marginTop: 16,
   marginBottom: 0,
   [theme.breakpoints.up('tablet_768')]: {
     fontSize: 20,

--- a/src/views/EAAbout/components/ActorMdViewer/ActorMdViewPage.tsx
+++ b/src/views/EAAbout/components/ActorMdViewer/ActorMdViewPage.tsx
@@ -168,7 +168,7 @@ const TypographyStyleDescription = styled('p')(({ theme }) => ({
     lineHeight: '24px',
   },
   [theme.breakpoints.up('desktop_1024')]: {
-    marginBottom: '16px',
+    marginBottom: '0px',
   },
 }));
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/tmFwaqq8/447-apply-reskin-design-to-the-cu-ea-about

## Description
<!--- What is new in this PR -->

## What solved

- [X]  Ecosystem Actors About (PH). **Expected Output:** The space between the paragraphs should be as the design shows. **Current Output:** A big gap between "Who we are" and the text below is displayed.
- [X]  Core Units About, Changing breakpoints. **Expected Output:** The breadcrumb, header, and content of the view should remain the same margin/padding. **Current Output:** The breadcrumb and the header remain the same margin/padding but the content doesn't.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
