### PR TITLE
[FIX-428] Fix/remove undefined when page refresh

### DIFF
--- a/src/components/TopBarNavigation/TopBarNavigation.tsx
+++ b/src/components/TopBarNavigation/TopBarNavigation.tsx
@@ -68,8 +68,8 @@ const TopBarNavigation: FC<Props> = ({ className }) => {
             </SelectContainer>
           </LeftSection>
           <CenterLinks>
-            {Object.values(getMenusAvailable).map((link) => (
-              <LinkNavBar href={link.link} label={link.title} selected={activeItem} />
+            {Object.values(getMenusAvailable).map((link, index) => (
+              <LinkNavBar href={link.link} label={link.title} selected={activeItem} key={index} />
             ))}
           </CenterLinks>
           <RightSection>

--- a/src/components/TopBarNavigation/useTopBarNavigation.tsx
+++ b/src/components/TopBarNavigation/useTopBarNavigation.tsx
@@ -78,25 +78,17 @@ export const useTopBarNavigation = () => {
       }
     }
   }, [router.pathname]);
-  const filter: SelectItem[] = useMemo(() => {
-    const filtersResult = Object.values(menuItems).map((value) => ({
-      label: value.title,
-      value: value.title,
-    }));
+  const filter: SelectItem[] = useMemo(
+    () =>
+      Object.values(menuItems).map((value) => ({
+        label: value.title,
+        value: value.title,
+      })),
 
-    if (isSelectShow) {
-      return filtersResult;
-    } else {
-      return filtersResult.filter((filter) => filter.label !== 'Home');
-    }
-  }, [isSelectShow]);
+    []
+  );
 
-  const activeItem = useMemo(() => {
-    if (isSelectShow) {
-      return activeMenuItem?.title === '' ? 'Home' : activeMenuItem.title;
-    }
-    return activeMenuItem.title;
-  }, [isSelectShow, activeMenuItem]);
+  const activeItem = useMemo(() => activeMenuItem.title, [activeMenuItem]);
   const handleChangeRoute = (value: string | string[]) => {
     if (typeof value === 'string') {
       const find = Object.values(menuItems).find((menu) => menu.title === value);

--- a/src/views/Endgame/components/NavigationTabs/NavigationTabs.tsx
+++ b/src/views/Endgame/components/NavigationTabs/NavigationTabs.tsx
@@ -62,11 +62,14 @@ const NavigationTabs: FC<NavigationTabsProps> = ({ activeTab }) => {
 
 export default NavigationTabs;
 
-const Sticky = styled('div')({
+const Sticky = styled('div')(({ theme }) => ({
   position: 'sticky',
-  top: 98,
+  top: 64,
   zIndex: 2,
-});
+  [theme.breakpoints.up('tablet_768')]: {
+    top: 98,
+  },
+}));
 
 const Wrapper = styled('div')(({ theme }) => ({
   backgroundColor: theme.palette.isLight ? theme.palette.colors.gray[50] : '#1B1E24',


### PR DESCRIPTION
## Ticket
https://trello.com/c/EHGVkCf3/428-tnb-0-top-navigation-bar-for-fusion

## What solved

- [X] The menu item should remain as Home. **Current Output:** Change to Undefined and later show Home again. ** Visual Proof:** - **Order Execution:** Please, remove this behavior.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
