### PR TITLE
[Reskin-470] Reskin the Canonical Expense Categories  and Improve the space in the cards

### DIFF
--- a/src/components/AdditionalNotesSection/AdditionalNotesSection.stories.tsx
+++ b/src/components/AdditionalNotesSection/AdditionalNotesSection.stories.tsx
@@ -4,7 +4,7 @@ import AdditionalNotesSection from './AdditionalNotesSection';
 import type { Meta } from '@storybook/react';
 
 const meta: Meta<typeof AdditionalNotesSection> = {
-  title: 'Fusion/Components/Budget Statements//AdditionalNotesSection',
+  title: 'Fusion/Components/Budget Statements/AdditionalNotesSection',
   component: AdditionalNotesSection,
   parameters: {
     chromatic: {

--- a/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -251,10 +251,6 @@ const GroupTitle = styled('div')(({ theme }) => ({
   lineHeight: '22px',
   fontWeight: 600,
   color: theme.palette.isLight ? '#231536' : '#D2D4EF',
-  // display: 'none',
-  [theme.breakpoints.up('tablet_768')]: {
-    // display: 'flex',
-  },
 }));
 
 const TableRow = styled('tr')<{ borderTop?: boolean; borderBottom?: boolean }>(

--- a/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -7,7 +7,7 @@ import { TransparencyEmptyTable } from '../../views/CoreUnitBudgetStatement/comp
 import { NumberCell } from './NumberCell/NumberCell';
 import { TextCell } from './TextCell/TextCell';
 import { TransparencyCard } from './TransparencyCard/TransparencyCard';
-import type { AdvancedInnerTableProps, Alignment, CardSpacingSize, InnerTableColumn, RowType } from './types';
+import type { AdvancedInnerTableProps, Alignment, InnerTableColumn, RowType } from './types';
 
 export const AdvancedInnerTable: React.FC<AdvancedInnerTableProps> = ({
   cardsTotalPosition = 'bottom',
@@ -136,21 +136,12 @@ export const AdvancedInnerTable: React.FC<AdvancedInnerTableProps> = ({
             item.items[i]?.column.isCardHeader
           );
           if (item.type === 'groupTitle') {
-            return (
-              <TitleCard isGroupCard={true} cardSpacingSize={cardSpacingSize} className="advanced-table--group-section">
-                <GroupTitle key={`groupTitle-${i}`} className="advanced-table--table-groupTitle">
-                  {item.items[0].value as string}
-                </GroupTitle>
-                {i + 1 < cardItems.length && cardItems[i + 1].type === 'section' && (
-                  <Title fontSize="14px" className="advanced-table--table-section">
-                    {cardItems[i].items[0].value as string}
-                  </Title>
-                )}
-              </TitleCard>
-            );
+            return null;
           }
+
           return (
             <TransparencyCard
+              category={item.category}
               showSubHeader={showSubHeader}
               itemType={item.type}
               subHeader={item.subHeader || ''}
@@ -255,35 +246,15 @@ const CardsWrapper = styled('div')(({ theme }) => ({
   },
 }));
 
-const TitleCard = styled('div')<{ cardSpacingSize?: CardSpacingSize; isGroupCard?: boolean }>(
-  ({ theme, cardSpacingSize = 'large', isGroupCard = false }) => ({
-    padding: cardSpacingSize === 'large' ? '8px 24px' : '8px 16px',
-    background: theme.palette.isLight ? 'rgba(255, 255, 255, 0.7)' : 'rgba(120, 122, 155, 0.3)',
-    boxShadow: theme.palette.isLight
-      ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
-      : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
-    borderRadius: 6,
-    marginBottom: 8,
-
-    '&:not(:first-of-type)': {
-      marginTop: isGroupCard ? 24 : 0,
-    },
-
-    '& > .advanced-table--table-groupTitle': {
-      marginBottom: 16,
-    },
-
-    '& > .advanced-table--table-section': {
-      margin: 0,
-    },
-  })
-);
-
 const GroupTitle = styled('div')(({ theme }) => ({
   fontSize: 16,
   lineHeight: '22px',
   fontWeight: 600,
   color: theme.palette.isLight ? '#231536' : '#D2D4EF',
+  // display: 'none',
+  [theme.breakpoints.up('tablet_768')]: {
+    // display: 'flex',
+  },
 }));
 
 const TableRow = styled('tr')<{ borderTop?: boolean; borderBottom?: boolean }>(
@@ -349,22 +320,4 @@ const StyledOpenModalTransparency = styled(OpenModalTransparency)(({ theme }) =>
       display: 'none',
     },
   },
-}));
-
-const Title = styled('div')<{
-  marginBottom?: number;
-  fontSize?: string;
-  responsiveMarginBottom?: number;
-  isBreakDown?: boolean;
-  marginTop?: number;
-}>(({ marginBottom = 16, theme, marginTop = 24, isBreakDown = false }) => ({
-  fontFamily: 'Inter, sans-serif',
-  fontWeight: isBreakDown ? 700 : 600,
-  fontStyle: 'normal',
-  fontSize: 14,
-  lineHeight: isBreakDown ? '19.36px' : '24px',
-  marginTop,
-  letterSpacing: '0.4px',
-  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
-  marginBottom: `${marginBottom}px`,
 }));

--- a/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
+++ b/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
@@ -146,9 +146,14 @@ const ContainerLine = styled('div')(({ theme }) => ({
 }));
 
 const ContainerData = styled('div')<{ spacing: CardSpacingSize }>(({ spacing }) => ({
-  padding: spacing === 'large' ? '20px 24px 10px' : '16px 24px 6px',
+  padding: spacing === 'large' ? '20px 24px 10px' : '4px 24px 4px',
   '& .advanced-table__cell-row--category--comments': {
     padding: 0,
+    textAlign: 'end',
+    '& div': {
+      width: 0,
+      height: 0,
+    },
   },
 }));
 

--- a/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
+++ b/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
@@ -13,6 +13,7 @@ interface Props {
   cardSpacingSize?: CardSpacingSize;
   subHeader: string;
   showSubHeader: boolean;
+  category?: string;
 }
 
 export const TransparencyCard: React.FC<Props> = ({
@@ -25,8 +26,10 @@ export const TransparencyCard: React.FC<Props> = ({
   items,
   separators,
   showSubHeader,
+  category = 'General',
 }) => {
   if (itemType === 'section') return null;
+
   return (
     <Container
       style={{ marginTop: itemType === 'total' ? 24 : 0 }}
@@ -35,9 +38,11 @@ export const TransparencyCard: React.FC<Props> = ({
       }`}
     >
       <HeaderWrapper showSubHeader={showSubHeader}>
-        {header}
+        {showSubHeader && <Category>{category}</Category>}
         {showSubHeader && <SubHeader>{subHeader}</SubHeader>}
       </HeaderWrapper>
+      {header}
+
       {headers.map((header, i) => {
         const titleReactComponent = (header as JSX.Element).props?.title || '';
         const totalsStyle = header === 'Totals' || titleReactComponent === 'Totals';
@@ -96,6 +101,7 @@ const HeaderWrapper = styled('div')<{ showSubHeader: boolean }>(({ theme, showSu
     : theme.palette.colors.charcoal[800],
   borderTopLeftRadius: 12,
   borderTopRightRadius: 12,
+  paddingTop: 8,
 }));
 
 const FooterWrapper = styled('div')(({ theme }) => ({
@@ -140,9 +146,9 @@ const Label = styled('div')<{ hasIcon?: boolean; height?: string; isTotal: boole
 const ContainerLine = styled('div')(({ theme }) => ({
   display: 'flex',
   flex: 1,
-  borderTop: `1px solid ${theme.palette.isLight ? '#D4D9E1' : '#405361'}`,
-  marginBottom: 20,
-  marginTop: 20,
+  borderTop: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[200] : theme.palette.colors.charcoal[800]}`,
+  marginBottom: 6,
+  marginTop: 6,
 }));
 
 const ContainerData = styled('div')<{ spacing: CardSpacingSize }>(({ spacing }) => ({
@@ -162,6 +168,19 @@ const SubHeader = styled('div')(({ theme }) => ({
   fontSize: 14,
   fontWeight: 600,
   lineHeight: '22px',
+  paddingLeft: 24,
+  paddingRight: 24,
+  paddingBottom: 8,
+  [theme.breakpoints.up('tablet_768')]: {
+    paddingLeft: 16,
+  },
+}));
+
+const Category = styled('div')(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+  fontSize: 16,
+  fontWeight: 600,
+  lineHeight: '24px',
   paddingLeft: 24,
   paddingRight: 24,
   paddingBottom: 8,

--- a/src/components/AdvancedInnerTable/types.ts
+++ b/src/components/AdvancedInnerTable/types.ts
@@ -27,6 +27,8 @@ export type CardSpacingSize = 'small' | 'large';
 export interface InnerTableRow {
   type: RowType;
   subHeader?: string;
+  category?: string;
+  categoryGroup?: string;
   items: InnerTableCell[];
   borderTop?: boolean;
   borderBottom?: boolean;

--- a/src/components/BudgetStatement/BudgetStatementActuals/BudgetStatementActuals.tsx
+++ b/src/components/BudgetStatement/BudgetStatementActuals/BudgetStatementActuals.tsx
@@ -49,6 +49,7 @@ export const TransparencyActuals: React.FC<TransparencyActualsProps> = ({
         style={{ marginBottom: '64px' }}
         cardsTotalPosition="top"
         longCode={longCode}
+        cardSpacingSize="small"
         tablePlaceholder={
           <div style={{ marginBottom: 64 }}>
             <TransparencyEmptyTable longCode={longCode} shortCode={shortCode} resource={resource} />

--- a/src/components/BudgetStatement/BudgetStatementActuals/useBudgetStatementActuals.ts
+++ b/src/components/BudgetStatement/BudgetStatementActuals/useBudgetStatementActuals.ts
@@ -143,26 +143,31 @@ export const useTransparencyActuals = (
         header: 'Mthly Budget',
         align: 'right',
         type: 'number',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Forecast',
         align: 'right',
         type: 'incomeNumber',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Actuals',
         align: 'right',
         type: 'incomeNumber',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Difference',
         align: 'right',
         type: 'number',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Payments',
         align: 'right',
         type: 'number',
+        hasBorderBottomOnCard: true,
       },
     ];
     return mainTableColumns;

--- a/src/views/CoreUnitBudgetStatement/utils/actualsTableHelpers.tsx
+++ b/src/views/CoreUnitBudgetStatement/utils/actualsTableHelpers.tsx
@@ -65,6 +65,12 @@ export const getActualsBreakdownItems = (
 
       result.push({
         subHeader: groupedCategory[groupedCatKey][0].headcountExpense ? 'Headcount Expenses' : 'Non-Headcount Expenses',
+        category:
+          groupedCategory[groupedCatKey][0].group === '' ||
+          groupedCategory[groupedCatKey][0].group === null ||
+          groupedCategory[groupedCatKey][0].group === 'null'
+            ? 'General'
+            : groupedCategory[groupedCatKey][0].group,
         type: type || 'normal',
         ...(type === 'subTotal'
           ? {
@@ -125,27 +131,32 @@ export const getActualsBreakdownColumns = (wallet: BudgetStatementWallet, handle
       header: 'Mthly Budget',
       align: 'right',
       type: 'number',
+      hasBorderBottomOnCard: true,
     },
     {
       header: 'Forecast',
       align: 'right',
       type: 'incomeNumber',
+      hasBorderBottomOnCard: true,
     },
     {
       header: 'Actuals',
       align: 'right',
       type: 'incomeNumber',
+      hasBorderBottomOnCard: true,
     },
     {
       header: 'Difference',
       align: 'right',
       type: 'number',
+      hasBorderBottomOnCard: true,
     },
     {
       header: 'Comments',
       align: 'left',
       type: 'text',
       width: '300px',
+      hasBorderBottomOnCard: true,
     },
     {
       header: 'Payments',
@@ -177,6 +188,7 @@ export const getActualsBreakdownItemsForWallet = (
       // it is a project group
       result.push({
         type: 'groupTitle',
+        categoryGroup: groupedKey === '' ? 'General' : groupedKey,
         borderTop: true,
         items: [
           {

--- a/src/views/CoreUnitBudgetStatement/utils/helpers.tsx
+++ b/src/views/CoreUnitBudgetStatement/utils/helpers.tsx
@@ -3,6 +3,7 @@ import type { InnerTableRow } from '@/components/AdvancedInnerTable/types';
 const replacePaymentTopup = (breakdownItems: InnerTableRow[]): InnerTableRow[] =>
   breakdownItems.map((innerRow) => ({
     ...innerRow,
+    category: innerRow.category,
     items: innerRow.items.map((item) => {
       if (item.value === 'payment topup') {
         return {

--- a/src/views/EcosystemActorAbout/components/CardProjects/ItemCustomProject.tsx
+++ b/src/views/EcosystemActorAbout/components/CardProjects/ItemCustomProject.tsx
@@ -9,19 +9,16 @@ interface Props {
   shortCode: string;
 }
 
-const ItemCustomProject: FC<Props> = ({ shortCode }) => {
-  console.log('hello');
-  return (
-    <CardSheetMobile
-      title="Projects"
-      description={`View all the of the projects ${shortCode} is involved in and there status.`}
-    >
-      <ContainerChildren>
-        <InternalLinkButtonStyled href={siteRoutes.ecosystemActorProjects(shortCode)} label="View Projects" showIcon />
-      </ContainerChildren>
-    </CardSheetMobile>
-  );
-};
+const ItemCustomProject: FC<Props> = ({ shortCode }) => (
+  <CardSheetMobile
+    title="Projects"
+    description={`View all the of the projects ${shortCode} is involved in and there status.`}
+  >
+    <ContainerChildren>
+      <InternalLinkButtonStyled href={siteRoutes.ecosystemActorProjects(shortCode)} label="View Projects" showIcon />
+    </ContainerChildren>
+  </CardSheetMobile>
+);
 
 export default ItemCustomProject;
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/smptd4rr/470-reskin-budget-statements-cu-ea-actual-tab


## What solved

- [X] Should update the Canonical Expense Categories modal (state: elements collapsed/expanded, checkbox: selected/unselected) for light/dark mode. Desktop/Small resolutions.
- [X] Improve the styles in the mobile cards

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
