### PR TITLE
[Reskin-505] Remove Typeform link

### DIFF
--- a/src/core/utils/const.ts
+++ b/src/core/utils/const.ts
@@ -1,6 +1,5 @@
 export const HOW_TO_SUBMIT_EXPENSES =
   'https://www.notion.so/makerdao-ses/MakerDAO-Budget-Reporting-Tool-Setup-Guide-for-Data-Providers-v2-a8d59cc9a5aa4d73a4f677ddcef7d4a7';
-export const TYPE_FORM = 'https://makerdao.typeform.com/dashboardissues';
 export const SES_DASHBOARD = 'https://discord.com/channels/815917281728659516/992417719028830349';
 export const MAKER_BURN_LINK = 'https://makerburn.com/#/expenses/core-units';
 

--- a/src/views/CUAbout/CuAboutView.tsx
+++ b/src/views/CUAbout/CuAboutView.tsx
@@ -10,7 +10,7 @@ import { getMarkdownInformation } from '@/core/businessLogic/coreUnitAbout';
 import { getFTEsFromCoreUnit } from '@/core/businessLogic/coreUnits';
 import type { Team } from '@/core/models/interfaces/team';
 import { ResourceType } from '@/core/models/interfaces/types';
-import { SES_DASHBOARD, TYPE_FORM } from '@/core/utils/const';
+import { SES_DASHBOARD } from '@/core/utils/const';
 import { toAbsoluteURL } from '@/core/utils/urls';
 import { SEOHead } from '@/stories/components/SEOHead/SEOHead';
 import TeamMember from '@/stories/components/TeamMember/TeamMember';
@@ -183,7 +183,6 @@ const CuAboutView = ({ code, coreUnits, cuAbout }: Props) => {
                         <LabelLinks>Important Links</LabelLinks>
                         <ContainerLinksButton>
                           <ButtonLinkStyled href={`${SES_DASHBOARD}`}>Join SES channel</ButtonLinkStyled>
-                          <ButtonLinkStyled href={`${TYPE_FORM}`}>Fill Typeform</ButtonLinkStyled>
                         </ContainerLinksButton>
                       </ContainerLinks>
                     </CardSomethingWrong>
@@ -236,7 +235,6 @@ const CuAboutView = ({ code, coreUnits, cuAbout }: Props) => {
                 <LabelLinks>Important Links</LabelLinks>
                 <ContainerLinksButton>
                   <ButtonLinkStyled href={`${SES_DASHBOARD}`}>Join SES channel</ButtonLinkStyled>
-                  <ButtonLinkStyled href={`${TYPE_FORM}`}>Fill Typeform</ButtonLinkStyled>
                 </ContainerLinksButton>
               </ContainerLinks>
             </CardSomethingWrong>

--- a/src/views/CUAbout/NavigationCard/CardSomethingWrong.stories.tsx
+++ b/src/views/CUAbout/NavigationCard/CardSomethingWrong.stories.tsx
@@ -1,5 +1,5 @@
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
-import { SES_DASHBOARD, TYPE_FORM } from '@/core/utils/const';
+import { SES_DASHBOARD } from '@/core/utils/const';
 import { ButtonLinkStyled, ContainerLinks, ContainerLinksButton, LabelLinks } from '../CuAboutView';
 import CardSomethingWrong from './CardSomethingWrong';
 import type { Meta } from '@storybook/react';
@@ -29,7 +29,6 @@ const [[Card, CardDark]] = createThemeModeVariants(
         <LabelLinks>Important Links</LabelLinks>
         <ContainerLinksButton>
           <ButtonLinkStyled href={`${SES_DASHBOARD}`}>Join SES channel</ButtonLinkStyled>
-          <ButtonLinkStyled href={`${TYPE_FORM}`}>Fill Typeform</ButtonLinkStyled>
         </ContainerLinksButton>
       </ContainerLinks>
     </CardSomethingWrong>

--- a/src/views/EAAbout/EAAboutView.tsx
+++ b/src/views/EAAbout/EAAboutView.tsx
@@ -12,7 +12,7 @@ import Container from '@/components/Container/Container';
 import PageContainer from '@/components/Container/PageContainer';
 import ExternalLinkButton from '@/components/ExternalLinkButton/ExternalLinkButton';
 import TeamHeader from '@/components/TeamHeader/TeamHeader';
-import { SES_DASHBOARD, TYPE_FORM } from '@/core/utils/const';
+import { SES_DASHBOARD } from '@/core/utils/const';
 import CardExpenses from '../CUAbout/NavigationCard/CardExpenses';
 import CardSomethingWrong from '../CUAbout/NavigationCard/CardSomethingWrong';
 import ActorMdViewer from './components/ActorMdViewer/ActorMdViewer';
@@ -100,7 +100,6 @@ export const EAAboutView: React.FC<Props> = ({ actors, actor }) => {
                   <LabelLinks>Important Links</LabelLinks>
                   <ContainerLinksButton>
                     <ButtonLinkStyled href={`${SES_DASHBOARD}`}>#dashboard-reporting channel</ButtonLinkStyled>
-                    <ButtonLinkStyled href={`${TYPE_FORM}`}>Fill Typeform</ButtonLinkStyled>
                   </ContainerLinksButton>
                 </ContainerLinks>
               </CardSomethingWrong>
@@ -135,7 +134,6 @@ export const EAAboutView: React.FC<Props> = ({ actors, actor }) => {
                     <LabelLinks>Important Links</LabelLinks>
                     <ContainerLinksButton>
                       <ButtonLinkStyled href={`${SES_DASHBOARD}`}>#dashboard-reporting channel</ButtonLinkStyled>
-                      <ButtonLinkStyled href={`${TYPE_FORM}`}>Fill Typeform</ButtonLinkStyled>
                     </ContainerLinksButton>
                   </ContainerLinks>
                 </CardSomethingWrong>


### PR DESCRIPTION
## Ticket
https://trello.com/c/ZTrmxnP1/505-remove-typeform-link-from-the-cu-ea-profile-view

## Description
Remove the typeform link in the "something wrong" card

## What solved

- [X] Should remove the typeform link from the CU/EA profile view.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook
