### PR TITLE
[Reskin-479] Reskin expense comparison table

### DIFF
--- a/src/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
+++ b/src/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.stories.tsx
@@ -1,7 +1,9 @@
+import { useMediaQuery } from '@mui/material';
 import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
 import type { RowProps } from '@/components/AdvanceTable/types';
 import { buildRow, buildRowWithoutOffChain } from '../../utils/expenseComparisonUtils';
 import ExpensesComparison from './ExpensesComparison';
+import type { Theme } from '@mui/material';
 import type { Meta } from '@storybook/react';
 import type { FigmaParams } from 'sb-figma-comparator';
 
@@ -17,30 +19,43 @@ const meta: Meta<typeof ExpensesComparison> = {
 };
 export default meta;
 
-const rows = [
-  buildRow(['May-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%', '221,504.00 DAI', '0.00%'], true, false),
-  buildRow(['Apr-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%', '171,500,00 DAI', '0.00%'], false, false),
-  buildRow(['Mar-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%', '288,300.00 DAI', '-0.07%'], false, false),
-  buildRow(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%', '681,304.25 DAI', '-0.03%'], false, true),
-] as RowProps[];
-
-const rowsWithoutOffChain = [
-  buildRowWithoutOffChain(['May-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%'], true, false),
-  buildRowWithoutOffChain(['Apr-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%'], false, false),
-  buildRowWithoutOffChain(['Mar-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%'], false, false),
-  buildRowWithoutOffChain(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%'], false, true),
-] as RowProps[];
-
 const [[LightMode, DarkMode]] = createThemeModeVariants(
   // it is required to initialized this way due the rows has react components and they can not be serialized
-  () => <ExpensesComparison hasOffChainData={true} rows={rows} />,
+  () => {
+    const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('desktop_1024'));
+    const rows = [
+      buildRow(['May-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%', '221,504.00 DAI', '0.00%'], true, false, {
+        isTablet,
+      }),
+      buildRow(['Apr-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%', '171,500,00 DAI', '0.00%'], false, false, {
+        isTablet,
+      }),
+      buildRow(['Mar-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%', '288,300.00 DAI', '-0.07%'], false, false, {
+        isTablet,
+      }),
+      buildRow(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%', '681,304.25 DAI', '-0.03%'], false, true, {
+        isTablet,
+      }),
+    ] as RowProps[];
+
+    return <ExpensesComparison hasOffChainData={true} rows={rows} />;
+  },
   [{}],
   false
 );
 export { LightMode, DarkMode };
 
 const [[WithoutOffChainLightMode, WithoutOffChainDarkMode]] = createThemeModeVariants(
-  () => <ExpensesComparison hasOffChainData={false} rows={rowsWithoutOffChain} />,
+  () => {
+    const rowsWithoutOffChain = [
+      buildRowWithoutOffChain(['May-2023', '221,503.00 DAI', '240,000.00 DAI', '8.35%'], true, false),
+      buildRowWithoutOffChain(['Apr-2023', '171,503.00 DAI', '170,000.00 DAI', '-0.88%'], false, false),
+      buildRowWithoutOffChain(['Mar-2023', '288,503.00 DAI', '280,000.00 DAI', '-2,95%'], false, false),
+      buildRowWithoutOffChain(['Totals', '681,509.00 DAI', '681,509.00 DAI', '1.25%'], false, true),
+    ] as RowProps[];
+
+    return <ExpensesComparison hasOffChainData={false} rows={rowsWithoutOffChain} />;
+  },
   [{}],
   false
 );
@@ -61,51 +76,51 @@ LightMode.parameters = {
           },
         },
       },
-      834: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18595%3A254055',
+      768: {
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1811-52620',
         options: {
           componentStyle: {
-            width: 770,
+            width: 704,
           },
           style: {
-            top: 0,
-            left: -40,
+            top: -2,
+            left: -14,
           },
         },
       },
