### PR TITLE
[Resin-428] Add link to the logo in desk resolutions

### DIFF
--- a/src/components/TopBarNavigation/TopBarNavigation.tsx
+++ b/src/components/TopBarNavigation/TopBarNavigation.tsx
@@ -40,12 +40,16 @@ const TopBarNavigation: FC<Props> = ({ className }) => {
       <Container>
         <NavContainer aria-label="Primary Navigation" className={className}>
           <LeftSection>
-            <LogoContainerMobile>
-              <Makerdao />
-            </LogoContainerMobile>
-            <LogoContainerDesk>
-              <LogoText />
-            </LogoContainerDesk>
+            <Link href="/">
+              <LogoContainerMobile>
+                <Makerdao />
+              </LogoContainerMobile>
+            </Link>
+            <Link href="/">
+              <LogoContainerDesk>
+                <LogoText />
+              </LogoContainerDesk>
+            </Link>
             <SelectContainer>
               <StyledCustomSelect
                 multiple={false}

--- a/src/components/TopBarNavigation/TopBarNavigation.tsx
+++ b/src/components/TopBarNavigation/TopBarNavigation.tsx
@@ -27,7 +27,7 @@ const TopBarNavigation: FC<Props> = ({ className }) => {
     isLight,
     toggleTheme,
     activeItem,
-    menuItems,
+    getMenusAvailable,
     handleGoLogin,
     handleChangeRoute,
     handleOnClickLogOut,
@@ -40,16 +40,16 @@ const TopBarNavigation: FC<Props> = ({ className }) => {
       <Container>
         <NavContainer aria-label="Primary Navigation" className={className}>
           <LeftSection>
-            <Link href="/">
+            <LinkStyled href="/">
               <LogoContainerMobile>
                 <Makerdao />
               </LogoContainerMobile>
-            </Link>
-            <Link href="/">
+            </LinkStyled>
+            <LinkStyled href="/">
               <LogoContainerDesk>
                 <LogoText />
               </LogoContainerDesk>
-            </Link>
+            </LinkStyled>
             <SelectContainer>
               <StyledCustomSelect
                 multiple={false}
@@ -68,7 +68,7 @@ const TopBarNavigation: FC<Props> = ({ className }) => {
             </SelectContainer>
           </LeftSection>
           <CenterLinks>
-            {Object.values(menuItems).map((link) => (
+            {Object.values(getMenusAvailable).map((link) => (
               <LinkNavBar href={link.link} label={link.title} selected={activeItem} />
             ))}
           </CenterLinks>
@@ -214,9 +214,13 @@ const SelectContainer = styled('div')(({ theme }) => ({
 const LeftSection = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
-  gap: 16,
+  gap: 8,
+
   [theme.breakpoints.up('tablet_768')]: {
-    gap: 32,
+    gap: 16,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 'revert',
   },
 }));
 
@@ -232,7 +236,7 @@ const RightSection = styled('div')(({ theme }) => ({
     marginRight: 'revert',
   },
   [theme.breakpoints.up('desktop_1024')]: {
-    marginTop: -4,
+    marginTop: 4,
     marginRight: 'revert',
   },
   [theme.breakpoints.up('desktop_1920')]: {
@@ -276,18 +280,16 @@ const CenterLinks = styled('ul')(({ theme }) => ({
   [theme.breakpoints.up('desktop_1024')]: {
     display: 'flex',
     alignItems: 'center',
-    margin: 0,
     padding: 0,
     gap: 24,
-    height: 24,
-    marginTop: -8,
+    marginTop: 18,
   },
 
   [theme.breakpoints.up('desktop_1280')]: {
     gap: 48,
   },
   [theme.breakpoints.up('desktop_1920')]: {
-    marginTop: -2,
+    marginTop: 20,
   },
 }));
 
@@ -410,4 +412,8 @@ const StyledMenuProps = (theme: Theme) => ({
       },
     },
   },
+});
+
+const LinkStyled = styled(Link)({
+  display: 'flex',
 });

--- a/src/components/TopBarNavigation/types.ts
+++ b/src/components/TopBarNavigation/types.ts
@@ -9,4 +9,4 @@ export interface MenuType {
   titleMobile?: string;
   mobileOnly?: boolean;
 }
-export type RouteOnHeader = 'contributors' | 'finances' | 'roadmap' | 'endgame' | 'connect' | '';
+export type RouteOnHeader = 'contributors' | 'finances' | 'roadmap' | 'endgame' | 'connect' | 'home';

--- a/src/components/TopBarNavigation/useTopBarNavigation.tsx
+++ b/src/components/TopBarNavigation/useTopBarNavigation.tsx
@@ -23,6 +23,11 @@ export const useTopBarNavigation = () => {
     router.push(siteRoutes.login);
   };
 
+  menuItems.home = {
+    title: 'Home',
+    link: '/',
+  };
+
   menuItems.contributors = {
     title: 'Contributors',
     link: '/contributors',
@@ -48,18 +53,13 @@ export const useTopBarNavigation = () => {
     link: CONNECT,
   };
 
-  menuItems[''] = {
-    title: '',
-    link: '',
-  };
-  const filter: SelectItem[] = useMemo(
-    () =>
-      Object.values(menuItems).map((value) => ({
-        label: value.title,
-        value: value.title,
-      })),
-    []
-  );
+  const getMenusAvailable = useMemo(() => {
+    if (isSelectShow) {
+      return menuItems;
+    } else {
+      return Object.values(menuItems).filter((filter) => filter.title !== 'Home');
+    }
+  }, [isSelectShow]);
 
   const activeMenuItem: MenuType = useMemo(() => {
     if (router.pathname.startsWith('/contributors')) {
@@ -74,34 +74,45 @@ export const useTopBarNavigation = () => {
       if (router.pathname.startsWith('/core-units') || router.pathname.startsWith('/ecosystem-actors')) {
         return menuItems.contributors;
       } else {
-        return menuItems[''];
+        return menuItems.home;
       }
     }
   }, [router.pathname]);
+  const filter: SelectItem[] = useMemo(() => {
+    const filtersResult = Object.values(menuItems).map((value) => ({
+      label: value.title,
+      value: value.title,
+    }));
+
+    if (isSelectShow) {
+      return filtersResult;
+    } else {
+      return filtersResult.filter((filter) => filter.label !== 'Home');
+    }
+  }, [isSelectShow]);
 
   const activeItem = useMemo(() => {
     if (isSelectShow) {
-      return activeMenuItem?.title === '' ? 'Contributors' : activeMenuItem.title;
+      return activeMenuItem?.title === '' ? 'Home' : activeMenuItem.title;
     }
     return activeMenuItem.title;
   }, [isSelectShow, activeMenuItem]);
   const handleChangeRoute = (value: string | string[]) => {
     if (typeof value === 'string') {
       const find = Object.values(menuItems).find((menu) => menu.title === value);
-      router.push(find?.link || '/contributors');
+      router.push(find?.link || '/');
     }
   };
-
   return {
     filter,
     themeMode,
     toggleTheme,
     isLight,
-    menuItems,
     activeItem,
     handleGoLogin,
     handleChangeRoute,
     handleOnClickLogOut,
     permissionManager,
+    getMenusAvailable,
   };
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/EHGVkCf3/428-tnb-0-top-navigation-bar-for-fusion


## What solved
- [X] Should the logo link to the old homepage and no items should be highlighted in Desktop resolutions.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
