### PR TITLE
[Reskin-470] Fix fonts issues relate with actuals tab

### DIFF
--- a/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -298,6 +298,7 @@ const StyledOpenModalTransparency = styled(OpenModalTransparency)(({ theme }) =>
     fontWeight: 400,
     paddingTop: 0,
     marginBottom: 0,
+    paddingBottom: 0,
     paddingLeft: 16,
     lineHeight: '16.94px',
     fontSize: 14,

--- a/src/components/AdvancedInnerTable/NumberCell/NumberCell.tsx
+++ b/src/components/AdvancedInnerTable/NumberCell/NumberCell.tsx
@@ -48,7 +48,7 @@ const Container = styled('div')<{ negative?: boolean; isIncome: boolean; bold?: 
       ? theme.palette.colors.gray[50]
       : theme.palette.colors.gray[400],
     [theme.breakpoints.up('tablet_768')]: {
-      padding: '10px 16px',
+      padding: '8px 16px',
     },
     [theme.breakpoints.up('desktop_1024')]: {
       fontSize: '16px',

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -25,6 +25,7 @@ interface BreadcrumbProps {
 }
 
 const MAX_ALLOWED_WIDTH = 250;
+const MAX_ALLOWED_WIDTH_MOBILE = 100;
 const THREE_DOTS_WIDTH = 60;
 
 const getTextWidth = (text: string, font: string) => {
@@ -261,7 +262,7 @@ const Segment = styled('div')<{ maxWidth?: number }>(({ theme, maxWidth }) => ({
   lineHeight: '24px',
   fontWeight: 600,
   color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.charcoal[100],
-  maxWidth: maxWidth || '100%',
+  maxWidth: MAX_ALLOWED_WIDTH_MOBILE,
 
   '& a': {
     color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[300],
@@ -294,6 +295,9 @@ const Segment = styled('div')<{ maxWidth?: number }>(({ theme, maxWidth }) => ({
     'svg path': {
       fill: theme.palette.isLight ? theme.palette.colors.slate[300] : theme.palette.colors.slate[200],
     },
+  },
+  [theme.breakpoints.up('tablet_768')]: {
+    maxWidth: maxWidth || '100%',
   },
 }));
 

--- a/src/components/BudgetStatement/BudgetStatementPager/BudgetStatementPager.tsx
+++ b/src/components/BudgetStatement/BudgetStatementPager/BudgetStatementPager.tsx
@@ -95,10 +95,13 @@ const PagerArrowStyled = styled(PagerArrows)(({ theme }) => ({
 
 const Label = styled('div')(({ theme }) => ({
   color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
-  fontSize: 20,
+  fontSize: 16,
   fontWeight: 700,
   lineHeight: '24px',
   marginLeft: 8,
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 20,
+  },
 }));
 
 const Spacer = styled('div')({


### PR DESCRIPTION
## Ticket
https://trello.com/c/smptd4rr/470-reskin-budget-statements-cu-ea-actual-tab

## What solved

- [X] Open actuals tab **Expected Output:** the font size of the date should be 16px in a mobile **Current Output:** the font size of the date is 20px 
- [X] Height should be 40px **Current Output:** height is more than 72px .
- [X] All the data should be center  in one line **Current Output:** The data in a line is not well aligned 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