-      1194: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18569%3A236220',
+      1024: {
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1734-45514',
         options: {
           componentStyle: {
-            width: 1130,
+            width: 960,
           },
           style: {
-            top: 0,
-            left: -40,
+            top: 1,
+            left: -14,
           },
         },
       },
       1280: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=18569%3A231450',
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1715-14695',
         options: {
           componentStyle: {
-            width: 1184,
+            width: 1200,
           },
           style: {
-            top: 0,
-            left: -40,
+            top: 1,
+            left: -14,
           },
         },
       },
       1440: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=19847:227753',
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1679-86978',
         options: {
           componentStyle: {
             width: 1312,
           },
           style: {
-            top: 0,
-            left: -40,
+            top: 1,
+            left: -14,
           },
         },
       },
@@ -116,51 +131,51 @@ LightMode.parameters = {
 WithoutOffChainLightMode.parameters = {
   figma: {
     component: {
-      834: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20802:265303',
+      768: {
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1811-57165',
         options: {
           componentStyle: {
-            width: 770,
+            width: 704,
           },
           style: {
-            top: 58,
-            left: -40,
+            top: 70,
+            left: 0,
           },
         },
       },
-      1194: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20802:265228',
+      1024: {
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1734-51132',
         options: {
           componentStyle: {
-            width: 1130,
+            width: 960,
           },
           style: {
-            top: 58,
-            left: -40,
+            top: 70,
+            left: 0,
           },
         },
       },
       1280: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20802:265153',
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1724-19230',
         options: {
           componentStyle: {
-            width: 1184,
+            width: 1200,
           },
           style: {
-            top: 58,
-            left: -40,
+            top: 70,
+            left: 0,
           },
         },
       },
       1440: {
-        component: 'https://www.figma.com/file/pyaYEjcwF2b5uf9y0vIfIy/SES-Dashboard?type=design&node-id=20802:265078',
+        component: 'https://www.figma.com/design/iLyzLutlWLu6Yf8tFdlM6T/Fusion%2FPowerhouse?node-id=1714-18409',
         options: {
           componentStyle: {
             width: 1312,
           },
           style: {
-            top: 58,
-            left: -40,
+            top: 70,
+            left: 0,
           },
         },
       },

--- a/src/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
+++ b/src/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
@@ -1,41 +1,50 @@
-import { styled } from '@mui/material';
+import { styled, useMediaQuery } from '@mui/material';
 import AdvanceTable from '@/components/AdvanceTable/AdvanceTable';
 import type { RowProps } from '@/components/AdvanceTable/types';
 import SectionHeader from '../SectionHeader/SectionHeader';
-import { EXPENSES_COMPARISON_TABLE_HEADER, EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN } from './headers';
+import { expensesComparisonTableHeader, expensesComparisonTableHeaderWithoutOffChain } from './headers';
+import type { Theme } from '@mui/material';
 
 interface ExpensesComparisonProps {
   rows: RowProps[];
   hasOffChainData: boolean;
 }
 
-const ExpensesComparison: React.FC<ExpensesComparisonProps> = ({ rows, hasOffChainData }) => (
-  <div>
-    <SectionHeader
-      title="Reported Expenses Comparison"
-      subtitle={'Reported actuals compared to expense and revenue transactions.'}
-      tooltip={
-        'Understand the differences between reported and net transactions. Easily spot variations \
-          and improve financial tracking for comprehensive expense  and revenue analysis.'
-      }
-      level="h2"
-    />
+const ExpensesComparison: React.FC<ExpensesComparisonProps> = ({ rows, hasOffChainData }) => {
+  const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('desktop_1024'));
 
-    <TableWrapper>
-      <StyledTable
-        header={hasOffChainData ? EXPENSES_COMPARISON_TABLE_HEADER : EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN}
-        body={rows}
+  return (
+    <div>
+      <SectionHeader
+        title="Reported Expenses Comparison"
+        subtitle={'Reported actuals compared to expense and revenue transactions.'}
+        tooltip={
+          'Understand the differences between reported and net transactions. Easily spot variations \
+            and improve financial tracking for comprehensive expense  and revenue analysis.'
+        }
+        level="h2"
       />
-    </TableWrapper>
-  </div>
-);
+
+      <TableWrapper>
+        <AdvanceTable
+          header={
+            hasOffChainData
+              ? expensesComparisonTableHeader({ isTablet })
+              : expensesComparisonTableHeaderWithoutOffChain({ isTablet })
+          }
+          body={rows}
+        />
+      </TableWrapper>
+    </div>
+  );
+};
 
 export default ExpensesComparison;
 
-const TableWrapper = styled('div')({
+const TableWrapper = styled('div')(({ theme }) => ({
   marginTop: 24,
-});
 
-const StyledTable = styled(AdvanceTable)(({ theme }) => ({
-  background: theme.palette.isLight ? '#FFFFFF' : '#1E2C37',
+  [theme.breakpoints.up('tablet_768')]: {
+    marginTop: 16,
+  },
 }));

--- a/src/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
+++ b/src/components/AccountsSnapshot/components/ExpensesComparison/ExpensesComparison.tsx
@@ -30,7 +30,7 @@ const ExpensesComparison: React.FC<ExpensesComparisonProps> = ({ rows, hasOffCha
           header={
             hasOffChainData
               ? expensesComparisonTableHeader({ isTablet })
-              : expensesComparisonTableHeaderWithoutOffChain({ isTablet })
+              : expensesComparisonTableHeaderWithoutOffChain()
           }
           body={rows}
         />

--- a/src/components/AccountsSnapshot/components/ExpensesComparison/headers.tsx
+++ b/src/components/AccountsSnapshot/components/ExpensesComparison/headers.tsx
@@ -2,6 +2,7 @@ import { styled, useMediaQuery } from '@mui/material';
 import InfoOutlined from 'public/assets/svg/info_outlined.svg';
 import type { RowProps } from '@/components/AdvanceTable/types';
 import SESTooltip from '@/components/SESTooltip/SESTooltip';
+import type { BreakpointOptions } from '../../utils/expenseComparisonUtils';
 import type { Theme } from '@mui/material';
 
 const HeaderWithIcon = styled('div')(({ theme }) => ({
@@ -15,17 +16,21 @@ const HeaderWithIcon = styled('div')(({ theme }) => ({
   },
 }));
 
-const InfoWrapper = styled('div')({
+const InfoWrapper = styled('div')(({ theme }) => ({
   display: 'flex',
   cursor: 'pointer',
-});
+
+  [theme.breakpoints.up('tablet_768')]: {
+    paddingLeft: 4,
+  },
+}));
 
 const NetExpenseTransactions = () => {
   const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
 
   return (
     <HeaderWithIcon>
-      Net {isMobile ? 'Exp' : 'Expense'} transactions
+      Net {isMobile ? 'Exp' : 'Expense'} Transactions
       <SESTooltip
         content={
           'On-Chain view offers valuable insights into On-Chain dynamics, but excludes external (off-chain) transactions.'
@@ -42,197 +47,204 @@ const NetExpenseTransactions = () => {
   );
 };
 
-export const EXPENSES_COMPARISON_TABLE_HEADER = [
-  {
-    cells: [
-      {
-        value: 'Reported actuals',
-        rowSpan: 2,
-        colSpan: 2,
-        border: {
-          right: true,
+export const expensesComparisonTableHeader = (breakpointOptions: BreakpointOptions) =>
+  [
+    {
+      cells: [
+        {
+          value: 'Reported Actuals',
+          rowSpan: 2,
+          colSpan: 2,
+          border: {
+            right: true,
+          },
+          alignment: 'right',
         },
-        alignment: 'right',
-      },
-      {
-        value: 'Net Expense Transactions',
-        defaultRenderer: 'boldText',
-        colSpan: 4,
-        border: {
-          bottom: true,
+        {
+          value: 'Net Expense Transactions',
+          defaultRenderer: 'boldText',
+          colSpan: 4,
+          border: {
+            bottom: true,
+          },
+          cellPadding: {
+            tablet_768: '12px 16px 15px',
+            desktop_1024: '13px 16px',
+          },
+          alignment: 'center',
         },
-        cellPadding: {
-          tablet_768: '16px 16px 18px',
-          desktop_1024: '16px',
-        },
-        alignment: 'center',
-      },
-    ],
-  },
-  {
-    cellPadding: {
-      tablet_768: '23px 8px 23px 0',
-      desktop_1024: '23px 16px',
+      ],
     },
-    cells: [
-      {
-        isHidden: true,
-        border: {
-          right: true,
-        },
-        width: {
-          desktop_1024: '16.463%',
-          tablet_768: '12%',
-        },
+    {
+      cellPadding: {
+        tablet_768: '18px 8px 18px 0',
+        desktop_1024: '18px 16px',
       },
-      {
-        isHidden: true,
-        border: {
-          right: true,
+      cells: [
+        {
+          isHidden: true,
+          border: {
+            right: true,
+          },
+          width: {
+            desktop_1280: '16.5%',
+            desktop_1024: '14.375%',
+            tablet_768: '13.5%',
+          },
         },
-        alignment: 'right',
-        width: {
-          desktop_1024: '16.463%',
-          tablet_768: '18.463%',
+        {
+          isHidden: true,
+          border: {
+            right: true,
+          },
+          alignment: 'right',
+          width: {
+            desktop_1280: '16.42%',
+            desktop_1024: '18.33%',
+            tablet_768: '17.6%',
+          },
         },
+        {
+          value: (
+            <HeaderWithIcon>
+              On-chain only
+              <SESTooltip
+                content={
+                  'On-Chain view offers valuable insights into On-Chain dynamics, but excludes external (off-chain) transactions.'
+                }
+                placement="bottom-start"
+                enterTouchDelay={0}
+                leaveTouchDelay={15000}
+              >
+                <InfoWrapper>
+                  <InfoOutlined width={16} height={16} />
+                </InfoWrapper>
+              </SESTooltip>
+            </HeaderWithIcon>
+          ),
+          alignment: 'right',
+          width: {
+            desktop_1280: '22%',
+            desktop_1024: '20.83%',
+            tablet_768: '22.5%',
+          },
+          cellPadding: {
+            tablet_768: '18px 11px 18px 0',
+            desktop_1024: '18px 14px 18px 6px',
+          },
+        },
+        {
+          value: breakpointOptions.isTablet ? 'Diff' : 'Difference',
+          alignment: 'right',
+          width: {
+            desktop_1280: '11.25%',
+            desktop_1024: '12.81%',
+            tablet_768: '11.9%',
+          },
+          border: {
+            right: true,
+          },
+        },
+        {
+          value: (
+            <HeaderWithIcon>
+              {breakpointOptions.isTablet ? 'Incl.' : 'Including'} off-chain
+              <SESTooltip
+                content={'Enhance financial tracking and expense analysis by including off-chain transactions.'}
+                placement="bottom-start"
+                enterTouchDelay={0}
+                leaveTouchDelay={15000}
+              >
+                <InfoWrapper>
+                  <InfoOutlined width={16} height={16} />
+                </InfoWrapper>
+              </SESTooltip>
+            </HeaderWithIcon>
+          ),
+          alignment: 'right',
+          width: {
+            desktop_1280: '22%',
+            desktop_1024: '20.83%',
+            tablet_768: '22.5%',
+          },
+          cellPadding: {
+            tablet_768: '18px 11px 18px 0',
+            desktop_1024: '18px 14px 18px 6px',
+          },
+        },
+        {
+          value: breakpointOptions.isTablet ? 'Diff' : 'Difference',
+          alignment: 'right',
+        },
+      ],
+      border: {
+        bottom: true,
       },
-      {
-        value: (
-          <HeaderWithIcon>
-            On-chain only
-            <SESTooltip
-              content={
-                'On-Chain view offers valuable insights into On-Chain dynamics, but excludes external (off-chain) transactions.'
-              }
-              placement="bottom-start"
-              enterTouchDelay={0}
-              leaveTouchDelay={15000}
-            >
-              <InfoWrapper>
-                <InfoOutlined width={16} height={16} />
-              </InfoWrapper>
-            </SESTooltip>
-          </HeaderWithIcon>
-        ),
-        alignment: 'right',
-        width: {
-          desktop_1024: '22.027%',
-          tablet_768: '19.5%',
-        },
-        cellPadding: {
-          tablet_768: '23px 13px 23px 0',
-          desktop_1024: '23px 16px',
-        },
-      },
-      {
-        value: 'Difference',
-        alignment: 'right',
-        width: {
-          desktop_1024: '11.28%',
-          tablet_768: '11.28%',
-        },
-        border: {
-          right: true,
-        },
-      },
-      {
-        value: (
-          <HeaderWithIcon>
-            Including off-chain
-            <SESTooltip
-              content={'Enhance financial tracking and expense analysis by including off-chain transactions.'}
-              placement="bottom-start"
-              enterTouchDelay={0}
-              leaveTouchDelay={15000}
-            >
-              <InfoWrapper>
-                <InfoOutlined width={16} height={16} />
-              </InfoWrapper>
-            </SESTooltip>
-          </HeaderWithIcon>
-        ),
-        alignment: 'right',
-        width: {
-          desktop_1024: '22.027%',
-          tablet_768: '26%',
-        },
-        cellPadding: {
-          tablet_768: '23px 13px 23px 0',
-          desktop_1024: '23px 16px',
-        },
-      },
-      {
-        value: 'Difference',
-        alignment: 'right',
-      },
-    ],
-    border: {
-      bottom: true,
     },
-  },
-] as RowProps[];
+  ] as RowProps[];
 
-export const EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN = [
-  {
-    cellPadding: {
-      tablet_768: '23px 8px 23px 0',
-      desktop_1024: '23px 16px',
+export const expensesComparisonTableHeaderWithoutOffChain = () =>
+  [
+    {
+      cellPadding: {
+        tablet_768: '20px 16px 18px 0',
+        desktop_1024: '18px 16px',
+      },
+      cells: [
+        {
+          isHidden: true,
+          border: {
+            right: true,
+          },
+          width: {
+            desktop_1440: '16.5%',
+            desktop_1280: '18%',
+            desktop_1024: '22.5%',
+            tablet_768: '18.7%',
+          },
+        },
+        {
+          isHidden: true,
+          border: {
+            right: true,
+          },
+          alignment: 'right',
+          width: {
+            desktop_1440: '16.5%',
+            desktop_1280: '18%',
+            desktop_1024: '22.5%',
+            tablet_768: '24.3%',
+          },
+        },
+        {
+          value: 'Reported Actuals',
+          colSpan: 2,
+          border: {
+            right: true,
+          },
+          alignment: 'right',
+        },
+        {
+          value: <NetExpenseTransactions />,
+          alignment: 'right',
+          width: {
+            desktop_1440: '33.5%',
+            desktop_1280: '32%',
+            desktop_1024: '27.5%',
+            tablet_768: '38.2%',
+          },
+          cellPadding: {
+            tablet_768: '20px 13px 18px 0',
+            desktop_1024: '17px 14px 18px 0',
+          },
+        },
+        {
+          value: 'Difference',
+          alignment: 'right',
+        },
+      ],
+      border: {
+        bottom: true,
+      },
     },
-    cells: [
-      {
-        isHidden: true,
-        border: {
-          right: true,
-        },
-        width: {
-          desktop_1440: '16.5%',
-          desktop_1280: '18.25%',
-          desktop_1024: '19.1%',
-          tablet_768: '25.5%',
-        },
-      },
-      {
-        isHidden: true,
-        border: {
-          right: true,
-        },
-        alignment: 'right',
-        width: {
-          desktop_1440: '16.5%',
-          desktop_1280: '18.25%',
-          desktop_1024: '19.2%',
-          tablet_768: '25.4%',
-        },
-      },
-      {
-        value: 'Reported actuals',
-        colSpan: 2,
-        border: {
-          right: true,
-        },
-        alignment: 'right',
-      },
-      {
-        value: <NetExpenseTransactions />,
-        alignment: 'right',
-        width: {
-          desktop_1440: '33.5%',
-          desktop_1280: '31.8%',
-          desktop_1024: '30.8%',
-          tablet_768: '33.5%',
-        },
-        cellPadding: {
-          tablet_768: '23px 13px 23px 0',
-          desktop_1024: '23px 16px',
-        },
-      },
-      {
-        value: 'difference',
-        alignment: 'right',
-      },
-    ],
-    border: {
-      bottom: true,
-    },
-  },
-] as RowProps[];
+  ] as RowProps[];

--- a/src/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -1,13 +1,13 @@
-import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { useMediaQuery } from '@mui/material';
 import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
 import { DateTime } from 'luxon';
 import { useMemo, useState } from 'react';
 import { buildExpensesComparisonRows } from './utils/expenseComparisonUtils';
 import { getReserveAccounts, transactionSort } from './utils/reserveUtils';
+import type { Theme } from '@mui/material';
 import type { Snapshots, Token } from '@ses/core/models/dto/snapshotAccountDTO';
 
 const useAccountsSnapshot = (snapshot: Snapshots) => {
-  const { isLight } = useThemeContext();
   const [isEnabled] = useFlagsActive();
 
   // TODO: the `setSelectedTo` is not used yet, but it will be used to filter the data
@@ -93,13 +93,17 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
     [selectedToken, snapshot.actualsComparison]
   );
 
+  const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('desktop_1024'));
+
   const expensesComparisonRows = useMemo(
-    () => buildExpensesComparisonRows(actualsComparison, selectedToken, snapshot.period, hasOffChainData),
-    [actualsComparison, hasOffChainData, selectedToken, snapshot.period]
+    () =>
+      buildExpensesComparisonRows(actualsComparison, selectedToken, snapshot.period, hasOffChainData, {
+        isTablet,
+      }),
+    [actualsComparison, hasOffChainData, isTablet, selectedToken, snapshot.period]
   );
   const isCoreUnit = snapshot.ownerType === 'CoreUnit';
   return {
-    isLight,
     enableCurrencyPicker,
     includeOffChain,
     toggleIncludeOffChain,

--- a/src/components/AccountsSnapshot/useAccountsSnapshot.tsx
+++ b/src/components/AccountsSnapshot/useAccountsSnapshot.tsx
@@ -94,7 +94,6 @@ const useAccountsSnapshot = (snapshot: Snapshots) => {
   );
 
   const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('desktop_1024'));
-
   const expensesComparisonRows = useMemo(
     () =>
       buildExpensesComparisonRows(actualsComparison, selectedToken, snapshot.period, hasOffChainData, {

--- a/src/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
+++ b/src/components/AccountsSnapshot/utils/expenseComparisonUtils.tsx
@@ -1,29 +1,37 @@
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
+import { colorPalette } from '@ses/styles/theme/colorPalette';
 import { DateTime } from 'luxon';
 import type { CardRenderProps, RowProps } from '@/components/AdvanceTable/types';
 import ExpensesComparisonRowCard from '../components/Cards/ExpensesComparisonRowCard/ExpensesComparisonRowCard';
 import {
-  EXPENSES_COMPARISON_TABLE_HEADER,
-  EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN,
+  expensesComparisonTableHeader,
+  expensesComparisonTableHeaderWithoutOffChain,
 } from '../components/ExpensesComparison/headers';
 import type { ActualsComparison, Token } from '@ses/core/models/dto/snapshotAccountDTO';
 
+export type BreakpointOptions = {
+  isTablet: boolean;
+};
+
 const RenderCurrentMonthRow: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { isLight } = useThemeContext();
-  return <tr style={{ background: isLight ? 'rgba(236, 239, 249, 0.5)' : '#283341' }}>{children}</tr>;
+  return <tr style={{ background: isLight ? colorPalette.slate[50] : '#21262F' }}>{children}</tr>;
 };
 
 export const buildRow = (
   values: [string, string, string, string, string, string],
   isCurrentMonth = false,
-  isTotal = false
-): RowProps =>
-  ({
+  isTotal = false,
+  breakpointOptions: BreakpointOptions
+): RowProps => {
+  const EXPENSES_COMPARISON_TABLE_HEADER = expensesComparisonTableHeader(breakpointOptions);
+
+  return {
     ...(isCurrentMonth ? { render: RenderCurrentMonthRow } : {}),
     cellPadding: {
-      tablet_768: isTotal ? '17px 8px 18.5px' : '18.5px 8px',
-      desktop_1024: '17.4px 16px',
+      tablet_768: isTotal ? '15px 8px 16px' : '16px 8px',
+      desktop_1024: isTotal ? '15px 16px 16px' : '15px 16px',
     },
     rowToCardConfig: {
       render: (props: CardRenderProps) => (
@@ -54,42 +62,45 @@ export const buildRow = (
       },
       {
         value: values[1],
-        defaultRenderer: 'number',
+        defaultRenderer: isTotal ? 'boldText' : 'number',
         inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[1],
       },
       {
         value: values[2],
-        defaultRenderer: 'number',
+        defaultRenderer: isTotal ? 'boldText' : 'number',
         inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[2],
       },
       {
         value: values[3],
-        defaultRenderer: 'number',
+        defaultRenderer: isTotal ? 'boldText' : 'number',
         inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[3],
       },
       {
         value: values[4],
-        defaultRenderer: 'number',
+        defaultRenderer: isTotal ? 'boldText' : 'number',
         inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[4],
       },
       {
         value: values[5],
-        defaultRenderer: 'number',
+        defaultRenderer: isTotal ? 'boldText' : 'number',
         inherit: EXPENSES_COMPARISON_TABLE_HEADER[1].cells[5],
       },
     ],
-  } as RowProps);
+  } as RowProps;
+};
 
 export const buildRowWithoutOffChain = (
   values: [string, string, string, string],
   isCurrentMonth = false,
   isTotal = false
-): RowProps =>
-  ({
+): RowProps => {
+  const EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN = expensesComparisonTableHeaderWithoutOffChain();
+
+  return {
     ...(isCurrentMonth ? { render: RenderCurrentMonthRow } : {}),
     cellPadding: {
-      tablet_768: isTotal ? '17px 8px 18.5px' : '18.5px 8px',
-      desktop_1024: '17.4px 16px',
+      tablet_768: isTotal ? '15px 16px 16px' : 16,
+      desktop_1024: isTotal ? '15px 16px 16px' : '15px 16px',
     },
     rowToCardConfig: {
       render: (props: CardRenderProps) => (
@@ -120,21 +131,22 @@ export const buildRowWithoutOffChain = (
       },
       {
         value: values[1],
-        defaultRenderer: 'number',
+        defaultRenderer: isTotal ? 'boldText' : 'number',
         inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[1],
       },
       {
         value: values[2],
-        defaultRenderer: 'number',
+        defaultRenderer: isTotal ? 'boldText' : 'number',
         inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[3],
       },
       {
         value: values[3],
-        defaultRenderer: 'number',
+        defaultRenderer: isTotal ? 'boldText' : 'number',
         inherit: EXPENSES_COMPARISON_TABLE_HEADER_WITHOUT_OFF_CHAIN[0].cells[4],
       },
     ],
-  } as RowProps);
+  } as RowProps;
+};
 
 export const formatExpenseMonth = (month: string): string => DateTime.fromFormat(month, 'yyyy/MM').toFormat('MMM-yyyy');
 
@@ -184,7 +196,8 @@ export const buildExpensesComparisonRows = (
   values: ActualsComparison[],
   currency: Token,
   currentPeriod: string,
-  hasOffChainData: boolean
+  hasOffChainData: boolean,
+  breakpointOptions: BreakpointOptions
 ): RowProps[] => {
   const rows: RowProps[] = [];
   if (hasOffChainData) {
@@ -199,7 +212,8 @@ export const buildExpensesComparisonRows = (
           formatExpenseDifference((comparison.netExpenses.offChainIncluded.difference || 0) * 100),
         ],
         comparison.month === currentPeriod,
-        false
+        false,
+        breakpointOptions
       );
       rows.push(row);
     });
@@ -217,7 +231,8 @@ export const buildExpensesComparisonRows = (
             formatExpenseDifference(totals.netExpenses.offChainIncluded.difference || 0),
           ],
           false,
-          true
+          true,
+          breakpointOptions
         )
       );
     }

--- a/src/components/AdvanceTable/BuiltIn/Cells/BasicTHCell.tsx
+++ b/src/components/AdvanceTable/BuiltIn/Cells/BasicTHCell.tsx
@@ -17,11 +17,9 @@ export default BasicTHCell;
 
 const TH = styled(BasicCell, {
   shouldForwardProp: () => true,
-})(() => ({
-  textTransform: 'uppercase',
-  letterSpacing: 1,
+})(({ theme }) => ({
+  fontSize: 16,
   fontWeight: 600,
-  fontSize: 12,
-  lineHeight: '15px',
-  color: '#708390',
+  lineHeight: '24px',
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
 }));

--- a/src/components/AdvanceTable/BuiltIn/Cells/BoldTextCell.tsx
+++ b/src/components/AdvanceTable/BuiltIn/Cells/BoldTextCell.tsx
@@ -20,12 +20,12 @@ const BoldCell = styled(BasicCell, {
   textTransform: 'none',
   fontWeight: 700,
   fontSize: 14,
-  lineHeight: '17px',
+  lineHeight: '22px',
   letterSpacing: 0,
-  color: theme.palette.isLight ? '#231536' : '#FFFFFF',
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
 
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
-    lineHeight: '19px',
+    lineHeight: '24px',
   },
 }));

--- a/src/components/AdvanceTable/BuiltIn/Cells/NumberCell.tsx
+++ b/src/components/AdvanceTable/BuiltIn/Cells/NumberCell.tsx
@@ -26,15 +26,13 @@ export default NumberCell;
 const Cell = styled(BasicCell, {
   shouldForwardProp: (prop) => prop !== 'isBold',
 })<{ isBold: boolean }>(({ theme, isBold }) => ({
-  fontWeight: isBold ? 700 : 400,
+  fontWeight: isBold ? 700 : 600,
   fontSize: 14,
-  lineHeight: '17px',
-  color: theme.palette.isLight ? '#231536' : '#FFFFFF',
-  letterSpacing: 0.3,
-  fontFeatureSettings: "'tnum' on, 'lnum' on",
+  lineHeight: '22px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
 
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
-    lineHeight: '19px',
+    lineHeight: '24px',
   },
 }));

--- a/src/components/AdvanceTable/BuiltIn/Cells/TextCell.tsx
+++ b/src/components/AdvanceTable/BuiltIn/Cells/TextCell.tsx
@@ -18,11 +18,11 @@ const Cell = styled(BasicCell, {
   shouldForwardProp: () => true,
 })(({ theme }) => ({
   fontSize: 14,
-  lineHeight: '17px',
-  color: theme.palette.isLight ? '#231536' : '#FFFFFF',
+  lineHeight: '22px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
 
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
-    lineHeight: '22px',
+    lineHeight: '24px',
   },
 }));

--- a/src/components/AdvanceTable/utils.ts
+++ b/src/components/AdvanceTable/utils.ts
@@ -1,10 +1,11 @@
+import { colorPalette } from '@ses/styles/theme/colorPalette';
 import lightTheme from '@ses/styles/theme/themes';
 import { isBorder } from './types';
 import type { Border, BorderConfig, GenericCell, CellPadding } from './types';
 
 const getBorderValue = (border: Border | boolean, isLight: boolean) => {
   const defaultWidth = 1;
-  const defaultColor = isLight ? '#D4D9E1' : '#405361';
+  const defaultColor = isLight ? colorPalette.charcoal[100] : colorPalette.charcoal[800];
   const defaultStyle = 'solid';
 
   if (typeof border === 'boolean') {


### PR DESCRIPTION
## Ticket
https://trello.com/c/ktA33FyI/479-reskin-budget-statements-cu-ea-accounts-snapshot-tab

## Description
Applied the reskin to the Expense Comparison section of the snapshots

## What solved

- [X] Should update the Reported Expense Comparison title, info icon with tooltip and the description below for light/dark mode. Desktop/Small resolutions. 
- [X] Should update the table styles (collapsed/expanded) with content for light/dark mode. Small resolutions
- [X] Should update the table styles with content for light/dark mode. Desktop resolutions.
- [X] Should update the Additional Notes section for light/dark mode. Desktop/Small resolutions.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
![Screenshot_896](https://github.com/user-attachments/assets/f4aa4e49-297b-4e30-ac4d-1420ca548d6f)

