### PR TITLE
[Reskin-470] Fix the colors of the arrows in modal

### DIFF
--- a/src/components/AdvancedInnerTable/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
+++ b/src/components/AdvancedInnerTable/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
@@ -2,10 +2,9 @@ import { styled } from '@mui/material';
 import MuiAccordion from '@mui/material/Accordion';
 import MuiAccordionDetails from '@mui/material/AccordionDetails';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';
-import { SelectChevronDown } from '@ses/components/svg/select-chevron-down';
 
 import { pascalCaseToNormalString } from '@ses/core/utils/string';
-import lightTheme from '@ses/styles/theme/themes';
+import ArrowSelect from 'public/assets/svg/arrow_select.svg';
 import React from 'react';
 import type { AccordionProps } from '@mui/material/Accordion';
 import type { AccordionSummaryProps } from '@mui/material/AccordionSummary';
@@ -19,65 +18,61 @@ interface Props {
 }
 
 const AccordionCategory: React.FC<Props> = ({ style, category, expanded, handleChangeItemAccordion }) => {
-  const handleOnchange = (event: React.SyntheticEvent, expanded: boolean) => {
-    handleChangeItemAccordion(category.id, expanded);
+  const handleOnchange = (event: React.SyntheticEvent, newExpanded: boolean) => {
+    handleChangeItemAccordion(category.id, newExpanded);
   };
 
   return (
     <TransactionHistoryContainer style={style}>
-      <Accordion expanded={expanded} onChange={handleOnchange}>
-        <AccordionSummary>{pascalCaseToNormalString(category.name)}</AccordionSummary>
+      <StyledAccordion expanded={expanded} onChange={handleOnchange}>
+        <StyledAccordionSummary>{pascalCaseToNormalString(category.name)}</StyledAccordionSummary>
 
-        <AccordionDetails>
+        <StyledAccordionDetails>
           <ItemsStyle>
-            {category?.subcategories?.map((category) => (
-              <div key={category.name}>{pascalCaseToNormalString(category.name)}</div>
+            {category?.subcategories?.map((subcategory) => (
+              <div key={subcategory.name}>{pascalCaseToNormalString(subcategory.name)}</div>
             ))}
           </ItemsStyle>
-        </AccordionDetails>
-      </Accordion>
+        </StyledAccordionDetails>
+      </StyledAccordion>
     </TransactionHistoryContainer>
   );
 };
 
 export default AccordionCategory;
 
-const TransactionHistoryContainer = styled('div')({
+const TransactionHistoryContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',
 
-  [lightTheme.breakpoints.down('tablet_768')]: {
+  [theme.breakpoints.down('tablet_768')]: {
     width: '100%',
   },
-});
+}));
 
-const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters elevation={0} square {...props} />)({
+const StyledAccordion = styled((props: AccordionProps) => (
+  <MuiAccordion disableGutters elevation={0} square {...props} />
+))(({ theme }) => ({
   backgroundColor: 'transparent',
   width: '100%',
 
-  [lightTheme.breakpoints.up('tablet_768')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     width: 310,
   },
 
-  [lightTheme.breakpoints.up('desktop_1024')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     width: 416,
   },
-});
+}));
 
-const AccordionSummary = styled((props: AccordionSummaryProps) => (
+const StyledAccordionSummary = styled((props: AccordionSummaryProps) => (
   <MuiAccordionSummary
     expandIcon={
-      <SelectChevronDown
-        fill="#1AAB9B"
-        width={10}
-        height={6}
-        style={{
-          transform: 'scaleY(1)',
-          marginRight: 2,
-        }}
-      />
+      <IconContainer>
+        <ArrowSelect />
+      </IconContainer>
     }
     {...props}
   />
@@ -91,11 +86,11 @@ const AccordionSummary = styled((props: AccordionSummaryProps) => (
     lineHeight: '22px',
     fontFamily: 'Inter, sans-serif',
     fontStyle: 'normal',
-    color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
+    color: theme.palette.mode === 'light' ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
     padding: 0,
     marginTop: 0,
     marginBottom: 0,
-    [lightTheme.breakpoints.up('desktop_1024')]: {
+    [theme.breakpoints.up('desktop_1024')]: {
       fontSize: 16,
       lineHeight: '24px',
     },
@@ -106,16 +101,16 @@ const AccordionSummary = styled((props: AccordionSummaryProps) => (
   },
 }));
 
-const AccordionDetails = styled(MuiAccordionDetails)({
+const StyledAccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
   padding: 0,
   paddingLeft: 24,
   marginTop: 8,
 
-  [lightTheme.breakpoints.up('tablet_768')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     marginTop: 24,
     paddingLeft: 32,
   },
-});
+}));
 
 const ItemsStyle = styled('div')(({ theme }) => ({
   display: 'flex',
@@ -123,13 +118,22 @@ const ItemsStyle = styled('div')(({ theme }) => ({
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
   textTransform: 'capitalize',
-  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+  color: theme.palette.mode === 'light' ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   gap: 16,
   fontWeight: 400,
   fontSize: 14,
   lineHeight: '22px',
-  [lightTheme.breakpoints.up('desktop_1024')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
     lineHeight: '24px',
   },
+}));
+
+const IconContainer = styled('div')(({ theme }) => ({
+  color: theme.palette.colors.gray[600],
+  width: 16,
+  height: 16,
+  display: 'flex',
+  alignItems: 'center',
+  transform: 'scaleY(1)',
 }));

--- a/src/components/AdvancedInnerTable/BasicModal/ContainerModal.tsx
+++ b/src/components/AdvancedInnerTable/BasicModal/ContainerModal.tsx
@@ -343,19 +343,21 @@ const StyledClose = styled(Close)(({ theme }) => ({
 
 const SimpleBarStyled = styled(SimpleBar)(({ theme }) => ({
   height: '100%',
+  borderRadius: 12,
 
   '.simplebar-scrollbar::before': {
     width: 4,
     marginLeft: 4,
-    background: '#1aab9b',
     borderRadius: 20,
+    height: 256,
+    background: theme.palette.isLight ? theme.palette.colors.charcoal[500] : theme.palette.colors.charcoal[700],
   },
 
   [theme.breakpoints.up('tablet_768')]: {
-    maxHeight: 813,
+    maxHeight: 256,
 
     '.simplebar-scrollbar::before': {
-      width: 6,
+      width: 8,
     },
   },
 

--- a/src/views/CoreUnitBudgetStatement/components/CuHeadlineText/CuHeadlineText.tsx
+++ b/src/views/CoreUnitBudgetStatement/components/CuHeadlineText/CuHeadlineText.tsx
@@ -16,7 +16,7 @@ const CuHeadlineText: React.FC<CuHeadlineTextProps> = ({ cuLongCode, isCoreUnit 
   const resource = isCoreUnit ? 'Core Unit' : 'Ecosystem Actor';
   return (
     <LinkDescription>
-      <ExternalLinkButtonStyled href={`${MAKER_BURN_LINK}/${cuLongCode}`}>
+      <ExternalLinkButtonStyled href={`${MAKER_BURN_LINK}/${cuLongCode}`} wrapText={false}>
         {`${shortCode} ${resource} on-chain transaction history`}
       </ExternalLinkButtonStyled>
     </LinkDescription>
@@ -31,7 +31,9 @@ export const LinkDescription = styled('div')(() => ({
 
 const ExternalLinkButtonStyled = styled(ExternalLinkButton)(({ theme }) => ({
   padding: '0px 6px 0px 8px',
-  letterSpacing: -0.2,
+  gap: 8,
+  borderTopWidth: 1.5,
+  letterSpacing: '-0.28px',
   borderWidth: 1.5,
   fontSize: 14,
   fontWeight: 500,


### PR DESCRIPTION
## Ticket
https://trello.com/c/smptd4rr/470-reskin-budget-statements-cu-ea-actual-tab

## What solved

- [X] Should update the Expense category icon (status: default, hover) for light/dark mode. Desktop/Small resolutions. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
