### PR TITLE
[Reskin-476] Update the space between tables

### DIFF
--- a/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -218,7 +218,7 @@ const TableHead = styled('thead')(({ theme }) => ({
 }));
 
 const HeadCell = styled('th')<{ hasBorderRight?: boolean }>(({ hasBorderRight, theme }) => ({
-  padding: '24px 16px',
+  padding: '7.5px 16px',
   fontWeight: 600,
   fontSize: 16,
   lineHeight: '24px',

--- a/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
+++ b/src/components/AdvancedInnerTable/TransparencyCard/TransparencyCard.tsx
@@ -32,7 +32,6 @@ export const TransparencyCard: React.FC<Props> = ({
 
   return (
     <Container
-      style={{ marginTop: itemType === 'total' ? 24 : 0 }}
       className={`advance-table--transparency-card ${
         itemType === 'total' ? 'advance-table--transparency-card_total' : 'advance-table--transparency_item'
       }`}
@@ -84,7 +83,7 @@ const Container = styled('div')(({ theme }) => ({
   flexDirection: 'column',
   boxShadow: theme.palette.isLight ? theme.fusionShadows.graphShadow : theme.fusionShadows.darkMode,
   background: theme.palette.isLight ? '#FFFFFF' : theme.palette.colors.charcoal[900],
-  marginBottom: 24,
+  marginBottom: 16,
   borderRadius: '12px',
   [theme.breakpoints.between('mobile_375', 'tablet_768')]: {
     ':last-child': {

--- a/src/components/BudgetStatement/BudgetStatementActuals/useBudgetStatementActuals.ts
+++ b/src/components/BudgetStatement/BudgetStatementActuals/useBudgetStatementActuals.ts
@@ -44,7 +44,7 @@ export const useBudgetStatementActuals = (
     );
 
     if (!budgetStatement || !budgetStatement.budgetStatementWallet) return [];
-    console.log('budgetStatement', budgetStatement);
+
     budgetStatement.budgetStatementWallet.forEach((wallet) => {
       if (wallet.address) {
         if (!dict[wallet.address.toLowerCase()]) {

--- a/src/components/BudgetStatement/BudgetStatementForecast/BudgetStatementForecast.tsx
+++ b/src/components/BudgetStatement/BudgetStatementForecast/BudgetStatementForecast.tsx
@@ -63,5 +63,4 @@ export const BudgetStatementForecast: React.FC<BudgetStatementForecastProps> = (
 const Container = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  marginBottom: 64,
 });

--- a/src/components/BudgetStatement/BudgetStatementForecast/ForecastBreakdownSection/ForecastBreakdownSection.tsx
+++ b/src/components/BudgetStatement/BudgetStatementForecast/ForecastBreakdownSection/ForecastBreakdownSection.tsx
@@ -72,7 +72,6 @@ export default ForecastBreakdownSection;
 const Container = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  marginBottom: 64,
 });
 
 const BreakdownTableWrapper = styled('div')({

--- a/src/components/BudgetStatement/BudgetStatementForecast/HeaderWithIcon/HeaderWithIcon.tsx
+++ b/src/components/BudgetStatement/BudgetStatementForecast/HeaderWithIcon/HeaderWithIcon.tsx
@@ -151,9 +151,14 @@ const IconContainer = styled('div')(({ theme }) => ({
   width: 15,
   height: 15,
   display: 'flex',
-
+  cursor: 'pointer',
   '& path': {
     fill: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
+  },
+  ':hover': {
+    '& path': {
+      fill: theme.palette.isLight ? theme.palette.colors.slate[200] : theme.palette.colors.slate[100],
+    },
   },
 }));
 

--- a/src/components/BudgetStatement/BudgetStatementForecast/HeaderWithIcon/TooltipHeader.tsx
+++ b/src/components/BudgetStatement/BudgetStatementForecast/HeaderWithIcon/TooltipHeader.tsx
@@ -83,7 +83,6 @@ const MipNumber = styled('div')(({ theme }) => ({
 
 const ExternalLinkStyled = styled(ExternalLink)({
   fontSize: 14,
-
   display: 'flex',
   gap: 8,
 });

--- a/src/components/BudgetStatement/BudgetStatementForecast/TotalForecastSection/TotalForecastSection.tsx
+++ b/src/components/BudgetStatement/BudgetStatementForecast/TotalForecastSection/TotalForecastSection.tsx
@@ -42,7 +42,6 @@ export default TotalForecastSection;
 const Container = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  marginBottom: 64,
 });
 const Title = styled('div')<{
   marginBottom?: number;


### PR DESCRIPTION
## Ticket
https://trello.com/c/JUvtoViK/476-reskin-budget-statements-cu-ea-forecast-tab


## What solved

- [X] Should update the table style for light/dark mode. Desktop/Small resolutions.
- [X] Should update the values (forecast number, horizontal bar, budget cap number: status-> default, hover) for light/dark mode. Desktop resolutions.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
