### PR TITLE
[Fix-447] Fix the size of the bars fix the container

### DIFF
--- a/src/stories/components/CustomBarChart/CustomBarChart.tsx
+++ b/src/stories/components/CustomBarChart/CustomBarChart.tsx
@@ -59,13 +59,13 @@ export const CustomBarChart = (props: CustomBarChartProps) => {
   const id = open ? 'graph-popover' : undefined;
 
   const padding = 8;
-  const maxBarHeight = 50;
+  const maxBarHeight = 45;
   const calculateHeight = (value: number): number => {
     if (!value) return 16;
 
     const allItems = [...(props?.items?.map((item) => item?.value || 0) || []), ...(props?.maxValues || [])];
     const max = Math.max(...allItems);
-    const maxLimit = 45;
+    const maxLimit = 40;
 
     return (value / max) * maxLimit;
   };
@@ -376,6 +376,7 @@ const MonthTextGroup = styled('g')({
 const SVGStyle = styled('svg')(({ theme }) => ({
   width: 60,
   height: 57,
+
   viewBox: '0 0 60 57',
   marginRight: '0px',
   marginLeft: '4px',
@@ -391,6 +392,7 @@ const SVGStyle = styled('svg')(({ theme }) => ({
 
 const BarMonth = styled('rect')<{ color: string }>(({ theme, color }) => ({
   transition: 'fill 0.3s ease',
+
   '&:hover': {
     fill: theme.palette.isLight
       ? color === theme.palette.colors.red[800]


### PR DESCRIPTION
## Ticket
https://trello.com/c/tmFwaqq8/447-apply-reskin-design-to-the-cu-ea-about



## What solved

- [X] Core Units Index, Expenditure column. **Expected Output:** The bars and the line should be fully displayed. **Current Output:** The Latest 3 Months area is cutting off the bars. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
