### PR TITLE
[Demo-518] Fix number format in tooltip of the charts

### DIFF
--- a/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/stories/containers/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -8,10 +8,11 @@ import {
 } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { zIndexEnum } from '@ses/core/enums/zIndexEnum';
-import { formatNumber, replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
+import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/themes';
 import ReactECharts from 'echarts-for-react';
 import React, { useEffect, useMemo } from 'react';
+import { usLocalizedNumber } from '@/core/utils/humanization';
 import { getSelectMetricText } from '../utils';
 import type { BarChartSeries, BreakdownChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { AnalyticGranularity, AnalyticMetric } from '@ses/core/models/interfaces/analytic';
@@ -143,7 +144,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
                       )}:</span>
                     <span style="font-size:16px;font-weight:700;color:${
                       isLight ? '#231536' : '#EDEFFF'
-                    };display: inline-block;">${formatNumber(item.value)}</span>
+                    };display: inline-block;">${usLocalizedNumber(item.value, 2)}</span>
                   </div>`
                   )
                   .join('')}

--- a/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
+++ b/src/stories/containers/Finances/components/SectionPages/MakerDAOExpenseMetrics/MakerDAOChartMetrics/MakerDAOChartMetrics.tsx
@@ -8,15 +8,17 @@ import {
 } from '@ses/containers/Finances/utils/utils';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { zIndexEnum } from '@ses/core/enums/zIndexEnum';
-import { formatNumber, replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
+import { replaceAllNumberLetOneBeforeDot } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/themes';
 import ReactECharts from 'echarts-for-react';
 import React, { useRef } from 'react';
+import { usLocalizedNumber } from '@/core/utils/humanization';
 import type { CumulativeType } from '../useMakerDAOExpenseMetrics';
 import type { BarChartSeries, LineChartSeriesData } from '@ses/containers/Finances/utils/types';
 import type { AnalyticGranularity } from '@ses/core/models/interfaces/analytic';
 import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 import type { EChartsOption } from 'echarts-for-react';
+
 interface BreakdownChartProps {
   year: string;
   selectedGranularity: AnalyticGranularity;
@@ -149,7 +151,7 @@ const MakerDAOChartMetrics: React.FC<BreakdownChartProps> = ({
                     }:</span>
                   <span style="font-size:16px;font-weight:700;color:${
                     isLight ? '#231536' : '#EDEFFF'
-                  };display: inline-block;">${formatNumber(item.value)}</span>
+                  };display: inline-block;">${usLocalizedNumber(item.value, 2)}</span>
                 </div>`
                 )
                 .join('')}


### PR DESCRIPTION
## Ticket
https://trello.com/c/e1aXau10/518-wrong-number-of-decimals-in-the-breakdown-chart

## Description
Fixed the decimal places rounding of the values of the tooltips in the charts on the finances page

## What solved

- [X] Should the values display as max 2 decimals.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
