### PR TITLE
[Reskin-479] Reskin transaction history

### DIFF
--- a/src/components/AccountsSnapshot/AccountsSnapshot.tsx
+++ b/src/components/AccountsSnapshot/AccountsSnapshot.tsx
@@ -61,9 +61,9 @@ const AccountsSnapshot: React.FC<AccountsSnapshotProps> = ({ snapshot, snapshotO
 
 export default AccountsSnapshot;
 
-const Wrapper = styled('div')({
+const Wrapper = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
-  gap: 64,
-  marginBottom: 64,
-});
+  gap: 32,
+  marginBottom: 24,
+}));

--- a/src/components/AccountsSnapshot/components/AccordionArrow/AccordionArrow.tsx
+++ b/src/components/AccountsSnapshot/components/AccordionArrow/AccordionArrow.tsx
@@ -17,13 +17,8 @@ const AccordionArrow: React.FC = () => {
 
 export default AccordionArrow;
 
-const SVG = styled('svg')(({ theme }) => ({
+const SVG = styled('svg')(() => ({
   width: 10,
   height: 6,
   margin: '5px 3px',
-
-  [theme.breakpoints.up('desktop_1024')]: {
-    width: 16,
-    height: 10,
-  },
 }));

--- a/src/components/AccountsSnapshot/components/AccordionArrow/AccordionArrow.tsx
+++ b/src/components/AccountsSnapshot/components/AccordionArrow/AccordionArrow.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material';
+import { colorPalette } from '@ses/styles/theme/colorPalette';
 import { useThemeContext } from '@/core/context/ThemeContext';
 
 const AccordionArrow: React.FC = () => {
@@ -8,7 +9,7 @@ const AccordionArrow: React.FC = () => {
     <SVG viewBox="0 0 16 10" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M7.50942 9.7718C7.76647 10.0761 8.23358 10.0761 8.49062 9.7718L15.8457 1.06587C16.2008 0.645583 15.9037 0 15.3551 0H0.644894C0.0963604 0 -0.200786 0.645583 0.154293 1.06587L7.50942 9.7718Z"
-        fill={isLight ? '#546978' : '#546978'}
+        fill={isLight ? colorPalette.gray[900] : colorPalette.gray[500]}
       />
     </SVG>
   );
@@ -21,7 +22,7 @@ const SVG = styled('svg')(({ theme }) => ({
   height: 6,
   margin: '5px 3px',
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     width: 16,
     height: 10,
   },

--- a/src/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
+++ b/src/components/AccountsSnapshot/components/CUReserves/CUReserves.tsx
@@ -124,7 +124,7 @@ export default CUReserves;
 const CardsContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   gap: 8,
-  marginTop: 24,
+  marginTop: 16,
   flexWrap: 'wrap',
 
   '& > div:nth-of-type(1)': {
@@ -178,22 +178,17 @@ const HeaderContainer = styled('div')(({ theme }) => ({
 }));
 
 const CheckContainer = styled('div')(({ theme }) => ({
-  fontSize: 14,
-  lineHeight: '17px',
-  color: theme.palette.isLight ? '#231536' : '#787A9B',
+  fontSize: 16,
+  lineHeight: '22px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   display: 'flex',
   marginRight: 2,
   marginBottom: 1,
   gap: 10,
-  marginTop: 20,
+  marginTop: 8,
 
   [theme.breakpoints.up('tablet_768')]: {
-    marginTop: 4,
-  },
-
-  [theme.breakpoints.up('desktop_1024')]: {
-    fontSize: 16,
-    lineHeight: '22px',
+    marginTop: 'auto',
   },
 
   '& span': {
@@ -203,7 +198,7 @@ const CheckContainer = styled('div')(({ theme }) => ({
 
 const Checkbox = styled(CheckboxMui)(({ theme }) => ({
   svg: {
-    fill: theme.palette.isLight ? '#231536' : '#ADAFD4',
+    fill: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   },
 }));
 

--- a/src/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
+++ b/src/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
@@ -152,51 +152,51 @@ ExpandedLightMode.parameters = {
           },
         },
       },
-      834: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19867:248091',
+      768: {
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1811-52934',
         options: {
           componentStyle: {
-            width: 770,
+            width: 704,
           },
           style: {
-            top: 0,
-            left: -40,
+            top: -55,
+            left: -14,
           },
         },
       },
-      1194: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19866:244261',
+      1024: {
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1734-46077',
         options: {
           componentStyle: {
-            width: 1130,
+            width: 960,
           },
           style: {
-            top: 0,
-            left: -40,
+            top: -57,
+            left: -14,
           },
         },
       },
       1280: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19865:238552',
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1715-15149',
         options: {
           componentStyle: {
-            width: 1184,
+            width: 1200,
           },
           style: {
-            top: 0,
-            left: -40,
+            top: -57,
+            left: -14,
           },
         },
       },
       1440: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18569:206364',
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1679-87116',
         options: {
           componentStyle: {
             width: 1312,
           },
           style: {
-            top: 0,
-            left: -40,
+            top: -57,
+            left: -14,
           },
         },
       },

--- a/src/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
+++ b/src/components/AccountsSnapshot/components/FundingOverview/FundingOverview.stories.tsx
@@ -65,7 +65,8 @@ const variantsArgs = [
 
 const [[LightMode, DarkMode], [ExpandedLightMode, ExpandedDarkMode]] = createThemeModeVariants(
   FundingOverview,
-  variantsArgs
+  variantsArgs,
+  false
 );
 export { LightMode, DarkMode, ExpandedLightMode, ExpandedDarkMode };
 

--- a/src/components/AccountsSnapshot/components/FundingOverview/FundingOverviewSkeleton.stories.tsx
+++ b/src/components/AccountsSnapshot/components/FundingOverview/FundingOverviewSkeleton.stories.tsx
@@ -16,7 +16,7 @@ export default meta;
 
 const variantsArgs = [{}];
 
-const [[LightMode, DarkMode]] = createThemeModeVariants(FundingOverviewSkeleton, variantsArgs);
+const [[LightMode, DarkMode]] = createThemeModeVariants(FundingOverviewSkeleton, variantsArgs, false);
 export { LightMode, DarkMode };
 
 LightMode.parameters = {

--- a/src/components/AccountsSnapshot/components/SVG/GreenArrowDown.tsx
+++ b/src/components/AccountsSnapshot/components/SVG/GreenArrowDown.tsx
@@ -1,3 +1,5 @@
+import { useTheme } from '@mui/material';
+import { colorPalette } from '@ses/styles/theme/colorPalette';
 import * as React from 'react';
 
 interface Props {
@@ -5,16 +7,20 @@ interface Props {
   height?: number;
 }
 
-const GreenArrowDown: React.FC<Props> = ({ height = 16, width = 16, ...props }) => (
-  <svg width={width} height={height} {...props} viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path
-      opacity="0.3"
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M8 0.5C3.58172 0.5 0 4.08172 0 8.5C0 12.9183 3.58172 16.5 8 16.5C12.4183 16.5 16 12.9183 16 8.5C16 4.08172 12.4183 0.5 8 0.5ZM8.01246 13.415C7.45185 13.4268 6.77225 12.6915 6.77225 12.6915L4.2011 9.6273C3.8461 9.20422 3.90128 8.53099 4.32436 8.17599C4.74743 7.82098 5.37819 7.87617 5.73319 8.29924L6.91504 9.70772L6.91504 4.5C6.91504 3.94771 7.44772 3.41504 8 3.41504C8.55228 3.41504 9.12337 3.94771 9.12337 4.5L9.12337 9.70772L10.2339 8.3842C10.5889 7.96113 11.2197 7.90594 11.6428 8.26095C12.0658 8.61595 12.121 9.20422 11.766 9.6273L9.19487 12.6915C9.19487 12.6915 8.5537 13.4037 8.01246 13.415Z"
-      fill="#1AAB9B"
-    />
-  </svg>
-);
+const GreenArrowDown: React.FC<Props> = ({ height = 16, width = 16, ...props }) => {
+  const isLight = useTheme().palette.isLight;
+
+  return (
+    <svg width={width} height={height} {...props} viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        opacity="0.3"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 0.5C3.58172 0.5 0 4.08172 0 8.5C0 12.9183 3.58172 16.5 8 16.5C12.4183 16.5 16 12.9183 16 8.5C16 4.08172 12.4183 0.5 8 0.5ZM8.01246 13.415C7.45185 13.4268 6.77225 12.6915 6.77225 12.6915L4.2011 9.6273C3.8461 9.20422 3.90128 8.53099 4.32436 8.17599C4.74743 7.82098 5.37819 7.87617 5.73319 8.29924L6.91504 9.70772L6.91504 4.5C6.91504 3.94771 7.44772 3.41504 8 3.41504C8.55228 3.41504 9.12337 3.94771 9.12337 4.5L9.12337 9.70772L10.2339 8.3842C10.5889 7.96113 11.2197 7.90594 11.6428 8.26095C12.0658 8.61595 12.121 9.20422 11.766 9.6273L9.19487 12.6915C9.19487 12.6915 8.5537 13.4037 8.01246 13.415Z"
+        fill={isLight ? colorPalette.green[700] : colorPalette.green[900]}
+      />
+    </svg>
+  );
+};
 
 export default GreenArrowDown;

--- a/src/components/AccountsSnapshot/components/SVG/RedArrowUp.tsx
+++ b/src/components/AccountsSnapshot/components/SVG/RedArrowUp.tsx
@@ -1,3 +1,5 @@
+import { useTheme } from '@mui/material';
+import { colorPalette } from '@ses/styles/theme/colorPalette';
 import * as React from 'react';
 
 interface Props {
@@ -5,16 +7,20 @@ interface Props {
   height?: number;
 }
 
-const RedArrowUp: React.FC<Props> = ({ height = 16, width = 16, ...props }) => (
-  <svg width={width} height={height} {...props} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path
-      opacity="0.3"
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16ZM7.98754 3.08496C8.54815 3.07318 9.22775 3.80852 9.22775 3.80852L11.7989 6.8727C12.1539 7.29578 12.0987 7.96901 11.6756 8.32401C11.2526 8.67902 10.6218 8.62383 10.2668 8.20076L9.08496 6.79228V12C9.08496 12.5523 8.55228 13.085 8 13.085C7.44772 13.085 6.87663 12.5523 6.87663 12L6.87663 6.79228L5.76607 8.1158C5.41107 8.53887 4.78031 8.59406 4.35724 8.23905C3.93416 7.88405 3.87898 7.29578 4.23398 6.8727L6.80513 3.80852C6.80513 3.80852 7.4463 3.09634 7.98754 3.08496Z"
-      fill={'#F77249'}
-    />
-  </svg>
-);
+const RedArrowUp: React.FC<Props> = ({ height = 16, width = 16, ...props }) => {
+  const isLight = useTheme().palette.isLight;
+
+  return (
+    <svg width={width} height={height} {...props} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        opacity="0.3"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16ZM7.98754 3.08496C8.54815 3.07318 9.22775 3.80852 9.22775 3.80852L11.7989 6.8727C12.1539 7.29578 12.0987 7.96901 11.6756 8.32401C11.2526 8.67902 10.6218 8.62383 10.2668 8.20076L9.08496 6.79228V12C9.08496 12.5523 8.55228 13.085 8 13.085C7.44772 13.085 6.87663 12.5523 6.87663 12L6.87663 6.79228L5.76607 8.1158C5.41107 8.53887 4.78031 8.59406 4.35724 8.23905C3.93416 7.88405 3.87898 7.29578 4.23398 6.8727L6.80513 3.80852C6.80513 3.80852 7.4463 3.09634 7.98754 3.08496Z"
+        fill={isLight ? colorPalette.red[700] : colorPalette.red[900]}
+      />
+    </svg>
+  );
+};
 
 export default RedArrowUp;

--- a/src/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
+++ b/src/components/AccountsSnapshot/components/SectionHeader/SectionHeader.tsx
@@ -78,5 +78,6 @@ const Subtitle = styled('div')(({ theme }) => ({
 
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
+    lineHeight: '24px',
   },
 }));

--- a/src/components/AccountsSnapshot/components/Transaction/MobileTransaction.stories.tsx
+++ b/src/components/AccountsSnapshot/components/Transaction/MobileTransaction.stories.tsx
@@ -40,14 +40,14 @@ CollapsedLightMode.parameters = {
   figma: {
     component: {
       0: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18738:221531',
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1996-37244',
         options: {
           componentStyle: {
             width: 327,
           },
           style: {
-            top: -20,
-            left: -40,
+            top: -11,
+            left: -14,
           },
         },
       },
@@ -59,14 +59,14 @@ ExpandedLightMode.parameters = {
   figma: {
     component: {
       0: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18738:221818',
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1996-40628',
         options: {
           componentStyle: {
             width: 327,
           },
           style: {
-            top: -20,
-            left: -40,
+            top: -11,
+            left: -14,
           },
         },
       },

--- a/src/components/AccountsSnapshot/components/Transaction/MobileTransaction.tsx
+++ b/src/components/AccountsSnapshot/components/Transaction/MobileTransaction.tsx
@@ -3,6 +3,7 @@ import MuiAccordion from '@mui/material/Accordion';
 import MuiAccordionDetails from '@mui/material/AccordionDetails';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import { colorPalette } from '@ses/styles/theme/colorPalette';
 import { DateTime } from 'luxon';
 import React, { useState } from 'react';
 import { useThemeContext } from '@/core/context/ThemeContext';
@@ -63,14 +64,14 @@ const MobileTransaction: React.FC<MobileTransactionProps> = ({
             <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path
                 d="M3.46205 4.43037C3.46205 4.43037 3.65393 4.43037 3.89062 4.43037C4.12733 4.43037 4.3192 4.43037 4.3192 4.43037V4.42894H6.46205C6.69875 4.42894 6.89062 4.23707 6.89062 4.00037C6.89062 3.76367 6.69875 3.57179 6.46205 3.57179H4.3192V3.57031C4.3192 3.57031 4.12733 3.57031 3.89062 3.57031C3.65393 3.57031 3.46205 3.57031 3.46205 3.57031V3.57179H1.3192C1.08251 3.57179 0.890625 3.76367 0.890625 4.00037C0.890625 4.23707 1.08251 4.42894 1.3192 4.42894H3.46205V4.43037Z"
-                fill={isLight ? '#231536' : '#D2D4EF'}
+                fill={isLight ? colorPalette.gray[900] : colorPalette.gray[600]}
               />
             </svg>
           ) : (
             <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path
                 d="M3.46205 6.57143C3.46205 6.80813 3.65393 7 3.89062 7C4.12733 7 4.3192 6.80813 4.3192 6.57143V4.42857H6.46205C6.69875 4.42857 6.89062 4.2367 6.89062 4C6.89062 3.76331 6.69875 3.57143 6.46205 3.57143H4.3192V1.42857C4.3192 1.19188 4.12733 1 3.89062 1C3.65393 1 3.46205 1.19188 3.46205 1.42857V3.57143H1.3192C1.08251 3.57143 0.890625 3.76331 0.890625 4C0.890625 4.2367 1.08251 4.42857 1.3192 4.42857H3.46205V6.57143Z"
-                fill={isLight ? '#231536' : '#D2D4EF'}
+                fill={isLight ? colorPalette.gray[900] : colorPalette.gray[600]}
               />
             </svg>
           )}
@@ -96,11 +97,9 @@ export default MobileTransaction;
 
 const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters elevation={0} square {...props} />)(
   ({ theme }) => ({
-    backgroundColor: theme.palette.isLight ? '#FBFBFB' : '#162530',
-    boxShadow: theme.palette.isLight
-      ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
-      : 'red',
-    borderRadius: 6,
+    backgroundColor: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.charcoal[900],
+    boxShadow: theme.palette.isLight ? theme.fusionShadows.modules : theme.fusionShadows.darkMode,
+    borderRadius: 8,
     position: 'relative',
     overflow: 'hidden',
 
@@ -113,7 +112,7 @@ const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters
 const TransactionSummary = styled((props: AccordionSummaryProps) => <MuiAccordionSummary {...props} />)<{
   expanded: boolean;
 }>(({ expanded }) => ({
-  padding: expanded ? '8px 16px 4px 8px' : '8px 16px 8px 8px',
+  padding: expanded ? '8px 16px 0 8px' : '8px 16px 8px 8px',
   transition: 'padding 0.1s ease-in-out',
   minHeight: 'auto',
 
@@ -128,7 +127,7 @@ const TransactionDetails = styled(MuiAccordionDetails)({
 
 const ArrowContainer = styled('div')({
   marginRight: 8,
-  paddingTop: 6,
+  paddingTop: 8,
 });
 
 const Content = styled('div')({
@@ -141,23 +140,20 @@ const Content = styled('div')({
 const Data = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  gap: 4,
 });
 
 const Name = styled('div')(({ theme }) => ({
   fontWeight: 500,
   fontSize: 12,
-  lineHeight: '15px',
-  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
+  lineHeight: '18px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
 }));
 
 const Date = styled('div')(({ theme }) => ({
-  fontWeight: 600,
-  fontSize: 10,
-  lineHeight: '12px',
-  letterSpacing: 1,
-  textTransform: 'uppercase',
-  color: theme.palette.isLight ? '#9FAFB9' : '#405361',
+  fontWeight: 500,
+  fontSize: 12,
+  lineHeight: '18px',
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
 }));
 
 const Value = styled('div')<{ isGreen: boolean }>(({ theme, isGreen }) => ({
@@ -167,10 +163,17 @@ const Value = styled('div')<{ isGreen: boolean }>(({ theme, isGreen }) => ({
   gap: 4,
   fontSize: 14,
   lineHeight: '22px',
-  marginTop: 5,
+  fontWeight: 600,
+  marginTop: 7,
 
   '&, & > span:first-of-type': {
-    color: isGreen ? '#1AAB9B' : theme.palette.isLight ? '#231536' : '#D2D4EF',
+    color: isGreen
+      ? theme.palette.isLight
+        ? theme.palette.colors.green[700]
+        : theme.palette.colors.green[900]
+      : theme.palette.isLight
+      ? theme.palette.colors.gray[900]
+      : theme.palette.colors.gray[50],
   },
 }));
 
@@ -181,12 +184,11 @@ const Sign = styled('span')({
 });
 
 const Currency = styled('span')(({ theme }) => ({
-  fontWeight: 600,
+  fontWeight: 500,
   fontSize: 12,
-  lineHeight: '15px',
-  letterSpacing: 1,
+  lineHeight: '18px',
   textTransform: 'uppercase',
-  color: theme.palette.isLight ? '#9FAFB9' : '#546978',
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
 }));
 
 const CollapseIndicator = styled('div')(({ theme }) => ({
@@ -199,7 +201,7 @@ const CollapseIndicator = styled('div')(({ theme }) => ({
   alignItems: 'center',
   justifyContent: 'center',
   borderRadius: '0 6px',
-  background: theme.palette.isLight ? '#EDEFFF' : '#3C3E64',
+  background: theme.palette.isLight ? theme.palette.colors.charcoal[100] : theme.palette.colors.charcoal[800],
 }));
 
 const TxContainer = styled('div')({
@@ -209,8 +211,10 @@ const TxContainer = styled('div')({
 const Divider = styled('div')(({ theme }) => ({
   marginLeft: 8,
   marginRight: 16,
-  margin: '8.5px 16px 8px 8px',
-  borderTop: `1px solid ${theme.palette.isLight ? '#D4D9E1' : '#405361'}`,
+  margin: '7px 16px 8px 8px',
+  borderTop: `1px solid ${
+    theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[800]
+  }`,
 }));
 
 const TargetContainer = styled('div')({
@@ -225,8 +229,9 @@ const TargetType = styled('div')(({ theme }) => ({
   justifyContent: 'center',
   width: '100%',
   fontSize: 12,
-  lineHeight: '15px',
-  color: theme.palette.isLight ? '#9FAFB9' : '#708390',
+  lineHeight: '18px',
+  fontWeight: 500,
+  color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
   paddingRight: 14,
 }));
 

--- a/src/components/AccountsSnapshot/components/Transaction/Transaction.tsx
+++ b/src/components/AccountsSnapshot/components/Transaction/Transaction.tsx
@@ -26,7 +26,7 @@ const Transaction: React.FC<TransactionProps> = ({
   amount,
   highlightPositiveAmounts = false,
 }) => {
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('table_834'));
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
   const isIncomingTransaction = amount > 0;
 
   return isMobile ? (
@@ -63,25 +63,31 @@ export default Transaction;
 
 const TransactionContainer = styled('div')(({ theme }) => ({
   display: 'grid',
-  gridTemplateColumns: '204px 15.7% max-content 1fr',
-  padding: '16px 32px 13px 20px',
+  gridTemplateColumns: '172px 15.7% max-content 1fr',
+  padding: '6px 24px 5px 12px',
 
-  [theme.breakpoints.up('desktop_1194')]: {
-    gridTemplateColumns: '295px 16% max-content 1fr',
-    padding: '16px 56px 14px 20px',
+  '&:not(:first-of-type)': {
+    borderTop: `1px solid ${
+      theme.palette.isLight ? theme.palette.colors.charcoal[100] : theme.palette.colors.charcoal[800]
+    }`,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    gridTemplateColumns: '218px 16% max-content 1fr',
+    padding: '8px 24px 5px 20px',
   },
 
   [theme.breakpoints.up('desktop_1280')]: {
-    gridTemplateColumns: '295px 16.1% max-content 1fr',
-    padding: '16px 64px 14px 20px',
+    gridTemplateColumns: '305px 16.1% max-content 1fr',
+    padding: '6px 40px 7px 20px',
   },
 
   [theme.breakpoints.up('desktop_1440')]: {
-    gridTemplateColumns: '295px 16.4% max-content 1fr',
-    padding: '16px 80px 14px 20px',
+    gridTemplateColumns: '280px 16.4% max-content 1fr',
+    padding: '8px 40px 5px 20px',
   },
 
   '&:hover': {
-    background: theme.palette.isLight ? '#F6F8F9' : '#1F2931',
+    background: theme.palette.isLight ? theme.palette.colors.gray[100] : '#292E38',
   },
 }));

--- a/src/components/AccountsSnapshot/components/Transaction/TransactionWalletInfo.tsx
+++ b/src/components/AccountsSnapshot/components/Transaction/TransactionWalletInfo.tsx
@@ -33,7 +33,7 @@ export default TransactionWalletInfo;
 const Container = styled('div')(({ theme }) => ({
   display: 'flex',
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     alignItems: 'center',
   },
 }));
@@ -47,12 +47,12 @@ const BlockiesContainer = styled('div')(({ theme }) => ({
   overflow: 'hidden',
   background: 'gray',
 
-  [theme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     marginTop: 0,
     marginRight: 16,
   },
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     marginRight: 15,
   },
 }));
@@ -62,7 +62,7 @@ const BlockieIdenticon = styled(Identicon)(({ theme }) => ({
   height: 24,
   minWidth: 24,
 
-  [theme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     width: 32,
     height: 32,
   },
@@ -77,13 +77,13 @@ const NameContainer = styled('div')({
 const Name = styled('div')(({ theme }) => ({
   fontWeight: 500,
   fontSize: 12,
-  lineHeight: '15px',
-  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
-  marginBottom: 4,
+  lineHeight: '18px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
     lineHeight: '22px',
+    marginBottom: 4,
   },
 }));
 
@@ -93,16 +93,16 @@ const AddressContainer = styled('div')({
 
 const Address = styled('a')(({ theme }) => ({
   fontSize: 12,
-  lineHeight: '15px',
-  color: '#447AFB',
-  marginRight: 17,
+  fontWeight: 500,
+  lineHeight: '18px',
+  color: theme.palette.colors.blue[700],
+  marginRight: 16,
 
-  [theme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     marginRight: 4,
   },
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 14,
-    lineHeight: '17px',
   },
 }));

--- a/src/components/AccountsSnapshot/components/Transaction/TransactionWalletInfo.tsx
+++ b/src/components/AccountsSnapshot/components/Transaction/TransactionWalletInfo.tsx
@@ -33,7 +33,7 @@ export default TransactionWalletInfo;
 const Container = styled('div')(({ theme }) => ({
   display: 'flex',
 
-  [theme.breakpoints.up('desktop_1024')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     alignItems: 'center',
   },
 }));
@@ -49,11 +49,10 @@ const BlockiesContainer = styled('div')(({ theme }) => ({
 
   [theme.breakpoints.up('tablet_768')]: {
     marginTop: 0,
-    marginRight: 16,
   },
 
   [theme.breakpoints.up('desktop_1024')]: {
-    marginRight: 15,
+    marginRight: 16,
   },
 }));
 
@@ -80,10 +79,15 @@ const Name = styled('div')(({ theme }) => ({
   lineHeight: '18px',
   color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
 
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 14,
+    fontWeight: 600,
+    lineHeight: '22px',
+  },
+
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
-    lineHeight: '22px',
-    marginBottom: 4,
+    lineHeight: '24px',
   },
 }));
 
@@ -104,5 +108,7 @@ const Address = styled('a')(({ theme }) => ({
 
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 14,
+    fontWeight: 600,
+    lineHeight: '22px',
   },
 }));

--- a/src/components/AccountsSnapshot/components/Transaction/segments/TransactionAmount.tsx
+++ b/src/components/AccountsSnapshot/components/Transaction/segments/TransactionAmount.tsx
@@ -23,23 +23,20 @@ const Wrapper = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-end',
-  justifyContent: 'center',
-  gap: 8,
+  justifyContent: 'flex-start',
+  gap: 16,
 
-  [theme.breakpoints.up('desktop_1194')]: {
-    marginTop: -1,
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 8,
+    justifyContent: 'center',
   },
 }));
 
 const Title = styled('div')(({ theme }) => ({
-  fontSize: 11,
-  lineHeight: '13px',
-  color: theme.palette.isLight ? '#546978' : '#708390',
-
-  [theme.breakpoints.up('desktop_1194')]: {
-    fontSize: 12,
-    lineHeight: '15px',
-  },
+  fontSize: 12,
+  fontWeight: 500,
+  lineHeight: '18px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
 }));
 
 const Amount = styled('div')<{ isGreen: boolean }>(({ theme, isGreen }) => ({
@@ -48,14 +45,22 @@ const Amount = styled('div')<{ isGreen: boolean }>(({ theme, isGreen }) => ({
   justifyContent: 'flex-end',
   gap: 4,
   fontSize: 14,
+  fontWeight: 600,
   lineHeight: '22px',
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
+    lineHeight: '24px',
   },
 
   '&, & > span:first-of-type': {
-    color: isGreen ? '#1AAB9B' : theme.palette.isLight ? '#231536' : '#D2D4EF',
+    color: isGreen
+      ? theme.palette.isLight
+        ? theme.palette.colors.green[700]
+        : theme.palette.colors.green[900]
+      : theme.palette.isLight
+      ? theme.palette.colors.gray[900]
+      : theme.palette.colors.gray[50],
   },
 }));
 
@@ -64,26 +69,22 @@ const Sign = styled('span')(({ theme }) => ({
   fontSize: 14,
   lineHeight: '17px',
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
-    lineHeight: '19px',
+    lineHeight: '24px',
   },
 }));
 
 const Currency = styled('span')(({ theme }) => ({
-  fontWeight: 600,
   fontSize: 12,
-  lineHeight: '15px',
-  letterSpacing: 1,
+  fontWeight: 500,
+  lineHeight: '18px',
   textTransform: 'uppercase',
-  color: theme.palette.isLight ? '#9FAFB9' : '#546978',
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
 
-  [theme.breakpoints.up('table_834')]: {
-    color: '#9FAFB9',
-  },
-
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 14,
-    lineHeight: '17px',
+    fontWeight: 600,
+    lineHeight: '22px',
   },
 }));

--- a/src/components/AccountsSnapshot/components/Transaction/segments/TransactionCounterParty.tsx
+++ b/src/components/AccountsSnapshot/components/Transaction/segments/TransactionCounterParty.tsx
@@ -19,21 +19,17 @@ export default TransactionCounterParty;
 const Wrapper = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-  gap: 8,
+  gap: 4,
   paddingRight: 10,
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     marginTop: -2,
   },
 }));
 
 const CounterPartyRole = styled('div')(({ theme }) => ({
-  fontSize: 11,
-  lineHeight: '13px',
-  color: theme.palette.isLight ? '#546978' : '#708390',
-
-  [theme.breakpoints.up('desktop_1194')]: {
-    fontSize: 12,
-    lineHeight: '15px',
-  },
+  fontSize: 12,
+  lineHeight: '18px',
+  fontWeight: 500,
+  color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
 }));

--- a/src/components/AccountsSnapshot/components/Transaction/segments/TransactionHeader.tsx
+++ b/src/components/AccountsSnapshot/components/Transaction/segments/TransactionHeader.tsx
@@ -33,11 +33,15 @@ const TransactionHeader: React.FC<TransactionHeaderProps> = ({ isIncomingTransac
 
 export default TransactionHeader;
 
-const Wrapper = styled('div')({
+const Wrapper = styled('div')(({ theme }) => ({
   display: 'flex',
-  gap: 16,
+  gap: 8,
   gridColumn: '1 / 3',
-});
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 16,
+  },
+}));
 
 const commonArrowStyles = {
   width: 24,
@@ -56,29 +60,26 @@ const RedArrow = styled(RedArrowUp)(() => ({
 const Content = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  gap: 4,
 });
 
 const Name = styled('div')(({ theme }) => ({
-  fontWeight: 500,
-  fontSize: 12,
-  lineHeight: '15px',
-  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
+  fontWeight: 600,
+  fontSize: 14,
+  lineHeight: '22px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
 
-  [theme.breakpoints.up('desktop_1194')]: {
-    fontWeight: 400,
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
-    lineHeight: '22px',
+    lineHeight: '24px',
   },
 }));
 
 const Date = styled('div')(({ theme }) => ({
-  fontWeight: 600,
+  fontWeight: 500,
   fontSize: 12,
-  lineHeight: '15px',
-  letterSpacing: 1,
+  lineHeight: '18px',
   textTransform: 'uppercase',
-  color: theme.palette.isLight ? '#9FAFB9' : '#405361',
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
 }));
 
 const ExtendedTxHash = styled(TxHash)({

--- a/src/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
@@ -32,7 +32,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ transactionHist
 export default TransactionHistory;
 
 const TransactionHistoryContainer = styled('div')({
-  marginTop: 24,
+  marginTop: 16,
 });
 
 const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters elevation={0} square {...props} />)({
@@ -40,46 +40,44 @@ const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters
 });
 
 const AccordionSummary = styled(MuiAccordionSummary)(({ theme }) => ({
-  backgroundColor: theme.palette.isLight ? '#FFFFFF' : '#1E2C37',
-  boxShadow: theme.palette.isLight
-    ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
-    : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
-  borderRadius: 6,
-  paddingLeft: 16,
+  backgroundColor: theme.palette.isLight ? 'white' : theme.palette.colors.charcoal[900],
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.modules : theme.fusionShadows.darkMode,
+  borderRadius: 8,
+  paddingLeft: 8,
   paddingRight: 8,
   minHeight: 'auto',
   zIndex: 1,
 
   '&.Mui-expanded': {
-    [theme.breakpoints.down('table_834')]: {
+    [theme.breakpoints.down('tablet_768')]: {
       borderEndEndRadius: 0,
       borderEndStartRadius: 0,
     },
   },
 
-  [theme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     paddingLeft: 24,
     paddingRight: 16,
   },
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     paddingRight: 25,
   },
 
   '& .MuiAccordionSummary-content': {
     fontWeight: 500,
     fontSize: 14,
-    lineHeight: '18px',
-    color: theme.palette.isLight ? '#231536' : '#D2D4EF',
+    lineHeight: 'normal',
+    color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
     marginTop: 8,
     marginBottom: 8,
 
-    [theme.breakpoints.up('table_834')]: {
+    [theme.breakpoints.up('tablet_768')]: {
       fontSize: 16,
       lineHeight: '19px',
     },
 
-    [theme.breakpoints.up('desktop_1194')]: {
+    [theme.breakpoints.up('desktop_1024')]: {
       marginTop: 10,
       marginBottom: 10,
     },

--- a/src/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/components/AccountsSnapshot/components/TransactionHistory/TransactionHistory.tsx
@@ -31,9 +31,17 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ transactionHist
 
 export default TransactionHistory;
 
-const TransactionHistoryContainer = styled('div')({
+const TransactionHistoryContainer = styled('div')(({ theme }) => ({
   marginTop: 16,
-});
+
+  [theme.breakpoints.up('tablet_768')]: {
+    marginTop: 24,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    marginTop: 32,
+  },
+}));
 
 const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters elevation={0} square {...props} />)({
   backgroundColor: 'transparent',
@@ -57,11 +65,7 @@ const AccordionSummary = styled(MuiAccordionSummary)(({ theme }) => ({
 
   [theme.breakpoints.up('tablet_768')]: {
     paddingLeft: 24,
-    paddingRight: 16,
-  },
-
-  [theme.breakpoints.up('desktop_1024')]: {
-    paddingRight: 25,
+    paddingRight: 24,
   },
 
   '& .MuiAccordionSummary-content': {
@@ -72,14 +76,9 @@ const AccordionSummary = styled(MuiAccordionSummary)(({ theme }) => ({
     marginTop: 8,
     marginBottom: 8,
 
-    [theme.breakpoints.up('tablet_768')]: {
-      fontSize: 16,
-      lineHeight: '19px',
-    },
-
     [theme.breakpoints.up('desktop_1024')]: {
-      marginTop: 10,
-      marginBottom: 10,
+      fontSize: 16,
+      lineHeight: 'normal',
     },
   },
 }));

--- a/src/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
+++ b/src/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
@@ -59,11 +59,11 @@ const TransactionListContainer = styled('div')(({ theme }) => ({
   position: 'relative',
 
   [theme.breakpoints.up('tablet_768')]: {
-    padding: '0 24px',
+    padding: '0 16px',
   },
 
   [theme.breakpoints.up('desktop_1024')]: {
-    padding: '0 32px',
+    padding: '0 24px',
   },
 
   [theme.breakpoints.up('desktop_1280')]: {
@@ -71,7 +71,7 @@ const TransactionListContainer = styled('div')(({ theme }) => ({
   },
 
   [theme.breakpoints.up('desktop_1440')]: {
-    padding: '0 56px',
+    padding: '0 32px',
   },
 
   '&:before': {
@@ -102,10 +102,8 @@ const TransactionCard = styled('div')(({ theme }) => ({
 
   [theme.breakpoints.up('tablet_768')]: {
     padding: 0,
-    background: theme.palette.isLight ? '#FBFBFB' : '#162530',
-    boxShadow: theme.palette.isLight
-      ? '0px 20px 40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
-      : 'none',
+    background: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.charcoal[900],
+    boxShadow: theme.palette.isLight ? theme.fusionShadows.modules : theme.fusionShadows.darkMode,
     gap: 0,
   },
 }));

--- a/src/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
+++ b/src/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
@@ -137,6 +137,15 @@ const GroupContainer = styled('div')(({ theme }) => ({
 const EmptyList = styled('div')(({ theme }) => ({
   display: 'flex',
   justifyContent: 'center',
-  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
+  fontSize: 16,
+  fontWeight: 600,
+  lineHeight: '24px',
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
   padding: '48px 0',
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontSize: 24,
+    fontWeight: 700,
+    lineHeight: '120%',
+  },
 }));

--- a/src/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
+++ b/src/components/AccountsSnapshot/components/TransactionList/TransactionList.tsx
@@ -58,11 +58,11 @@ const TransactionListContainer = styled('div')(({ theme }) => ({
   padding: 0,
   position: 'relative',
 
-  [theme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     padding: '0 24px',
   },
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     padding: '0 32px',
   },
 
@@ -84,23 +84,23 @@ const TransactionListContainer = styled('div')(({ theme }) => ({
     left: 0,
     opacity: 0.6,
     filter: 'blur(7.5px)',
-    borderRadius: '0px 0px 6px 6px',
+    borderRadius: '0px 0px 12px 12px',
     background: theme.palette.isLight
-      ? 'linear-gradient(0deg, rgba(219, 227, 237, 0.2), rgba(219, 227, 237, 0.2)), linear-gradient(180deg, rgba(190, 190, 190, 0.64) 0%, rgba(190, 190, 190, 0) 100%)'
-      : 'linear-gradient(0deg, rgba(3, 16, 32, 0.2), rgba(3, 16, 32, 0.2)), linear-gradient(180deg, rgba(0, 32, 202, 0.64) 0%, rgba(64, 85, 200, 0) 100%)',
+      ? 'linear-gradient(0deg, rgba(219, 227, 237, 0.20) 0%, rgba(219, 227, 237, 0.20) 100%), linear-gradient(180deg, rgba(190, 190, 190, 0.64) 0%, rgba(190, 190, 190, 0.00) 100%)'
+      : 'transparent',
   },
 }));
 
 const TransactionCard = styled('div')(({ theme }) => ({
-  borderRadius: '0 0 6px 6px',
-  background: theme.palette.isLight ? '#ECEFF9' : '#38364D',
+  borderRadius: '0 0 12px 12px',
+  background: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.slate[600],
   overflow: 'hidden',
   padding: 8,
   display: 'flex',
   flexDirection: 'column',
   gap: 8,
 
-  [theme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     padding: 0,
     background: theme.palette.isLight ? '#FBFBFB' : '#162530',
     boxShadow: theme.palette.isLight
@@ -115,7 +115,7 @@ const GroupContainer = styled('div')(({ theme }) => ({
   flexDirection: 'column',
   gap: 8,
 
-  [theme.breakpoints.down('table_834')]: {
+  [theme.breakpoints.down('tablet_768')]: {
     '&:not(:first-of-type)::before': {
       display: 'block',
       content: '""',
@@ -127,7 +127,7 @@ const GroupContainer = styled('div')(({ theme }) => ({
     },
   },
 
-  [theme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     gap: 0,
 
     '&:not(:first-of-type)': {

--- a/src/components/AccountsSnapshot/components/TxHash/TxHash.tsx
+++ b/src/components/AccountsSnapshot/components/TxHash/TxHash.tsx
@@ -27,10 +27,11 @@ const TxHashContainer = styled('div')({
 
 const Hash = styled('a')(({ theme }) => ({
   fontSize: 12,
-  lineHeight: '15px',
-  color: '#447AFB',
+  lineHeight: '18px',
+  color: theme.palette.colors.blue[700],
+  fontWeight: 500,
 
-  [theme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 14,
     lineHeight: '17px',
   },

--- a/src/components/AccountsSnapshot/components/TxHash/TxHash.tsx
+++ b/src/components/AccountsSnapshot/components/TxHash/TxHash.tsx
@@ -33,6 +33,7 @@ const Hash = styled('a')(({ theme }) => ({
 
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 14,
-    lineHeight: '17px',
+    fontWeight: 600,
+    lineHeight: '22px',
   },
 }));


### PR DESCRIPTION
## Ticket
https://trello.com/c/ktA33FyI/479-reskin-budget-statements-cu-ea-accounts-snapshot-tab

## Description
<!--- What is new in this PR -->

## What solved

- [X] Should update the View Transition History section (collapsed, expanded with all info) for light/dark mode. Desktop resolutions. 
- [X] Should update the View Transition History section (collapsed, expanded with all info) for light/dark mode. Small resolutions.
- [X] Should update the empty state in the View Transition History for light/dark mode. Desktop/Small resolutions
- [X] Should update the Total Core Unit Reserves title, info icon (status), tooltip, and brief description for light/dark mode. Desktop/Small resolutions. 
- [X] Should update the "Include Off-Chain Reserves" option (text + checkbox: selected/unselected) for light/dark mode. Desktop/Small resolutions. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
