### PR TITLE
[Reskin-470] Add style for the mobile resolutions in table

### DIFF
--- a/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -130,6 +130,8 @@ export const AdvancedInnerTable: React.FC<AdvancedInnerTableProps> = ({
       </TableWrapper>
       <CardsWrapper>
         {cardItems.map((item, i) => {
+          // TODO: Avoid the background in the card of the wallet
+          const showSubHeader = !(item.type === 'total' || item.type === 'subTotal');
           if (item.type === 'groupTitle') {
             return (
               <TitleCard isGroupCard={true} cardSpacingSize={cardSpacingSize} className="advanced-table--group-section">
@@ -138,26 +140,17 @@ export const AdvancedInnerTable: React.FC<AdvancedInnerTableProps> = ({
                 </GroupTitle>
                 {i + 1 < cardItems.length && cardItems[i + 1].type === 'section' && (
                   <Title fontSize="14px" className="advanced-table--table-section">
-                    {cardItems[i + 1].items[0].value as string}
+                    {cardItems[i].items[0].value as string}
                   </Title>
                 )}
               </TitleCard>
             );
           }
-
-          if (item.type === 'section') {
-            return i === 0 || (i > 0 && cardItems[i - 1].type !== 'groupTitle') ? (
-              <TitleCard cardSpacingSize={cardSpacingSize} className="advanced-table--group-section">
-                <Title fontSize="14px" key={`section-${i}`} className="advanced-table--table-section">
-                  {item.items[0].value as string}
-                </Title>
-              </TitleCard>
-            ) : null;
-          }
-
           return (
             <TransparencyCard
+              showSubHeader={showSubHeader}
               itemType={item.type}
+              subHeader={item.subHeader || ''}
               key={`item-${i}`}
               cardSpacingSize={cardSpacingSize}
               separators={item.items
@@ -300,14 +293,14 @@ const TableRow = styled('tr')<{ borderTop?: boolean; borderBottom?: boolean }>(
 );
 
 const StyledOpenModalTransparency = styled(OpenModalTransparency)(({ theme }) => ({
-  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
   fontSize: 16,
   lineHeight: '24px',
   fontWeight: 600,
-  paddingLeft: 16,
-  paddingTop: 16,
-  marginBottom: 16,
-
+  paddingLeft: 24,
+  paddingTop: 8,
+  paddingRight: 24,
+  paddingBottom: 8,
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   fontFamily: 'Inter, sans-serif',
   justifyContent: 'space-between',
   gap: 0,
@@ -322,11 +315,12 @@ const StyledOpenModalTransparency = styled(OpenModalTransparency)(({ theme }) =>
       display: 'none',
     },
     [theme.breakpoints.up('tablet_768')]: {
-      color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
       fontSize: 16,
       fontWeight: 600,
       lineHeight: '24px',
-      padding: '8px  0px 16px 16px',
+      paddingLeft: 16,
+
+      padding: '8px 0px 16px 16px',
     },
   },
   [theme.breakpoints.up('tablet_768')]: {
@@ -334,6 +328,7 @@ const StyledOpenModalTransparency = styled(OpenModalTransparency)(({ theme }) =>
     fontWeight: 400,
     paddingTop: 0,
     marginBottom: 0,
+    paddingLeft: 16,
     lineHeight: '16.94px',
     fontSize: 14,
     svg: {

--- a/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -130,8 +130,11 @@ export const AdvancedInnerTable: React.FC<AdvancedInnerTableProps> = ({
       </TableWrapper>
       <CardsWrapper>
         {cardItems.map((item, i) => {
-          // TODO: Avoid the background in the card of the wallet
-          const showSubHeader = !(item.type === 'total' || item.type === 'subTotal');
+          const showSubHeader = !(
+            item.type === 'total' ||
+            item.type === 'subTotal' ||
+            item.items[i]?.column.isCardHeader
+          );
           if (item.type === 'groupTitle') {
             return (
               <TitleCard isGroupCard={true} cardSpacingSize={cardSpacingSize} className="advanced-table--group-section">

--- a/src/components/AdvancedInnerTable/TextCell/TextCell.tsx
+++ b/src/components/AdvancedInnerTable/TextCell/TextCell.tsx
@@ -58,7 +58,7 @@ const Container = styled('div')<{
   padding: isHeader ? 16 : '8px 0',
   textAlign: isHeader ? 'left' : 'right',
   fontSize: isHeader ? '16px' : '14px',
-  paddingLeft: 16,
+  paddingLeft: 24,
   color: theme.palette.isLight
     ? isSection
       ? '#9da0a1'
@@ -75,6 +75,7 @@ const Container = styled('div')<{
     lineHeight: '19px',
     fontSize: '16px',
     textAlign: 'left',
+    paddingLeft: 16,
     fontWeight: isHeader ? (bold ? 600 : 400) : 400,
   },
 }));

--- a/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
+++ b/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material';
 import React from 'react';
-import type { CardSpacingSize } from '../types';
+import type { CardSpacingSize, ItemType } from '../types';
 
 interface Props {
   header: JSX.Element | string;
@@ -8,63 +8,78 @@ interface Props {
   items?: JSX.Element[];
   separators?: boolean[];
   footer?: JSX.Element | string;
-  hasIcon?: boolean;
   // TODO: Type this to avoid lower and uppercase error
-  itemType: string;
+  itemType: ItemType;
   cardSpacingSize?: CardSpacingSize;
+  subHeader: string;
+  showSubHeader: boolean;
 }
 
-export const TransparencyCard: React.FC<Props> = ({ cardSpacingSize = 'large', ...props }) => (
-  <Container
-    spacing={cardSpacingSize}
-    style={{ marginTop: props.itemType === 'total' ? 24 : 0 }}
-    className={`advance-table--transparency-card ${
-      props.itemType === 'total' ? 'advance-table--transparency-card_total' : 'advance-table--transparency_item'
-    }`}
-  >
-    <HeaderWrapper>{props.header}</HeaderWrapper>
-    {props.headers.map((header, i) => {
-      const titleReactComponent = (header as JSX.Element).props?.title || '';
-      const totalsStyle = header === 'Totals' || titleReactComponent === 'Totals';
+export const TransparencyCard: React.FC<Props> = ({
+  cardSpacingSize = 'large',
+  header,
+  headers,
+  itemType,
+  subHeader,
+  footer,
+  items,
+  separators,
+  showSubHeader,
+}) => {
+  if (itemType === 'section') return null;
+  return (
+    <Container
+      style={{ marginTop: itemType === 'total' ? 24 : 0 }}
+      className={`advance-table--transparency-card ${
+        itemType === 'total' ? 'advance-table--transparency-card_total' : 'advance-table--transparency_item'
+      }`}
+    >
+      <HeaderWrapper showSubHeader={showSubHeader}>
+        {header}
+        {showSubHeader && <SubHeader>{subHeader}</SubHeader>}
+      </HeaderWrapper>
+      {headers.map((header, i) => {
+        const titleReactComponent = (header as JSX.Element).props?.title || '';
+        const totalsStyle = header === 'Totals' || titleReactComponent === 'Totals';
 
-      return (
-        <>
-          <Row
-            key={header.toString()}
-            hasIcon={header !== 'Target Balance' || (header === 'Target Balance' && props.itemType === 'total')}
-          >
-            <Label hasIcon={header === 'Target Balance'} isTotal={totalsStyle}>
-              {header}
-            </Label>
-            <div
-              style={{
-                display: props.itemType === 'total' ? 'flex' : undefined,
-                justifyContent: props.itemType ? 'flex-end' : undefined,
-                width:
-                  header === 'Target Balance' || (header === 'Target Balance' && props.itemType !== 'total')
-                    ? '100%'
-                    : undefined,
-              }}
+        return (
+          <ContainerData spacing={cardSpacingSize}>
+            <Row
+              key={header.toString()}
+              hasIcon={header !== 'Target Balance' || (header === 'Target Balance' && itemType === 'total')}
             >
-              {(props.items && props.items[i]) ?? ''}
-            </div>
-          </Row>
-          {props.separators?.[i] && <ContainerLine />}
-        </>
-      );
-    })}
+              <Label hasIcon={header === 'Target Balance'} isTotal={totalsStyle}>
+                {header}
+              </Label>
+              <div
+                style={{
+                  display: itemType === 'total' ? 'flex' : undefined,
+                  justifyContent: itemType ? 'flex-end' : undefined,
+                  width:
+                    header === 'Target Balance' || (header === 'Target Balance' && itemType !== 'total')
+                      ? '100%'
+                      : undefined,
+                }}
+              >
+                {(items && items[i]) ?? ''}
+              </div>
+            </Row>
+            {separators?.[i] && <ContainerLine />}
+          </ContainerData>
+        );
+      })}
 
-    {props.footer && <FooterWrapper>{props.footer}</FooterWrapper>}
-  </Container>
-);
+      {footer && <FooterWrapper>{footer}</FooterWrapper>}
+    </Container>
+  );
+};
 
-const Container = styled('div')<{ spacing: CardSpacingSize }>(({ theme, spacing }) => ({
+const Container = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   boxShadow: theme.palette.isLight ? theme.fusionShadows.graphShadow : theme.fusionShadows.darkMode,
   background: theme.palette.isLight ? '#FFFFFF' : theme.palette.colors.charcoal[900],
-  padding: spacing === 'large' ? '20px 24px 10px' : '16px 16px 6px',
-  marginBottom: spacing === 'large' ? 24 : 8,
+  marginBottom: 24,
   borderRadius: '12px',
   [theme.breakpoints.between('mobile_375', 'tablet_768')]: {
     ':last-child': {
@@ -73,9 +88,15 @@ const Container = styled('div')<{ spacing: CardSpacingSize }>(({ theme, spacing 
   },
 }));
 
-const HeaderWrapper = styled('div')({
-  margin: '-16px 0 0 -16px',
-});
+const HeaderWrapper = styled('div')<{ showSubHeader: boolean }>(({ theme, showSubHeader }) => ({
+  backgroundColor: !showSubHeader
+    ? 'none'
+    : theme.palette.isLight
+    ? theme.palette.colors.slate[50]
+    : theme.palette.colors.charcoal[800],
+  borderTopLeftRadius: 12,
+  borderTopRightRadius: 12,
+}));
 
 const FooterWrapper = styled('div')(({ theme }) => ({
   display: 'flex',
@@ -119,4 +140,21 @@ const ContainerLine = styled('div')(({ theme }) => ({
   borderTop: `1px solid ${theme.palette.isLight ? '#D4D9E1' : '#405361'}`,
   marginBottom: 20,
   marginTop: 20,
+}));
+
+const ContainerData = styled('div')<{ spacing: CardSpacingSize }>(({ spacing }) => ({
+  padding: spacing === 'large' ? '20px 24px 10px' : '16px 24px 6px',
+}));
+
+const SubHeader = styled('div')(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+  fontSize: 14,
+  fontWeight: 600,
+  lineHeight: '22px',
+  paddingLeft: 24,
+  paddingRight: 24,
+  paddingBottom: 8,
+  [theme.breakpoints.up('tablet_768')]: {
+    paddingLeft: 16,
+  },
 }));

--- a/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
+++ b/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
@@ -120,16 +120,19 @@ const Row = styled('div')<{ hasIcon?: boolean; height?: string }>(({ hasIcon = f
 const Label = styled('div')<{ hasIcon?: boolean; height?: string; isTotal: boolean }>(
   ({ hasIcon = false, isTotal, theme }) => ({
     display: 'flex',
-
-    alignItems: hasIcon ? 'flex-start' : 'center',
-    color: theme.palette.isLight ? (isTotal ? '#434358' : '#708390') : isTotal ? '#9FAFB9' : '#708390',
     fontFamily: 'Inter, sans-serif',
+    alignItems: hasIcon ? 'flex-start' : 'center',
+    color: theme.palette.isLight
+      ? isTotal
+        ? theme.palette.colors.gray[900]
+        : theme.palette.colors.slate[100]
+      : isTotal
+      ? theme.palette.colors.gray[50]
+      : theme.palette.colors.slate[200],
     fontWeight: 600,
-    fontSize: '12px',
-    lineHeight: '15px',
+    fontSize: '16px',
+    lineHeight: '24px',
     height: '37px',
-    letterSpacing: '1px',
-    textTransform: 'uppercase',
     minWidth: 132,
   })
 );

--- a/src/components/AdvancedInnerTable/types.ts
+++ b/src/components/AdvancedInnerTable/types.ts
@@ -26,6 +26,7 @@ export type CardSpacingSize = 'small' | 'large';
 
 export interface InnerTableRow {
   type: RowType;
+  subHeader?: string;
   items: InnerTableCell[];
   borderTop?: boolean;
   borderBottom?: boolean;
@@ -41,6 +42,7 @@ export interface AdvancedInnerTableProps {
   longCode: string;
   className?: string;
   cardSpacingSize?: CardSpacingSize;
+  showSubHeader?: boolean;
 }
 
 export type Alignment = 'left' | 'center' | 'right';

--- a/src/views/CoreUnitBudgetStatement/CoreUnitBudgetStatementView.tsx
+++ b/src/views/CoreUnitBudgetStatement/CoreUnitBudgetStatementView.tsx
@@ -229,9 +229,7 @@ const CoreUnitBudgetStatementView = ({
             />
           )}
 
-          <Container>
-            <AdditionalNotesSection coreUnit={coreUnit} />
-          </Container>
+          <AdditionalNotesSection coreUnit={coreUnit} />
         </ModalCategoriesProvider>
       </PageSeparator>
     </PageContainer>

--- a/src/views/CoreUnitBudgetStatement/utils/actualsTableHelpers.tsx
+++ b/src/views/CoreUnitBudgetStatement/utils/actualsTableHelpers.tsx
@@ -64,6 +64,7 @@ export const getActualsBreakdownItems = (
       }
 
       result.push({
+        subHeader: groupedCategory[groupedCatKey][0].headcountExpense ? 'Headcount Expenses' : 'Non-Headcount Expenses',
         type: type || 'normal',
         ...(type === 'subTotal'
           ? {


### PR DESCRIPTION
## Ticket
https://trello.com/c/smptd4rr/470-reskin-budget-statements-cu-ea-actual-tab


## What solved

- [X] Should update the table's style for light/dark mode. Small resolutions.
- [X] Should update the table's header (text) for light/dark mode. Small resolutions.
- [X] Should update the values' styles for light/dark mode. Desktop/Small resolutions.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
