### PR TITLE
[Reskin-470] Add styles for the modal 

### DIFF
--- a/src/components/AdditionalNotesSection/AdditionalNotesSection.stories.tsx
+++ b/src/components/AdditionalNotesSection/AdditionalNotesSection.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof AdditionalNotesSection> = {
   component: AdditionalNotesSection,
   parameters: {
     chromatic: {
+      viewports: [375, 768, 1024, 1280, 1440],
       pauseAnimationAtEnd: true,
     },
   },

--- a/src/components/AdditionalNotesSection/AdditionalNotesSection.tsx
+++ b/src/components/AdditionalNotesSection/AdditionalNotesSection.tsx
@@ -105,8 +105,6 @@ const Question = styled('div')(({ theme }) => ({
 }));
 
 const ExternalLinkButtonStyled = styled(ExternalLinkButton)(({ theme }) => ({
-  padding: '0px 6px 0px 8px',
-  borderWidth: 1.5,
   '& div': {
     width: 16,
     height: 16,
@@ -119,6 +117,7 @@ const ExternalLinkButtonStyled = styled(ExternalLinkButton)(({ theme }) => ({
     height: 32,
     display: 'flex',
     alignItems: 'center',
+
     letterSpacing: '-0.32px',
   },
 }));

--- a/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -280,11 +280,9 @@ const TitleCard = styled('div')<{ cardSpacingSize?: CardSpacingSize; isGroupCard
 );
 
 const GroupTitle = styled('div')(({ theme }) => ({
-  fontSize: 12,
-  lineHeight: '15px',
+  fontSize: 16,
+  lineHeight: '22px',
   fontWeight: 600,
-  letterSpacing: '1px',
-  textTransform: 'uppercase',
   color: theme.palette.isLight ? '#231536' : '#D2D4EF',
 }));
 
@@ -317,6 +315,7 @@ const StyledOpenModalTransparency = styled(OpenModalTransparency)(({ theme }) =>
     lineHeight: '15px',
     marginBottom: 0,
     fontWeight: 400,
+    color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
 
     svg: {
       display: 'none',
@@ -326,8 +325,6 @@ const StyledOpenModalTransparency = styled(OpenModalTransparency)(({ theme }) =>
       fontWeight: 600,
       lineHeight: '24px',
       paddingLeft: 16,
-
-      padding: '8px 0px 16px 16px',
     },
   },
   [theme.breakpoints.up('tablet_768')]: {

--- a/src/components/AdvancedInnerTable/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
+++ b/src/components/AdvancedInnerTable/BasicModal/CategoryItem/ArrowAccordionCategory.tsx
@@ -107,7 +107,6 @@ const StyledAccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
   marginTop: 8,
 
   [theme.breakpoints.up('tablet_768')]: {
-    marginTop: 24,
     paddingLeft: 32,
   },
 }));
@@ -119,7 +118,7 @@ const ItemsStyle = styled('div')(({ theme }) => ({
   fontStyle: 'normal',
   textTransform: 'capitalize',
   color: theme.palette.mode === 'light' ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
-  gap: 16,
+  gap: 11,
   fontWeight: 400,
   fontSize: 14,
   lineHeight: '22px',

--- a/src/components/AdvancedInnerTable/BasicModal/ContainerModal.tsx
+++ b/src/components/AdvancedInnerTable/BasicModal/ContainerModal.tsx
@@ -291,27 +291,19 @@ const ContainerTwoColumns = styled('div')(({ theme }) => ({
   },
 }));
 
-const ContainerEven = styled('div')(({ theme }) => ({
+const ContainerEven = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
   flex: 1,
   gap: 16,
-
-  [theme.breakpoints.up('tablet_768')]: {
-    gap: 32,
-  },
 }));
 
-const ContainerOdd = styled('div')(({ theme }) => ({
+const ContainerOdd = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-end',
   flex: 1,
   gap: 16,
-
-  [theme.breakpoints.up('tablet_768')]: {
-    gap: 32,
-  },
 }));
 const ContainerClose = styled('div')(({ theme }) => ({
   paddingRight: 3,

--- a/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
+++ b/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
@@ -147,6 +147,9 @@ const ContainerLine = styled('div')(({ theme }) => ({
 
 const ContainerData = styled('div')<{ spacing: CardSpacingSize }>(({ spacing }) => ({
   padding: spacing === 'large' ? '20px 24px 10px' : '16px 24px 6px',
+  '& .advanced-table__cell-row--category--comments': {
+    padding: 0,
+  },
 }));
 
 const SubHeader = styled('div')(({ theme }) => ({

--- a/src/components/CuHeadlineText/CuHeadlineText.stories.tsx
+++ b/src/components/CuHeadlineText/CuHeadlineText.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof CuHeadlineText> = {
   component: CuHeadlineText,
   parameters: {
     chromatic: {
+      viewports: [375, 768, 1024, 1280, 1440],
       pauseAnimationAtEnd: true,
     },
   },

--- a/src/components/CuHeadlineText/CuHeadlineText.stories.tsx
+++ b/src/components/CuHeadlineText/CuHeadlineText.stories.tsx
@@ -1,0 +1,28 @@
+import { createThemeModeVariants } from '@/core/utils/storybook/factories';
+
+import CuHeadlineText from './CuHeadlineText';
+import type { Meta } from '@storybook/react';
+
+const meta: Meta<typeof CuHeadlineText> = {
+  title: 'Fusion/Components/Budget Statements/CuHeadlineText',
+  component: CuHeadlineText,
+  parameters: {
+    chromatic: {
+      pauseAnimationAtEnd: true,
+    },
+  },
+};
+
+export default meta;
+
+const variantsArgs = [
+  {
+    cuLongCode: 'SES-001',
+    shortCode: 'SES',
+
+    isCoreUnit: true,
+  },
+];
+
+const [[Notes, NotesDarkMode]] = createThemeModeVariants(CuHeadlineText, variantsArgs);
+export { Notes, NotesDarkMode };

--- a/src/components/Tabs/Tab.stories.tsx
+++ b/src/components/Tabs/Tab.stories.tsx
@@ -9,6 +9,7 @@ const meta: Meta<typeof Tab> = {
   component: Tab,
   parameters: {
     chromatic: {
+      viewports: [375, 768, 1024, 1280, 1440],
       pauseAnimationAtEnd: true,
     },
   },

--- a/src/components/Tabs/Tab.stories.tsx
+++ b/src/components/Tabs/Tab.stories.tsx
@@ -1,11 +1,12 @@
 import { createThemeModeVariants } from '@/core/utils/storybook/factories';
 import { SESCoreUnitMocked } from '@/core/utils/storybook/mocks/coreUnitsMocks';
-import AdditionalNotesSection from './AdditionalNotesSection';
+
+import Tab from './Tab';
 import type { Meta } from '@storybook/react';
 
-const meta: Meta<typeof AdditionalNotesSection> = {
-  title: 'Fusion/Components/Budget Statements//AdditionalNotesSection',
-  component: AdditionalNotesSection,
+const meta: Meta<typeof Tab> = {
+  title: 'Fusion/Components/Budget Statements/Tabs',
+  component: Tab,
   parameters: {
     chromatic: {
       pauseAnimationAtEnd: true,
@@ -21,5 +22,5 @@ const variantsArgs = [
   },
 ];
 
-const [[Notes, NotesDarkMode]] = createThemeModeVariants(AdditionalNotesSection, variantsArgs);
-export { Notes, NotesDarkMode };
+const [[Tabs, TabsDarkMode]] = createThemeModeVariants(Tab, variantsArgs);
+export { Tabs, TabsDarkMode };

--- a/src/components/WalletTableCell/WalletTableCell.stories.tsx
+++ b/src/components/WalletTableCell/WalletTableCell.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta } from '@storybook/react';
 import type { FigmaParams } from 'sb-figma-comparator';
 
 const meta: Meta<typeof WalletTableCell> = {
-  title: 'Fusion/Components/CUTransparencyReport/WalletTableCell',
+  title: 'Fusion/Components/Budget Statements/WalletTableCell',
   component: WalletTableCell,
   parameters: {
     chromatic: {


### PR DESCRIPTION
## Ticket
https://trello.com/c/smptd4rr/470-apply-reskin-to-the-actual-tab-for-cu-ea

## What solved

- [X] Should update the Canonical Expense Categories modal (state: elements collapsed/expanded, checkbox: selected/unselected) for light/dark mode. Desktop/Small resolutions.
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
