### PR TITLE
[Reskin-497] CU/EA reporting page background

### DIFF
--- a/src/components/Container/PageContainer.tsx
+++ b/src/components/Container/PageContainer.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 interface PageBackgroundProps extends React.PropsWithChildren {
   className?: string;
-  hasImageBackground?: boolean;
+  hasImageBackground?: boolean; // for legacy compatibility
 }
 
 const PageContainer: React.FC<PageBackgroundProps> = ({ children, className, hasImageBackground = false }) => (
@@ -21,6 +21,7 @@ const PageBackground = styled('div')<{ hasImageBackground: boolean }>(({ theme, 
   width: '100%',
 
   ...(hasImageBackground && {
+    backgroundColor: theme.palette.isLight ? '#FFFFFF' : '#000000',
     backgroundImage: theme.palette.isLight ? 'url(/assets/img/bg-page.png)' : 'url(/assets/img/bg-page-dark.png)',
     backgroundAttachment: 'fixed',
     backgroundSize: 'cover',

--- a/src/stories/containers/ActorProjects/ActorProjectsContainer.tsx
+++ b/src/stories/containers/ActorProjects/ActorProjectsContainer.tsx
@@ -1,8 +1,7 @@
-import styled from '@emotion/styled';
+import { styled } from '@mui/material';
 import { SEOHead } from '@ses/components/SEOHead/SEOHead';
 import { siteRoutes } from '@ses/config/routes';
 import { toAbsoluteURL } from '@ses/core/utils/urls';
-import lightTheme from '@ses/styles/theme/themes';
 import React from 'react';
 import Container from '@/components/Container/Container';
 import PageContainer from '@/components/Container/PageContainer';
@@ -14,7 +13,6 @@ import ProjectList from './components/ProjectList/ProjectList';
 import useActorProjectsContainer from './useActorProjectsContainer';
 import type { Project } from '@ses/core/models/interfaces/projects';
 import type { Team } from '@ses/core/models/interfaces/team';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface ActorProjectsContainerProps {
   actors: Team[];
@@ -24,7 +22,6 @@ interface ActorProjectsContainerProps {
 
 const ActorProjectsContainer: React.FC<ActorProjectsContainerProps> = ({ actor, actors, projects }) => {
   const {
-    isLight,
     height,
     ref,
     showHeader,
@@ -77,7 +74,7 @@ const ActorProjectsContainer: React.FC<ActorProjectsContainerProps> = ({ actor, 
             {/* TODO: instead of `projects.length` it should be `supportedProjects.length` once it is integrated with the API */}
             {(filteredProjects.length > 0 || filteredSupporterProjects.length > 0) && projects.length > 0 && (
               <>
-                <SupportedProjects isLight={isLight}>
+                <SupportedProjects>
                   <span>Projects supported by {actor.name}</span>
                   <SESTooltipLegacy
                     content="Contributory Projects: This highlights the ecosystem actor's role as a contributor rather than the primary owner."
@@ -108,7 +105,7 @@ const PageWrapper = styled(PageContainer)({
   paddingTop: 0,
 });
 
-const ContainerAllData = styled.div<{ marginTop: number }>(({ marginTop }) => ({
+const ContainerAllData = styled('div')<{ marginTop: number }>(({ marginTop }) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
@@ -116,25 +113,28 @@ const ContainerAllData = styled.div<{ marginTop: number }>(({ marginTop }) => ({
   marginTop,
 }));
 
-const ContainerResponsive = styled.div({
+const ContainerResponsive = styled('div')(({ theme }) => ({
   width: '100%',
   display: 'flex',
   flexDirection: 'column',
   marginTop: 96,
 
-  [lightTheme.breakpoints.down('desktop_1194')]: {
+  [theme.breakpoints.down('desktop_1194')]: {
     width: '100%',
-    marginTop: 100,
   },
-});
 
-const SupportedProjects = styled.h2<WithIsLight>(({ isLight }) => ({
+  [theme.breakpoints.up('tablet_768')]: {
+    marginTop: 0,
+  },
+}));
+
+const SupportedProjects = styled('h2')(({ theme }) => ({
   margin: '32px 0 16px',
   fontSize: 20,
   fontWeight: 600,
   lineHeight: 'normal',
   letterSpacing: 0.4,
-  color: isLight ? '#231536' : '#D2D4EF',
+  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
   display: 'flex',
   justifyContent: 'space-between',
 
@@ -143,7 +143,7 @@ const SupportedProjects = styled.h2<WithIsLight>(({ isLight }) => ({
     marginRight: 0,
   },
 
-  [lightTheme.breakpoints.up('tablet_768')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     justifyContent: 'normal',
     alignItems: 'flex-end',
     gap: 8,
@@ -152,7 +152,7 @@ const SupportedProjects = styled.h2<WithIsLight>(({ isLight }) => ({
   },
 }));
 
-const IconContainer = styled.span({
+const IconContainer = styled('span')({
   cursor: 'pointer',
   padding: 4.5,
   width: 24,

--- a/src/stories/containers/ActorProjects/useActorProjectsContainer.tsx
+++ b/src/stories/containers/ActorProjects/useActorProjectsContainer.tsx
@@ -1,20 +1,18 @@
 import { useMediaQuery } from '@mui/material';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { useHeaderSummary } from '@ses/core/hooks/useHeaderSummary';
 import { ProjectStatus } from '@ses/core/models/interfaces/projects';
-import lightTheme from '@ses/styles/theme/themes';
 import { useRouter } from 'next/router';
 import { useMemo, useRef, useState } from 'react';
 import ProjectStatusChip from './components/ProjectStatusChip/ProjectStatusChip';
+import type { Theme } from '@mui/material';
 import type { MultiSelectItem } from '@ses/components/CustomMultiSelect/CustomMultiSelect';
 import type { Project } from '@ses/core/models/interfaces/projects';
 
 const useActorProjectsContainer = (projects: Project[]) => {
-  const { isLight } = useThemeContext();
   const router = useRouter();
   const ref = useRef<HTMLDivElement>(null);
   const { height, showHeader } = useHeaderSummary(ref, router.query.code as string);
-  const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
 
   const [isFilterCollapsedOnMobile, setIsFilterCollapsedOnMobile] = useState<boolean>(true);
   const handleToggleFilterOnMobile = () => setIsFilterCollapsedOnMobile((prev) => !prev);
@@ -76,7 +74,6 @@ const useActorProjectsContainer = (projects: Project[]) => {
     ref,
     height,
     showHeader,
-    isLight,
     isMobile,
     isFilterCollapsedOnMobile,
     handleToggleFilterOnMobile,

--- a/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
+++ b/src/stories/containers/ActorsTransparencyReport/ActorsTransparencyReportContainer.tsx
@@ -70,7 +70,7 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
   const headline = <TeamHeadLine teamLongCode={actor.code} teamShortCode={actor.shortCode} />;
 
   return (
-    <Wrapper>
+    <>
       <SEOHead
         title={`${actor.name} Ecosystem Actor | Finances`}
         description={`Learn about the ${actor.name} Ecosystem Actor at MakerDAO: their mandate, scope, vision, strategy, and more.`}
@@ -199,17 +199,11 @@ const ActorsTransparencyReportContainer: React.FC<ActorsTransparencyReportContai
           </ModalCategoriesProvider>
         </PageSeparator>
       </PageContainer>
-    </Wrapper>
+    </>
   );
 };
 
 export default ActorsTransparencyReportContainer;
-
-const Wrapper = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  width: '100%',
-});
 
 const PageSeparator = styled.div<{ marginTop: number }>(({ marginTop }) => ({
   marginTop: `${32 + marginTop}px`,

--- a/src/stories/containers/Finances/FinancesContainer.tsx
+++ b/src/stories/containers/Finances/FinancesContainer.tsx
@@ -52,7 +52,7 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
   } = useFinances(budgets, allBudgets, initialYear);
 
   return (
-    <PageContainer>
+    <PageContainerLegacy>
       <SEOHead
         title="MakerDAO | Finances"
         description="MakerDAO Finances page provides a structured overview of MakerDAO's budgets, from high-level finances to detailed legacy and endgame allocations "
@@ -221,11 +221,15 @@ const FinancesContainer: React.FC<Props> = ({ budgets, allBudgets, yearsRange, i
           />
         </ContainerLastReport>
       </Container>
-    </PageContainer>
+    </PageContainerLegacy>
   );
 };
 
 export default FinancesContainer;
+
+const PageContainerLegacy = styled(PageContainer)(({ theme }) => ({
+  background: theme.palette.mode === 'light' ? '#fff' : '#000',
+}));
 
 const TitleContainer = styled('div')(({ theme }) => ({
   display: 'flex',

--- a/src/stories/containers/TransparencyReport/TransparencyReport.tsx
+++ b/src/stories/containers/TransparencyReport/TransparencyReport.tsx
@@ -76,7 +76,7 @@ export const TransparencyReport = ({
   const headline = <CuHeadlineText cuLongCode={longCode} />;
 
   return (
-    <Wrapper>
+    <>
       <SEOHead
         title={`${coreUnit.name} Core Unit | Finances`}
         description={`Learn about the ${coreUnit.name} Core Unit at MakerDAO: their finances, expense reports, and more.`}
@@ -260,15 +260,9 @@ export const TransparencyReport = ({
           </ModalCategoriesProvider>
         </PageSeparator>
       </PageContainer>
-    </Wrapper>
+    </>
   );
 };
-
-const Wrapper = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  width: '100%',
-});
 
 const PageSeparator = styled.div<{ marginTop: number }>(({ marginTop }) => ({
   marginTop: `${32 + marginTop}px`,


### PR DESCRIPTION
## Ticket
https://trello.com/c/16pG9Esv/497-change-background-color-to-the-pages

## Description
Fix page backgrounds that still have the legacy backgrounds

## What solved

- [X] Should change the background of the  Budget Statements (CU/EA) view to the legacy.
- [X] Should change the background of the  Finances view to the legacy.
- [X] Should change the background of the  Projects view to the legacy.
- [X] Should change the background of the  Global Activity Feed view to the legacy.
- [X] Should change the background of the  Activity Feed view to the legacy.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

