### PR TITLE
[Reskin-478] Add icon to difference columns

### DIFF
--- a/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -45,7 +45,7 @@ export const AdvancedInnerTable: React.FC<AdvancedInnerTableProps> = ({
             className={
               value === 'Total' || value === 'Subtotal'
                 ? 'advanced-table__cell-row--category'
-                : column.header === 'Comments'
+                : column.header === 'Comments' || column.header === 'Reason(s)'
                 ? 'advanced-table__cell-row--category--comments'
                 : ''
             }

--- a/src/components/BudgetStatement/BudgetStatementMkrVesting/BudgetStatementMkrVesting.tsx
+++ b/src/components/BudgetStatement/BudgetStatementMkrVesting/BudgetStatementMkrVesting.tsx
@@ -1,6 +1,8 @@
 import { styled } from '@mui/material';
+import Info from 'public/assets/svg/info_outlined.svg';
 import React from 'react';
 import { AdvancedInnerTable } from '@/components/AdvancedInnerTable/AdvancedInnerTable';
+import SESTooltip from '@/components/SESTooltip/SESTooltip';
 import { TransparencyEmptyTable } from '@/views/CoreUnitBudgetStatement/components/Placeholders/TransparencyEmptyTable';
 import MkrVestingInfo from './MkrVestingInfo';
 import MkrVestingTotalFTE from './MkrVestingTotalFTE';
@@ -18,7 +20,7 @@ interface TransparencyMkrVestingProps {
   resource: ResourceType;
 }
 
-export const TransparencyMkrVesting: React.FC<TransparencyMkrVestingProps> = ({
+export const BudgetStatementMkrVesting: React.FC<TransparencyMkrVestingProps> = ({
   currentMonth,
   budgetStatements,
   longCode,
@@ -32,13 +34,26 @@ export const TransparencyMkrVesting: React.FC<TransparencyMkrVestingProps> = ({
     <Container>
       {headline}
 
-      <Title marginBottom={24}>MKR Vesting Overview</Title>
+      <ContainerTitle marginBottom={16}>
+        <Title>MKR Vesting Overview</Title>
+
+        <SESTooltipStyled
+          content={
+            <ContainerToolTip>This Overview is based on MIP40c3-SP17, SES’MKR Incentive Proposal.</ContainerToolTip>
+          }
+        >
+          <IconContainer className="advance-table--transparency-card_icon_hidden">
+            <Info />
+          </IconContainer>
+        </SESTooltipStyled>
+      </ContainerTitle>
       <MkrVestingTotalFTE totalFTE={FTEs} />
 
       <AdvancedInnerTable
         columns={mainTableColumns}
         items={mainTableItems}
         longCode={longCode}
+        cardSpacingSize="small"
         tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={shortCode} resource={resource} />}
       />
       {mainTableItems.length > 0 && (
@@ -50,40 +65,70 @@ export const TransparencyMkrVesting: React.FC<TransparencyMkrVestingProps> = ({
   );
 };
 
+const MkrInfoContainer = styled('div')({
+  marginTop: 32,
+  marginBottom: 90,
+});
 const Container = styled('div')({
   display: 'flex',
   flexDirection: 'column',
 });
 
-const MkrInfoContainer = styled('div')({
-  marginTop: 32,
-  marginBottom: 90,
-});
-
 const Title = styled('div')<{
-  marginBottom?: number;
-  fontSize?: string;
   responsiveMarginBottom?: number;
-  isTitleOfPage?: boolean;
-  marginTop?: number;
-}>(({ marginBottom = 16, theme, responsiveMarginBottom, isTitleOfPage = false, marginTop = 24 }) => ({
+}>(({ theme }) => ({
   fontFamily: 'Inter, sans-serif',
-  fontWeight: isTitleOfPage ? 500 : 600,
+  fontWeight: 700,
   fontStyle: 'normal',
-  fontSize: 16,
-  lineHeight: '19px',
-  marginTop,
-  letterSpacing: '0.4px',
+  fontSize: 20,
+  lineHeight: '24px',
+
   color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
-  marginBottom: `${marginBottom}px`,
+}));
 
-  [theme.breakpoints.up('tablet_768')]: {
-    fontSize: '18px',
-    lineHeight: '24px',
-    marginBottom: `${responsiveMarginBottom || marginBottom}px`,
-  },
+const SESTooltipStyled = styled(SESTooltip)(({ theme }) => ({
+  padding: 0,
+  marginTop: 0,
+  width: '100%',
+  backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
+  minWidth: 327,
+  borderRadius: 12,
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.graphShadow : theme.fusionShadows.darkMode,
+}));
 
-  [theme.breakpoints.between('mobile_375', 'tablet_768')]: {
-    fontWeight: 700,
+const IconContainer = styled('div')(({ theme }) => ({
+  width: 15,
+  height: 15,
+  display: 'flex',
+  cursor: 'pointer',
+  '& path': {
+    fill: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
   },
+  ':hover': {
+    '& path': {
+      fill: theme.palette.isLight ? theme.palette.colors.slate[200] : theme.palette.colors.slate[100],
+    },
+  },
+}));
+
+const ContainerTitle = styled('div')<{ marginBottom?: number; responsiveMarginBottom?: number; marginTop?: number }>(
+  ({ marginBottom = 24, responsiveMarginBottom, theme, marginTop = 24 }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12.5,
+    marginTop,
+    marginBottom: `${marginBottom}px`,
+    [theme.breakpoints.up('tablet_768')]: {
+      marginBottom: `${responsiveMarginBottom || marginBottom}px`,
+    },
+  })
+);
+
+const ContainerToolTip = styled('div')(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.charcoal[900] : theme.palette.colors.charcoal[100],
+  fontSize: 16,
+  fontWeight: 500,
+  lineHeight: '24px',
+  padding: 16,
 }));

--- a/src/components/BudgetStatement/BudgetStatementMkrVesting/MkrVestingTotalFTE.tsx
+++ b/src/components/BudgetStatement/BudgetStatementMkrVesting/MkrVestingTotalFTE.tsx
@@ -1,91 +1,46 @@
-import styled from '@emotion/styled';
-import { CustomPopover } from '@ses/components/CustomPopover/CustomPopover';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
-import lightTheme from '@ses/styles/theme/themes';
+import { styled } from '@mui/material';
 import React from 'react';
 
 interface MkrVestingTotalFTEProps {
   totalFTE: string | number;
 }
 
-const MkrVestingTotalFTE: React.FC<MkrVestingTotalFTEProps> = ({ totalFTE }) => {
-  const { isLight } = useThemeContext();
-
-  return (
-    <ContainerPopover>
-      <CustomPopover
-        title={'Full-Time Equivalents'}
-        id={'popover-fulltime equivalent'}
-        popupStyle={{
-          color: isLight ? '#231536' : '#D2D4EF',
-        }}
-      >
-        <TotalFte isLight={isLight}>
-          <span>Total FTEs</span>
-          <u>{totalFTE}</u>
-        </TotalFte>
-      </CustomPopover>
-    </ContainerPopover>
-  );
-};
+const MkrVestingTotalFTE: React.FC<MkrVestingTotalFTEProps> = ({ totalFTE }) => (
+  <Container>
+    <TotalFte>
+      <span>Total FTEs</span>
+      <u>{totalFTE}</u>
+    </TotalFte>
+  </Container>
+);
 
 export default MkrVestingTotalFTE;
 
-export const ContainerPopover = styled.div({
+const Container = styled('div')({
   display: 'flex',
   flex: 1,
   alignItems: 'center',
   cursor: 'pointer',
   marginBottom: 16,
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    marginBottom: 24,
-  },
-
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    marginBottom: 32,
-  },
 });
 
-export const TotalFte = styled.div<{ isLight: boolean }>(({ isLight }) => ({
+const TotalFte = styled('div')(({ theme }) => ({
   fontFamily: 'Inter, sans-serif',
   fontStyle: 'normal',
-  fontWeight: 600,
-  fontSize: '14px',
-  lineHeight: '17px',
-  color: isLight ? '#231536' : '#D2D4EF',
+  fontWeight: 700,
+  fontSize: 18,
+  lineHeight: '21.6px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
 
   '> u': {
     fontStyle: 'normal',
     fontFamily: 'Inter, sans-serif',
-    fontWeight: 800,
-    fontSize: '16px',
-    lineHeight: '19px',
+    fontWeight: 700,
+    fontSize: 20,
+    lineHeight: '24px',
     paddingBottom: '2px',
     textDecoration: 'none',
-    color: isLight ? '#25273D' : '#708390',
+    color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
     marginLeft: 8,
-
-    [lightTheme.breakpoints.up('table_834')]: {
-      fontSize: '20px',
-      lineHeight: '24px',
-      marginLeft: 16,
-    },
-
-    [lightTheme.breakpoints.up('desktop_1194')]: {
-      fontSize: '22px',
-      lineHeight: '27px',
-    },
-  },
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    fontSize: '16px',
-    lineHeight: '19px',
-    fontWeight: 700,
-  },
-
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    fontSize: '20px',
-    lineHeight: '24px',
   },
 }));

--- a/src/components/BudgetStatement/BudgetStatementMkrVesting/ToolTipMkrVesting.tsx
+++ b/src/components/BudgetStatement/BudgetStatementMkrVesting/ToolTipMkrVesting.tsx
@@ -1,0 +1,71 @@
+import { styled } from '@mui/material';
+import Info from 'public/assets/svg/info_outlined.svg';
+import React from 'react';
+import SESTooltip from '@/components/SESTooltip/SESTooltip';
+import type { FC } from 'react';
+
+interface Props {
+  title: string;
+}
+
+const ToolTipMkrVesting: FC<Props> = ({ title }) => (
+  <Container>
+    <div>{title}</div>
+
+    <SESTooltipStyled
+      content={
+        <ContainerToolTip>
+          The Difference column indicates any changes in the MKR vesting amounts compared to last month, with the
+          Reason(s) column indicating why the amounts changed. Reasons may include: New hires, FTE changes, Promotions,
+          or Terminations.
+        </ContainerToolTip>
+      }
+    >
+      <IconContainer>
+        <Info />
+      </IconContainer>
+    </SESTooltipStyled>
+  </Container>
+);
+
+export default ToolTipMkrVesting;
+
+const Container = styled('div')({
+  display: 'flex',
+  gap: 4.5,
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+});
+
+const SESTooltipStyled = styled(SESTooltip)(({ theme }) => ({
+  padding: 0,
+  marginTop: 0,
+  width: '100%',
+  backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
+  minWidth: 327,
+  borderRadius: 12,
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.graphShadow : theme.fusionShadows.darkMode,
+}));
+
+const IconContainer = styled('div')(({ theme }) => ({
+  width: 15,
+  height: 15,
+  display: 'flex',
+  cursor: 'pointer',
+  '& path': {
+    fill: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
+  },
+  ':hover': {
+    '& path': {
+      fill: theme.palette.isLight ? theme.palette.colors.slate[200] : theme.palette.colors.slate[100],
+    },
+  },
+}));
+
+const ContainerToolTip = styled('div')(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.charcoal[900] : theme.palette.colors.charcoal[100],
+  fontSize: 16,
+  fontWeight: 500,
+  lineHeight: '24px',
+  padding: 16,
+}));

--- a/src/components/BudgetStatement/BudgetStatementMkrVesting/useBudgetStatementMkrVesting.tsx
+++ b/src/components/BudgetStatement/BudgetStatementMkrVesting/useBudgetStatementMkrVesting.tsx
@@ -2,6 +2,7 @@ import { API_MONTH_TO_FORMAT } from '@ses/core/utils/date';
 import _ from 'lodash';
 import { useMemo } from 'react';
 import type { InnerTableColumn, InnerTableRow } from '@/components/AdvancedInnerTable/types';
+import ToolTipMkrVesting from './ToolTipMkrVesting';
 import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatement';
 import type { DateTime } from 'luxon';
 
@@ -44,24 +45,29 @@ export const useTransparencyMkrVesting = (currentMonth: DateTime, budgetStatemen
       {
         header: 'Vesting Date',
         isCardHeader: true,
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'MKR Amount',
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Last month',
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
-        header: 'Difference',
+        header: <ToolTipMkrVesting title="Difference" />,
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
-        header: 'Reasons(s)',
+        header: 'Reason(s)',
+        type: 'text',
       },
     ];
     return mainTableColumns;
@@ -74,7 +80,8 @@ export const useTransparencyMkrVesting = (currentMonth: DateTime, budgetStatemen
 
     mkrVestingsOrdered.forEach((mkrVesting) => {
       result.push({
-        type: 'normal',
+        borderBottom: true,
+        type: 'category',
         items: [
           {
             value: mkrVesting.vestingDate,

--- a/src/views/CoreUnitBudgetStatement/CoreUnitBudgetStatementView.tsx
+++ b/src/views/CoreUnitBudgetStatement/CoreUnitBudgetStatementView.tsx
@@ -9,7 +9,7 @@ import { BudgetStatementActuals } from '@/components/BudgetStatement/BudgetState
 import { TransparencyAudit } from '@/components/BudgetStatement/BudgetStatementAudit/BudgetStatementAudit';
 import AuditorCommentsContainer from '@/components/BudgetStatement/BudgetStatementAuditorComments/AuditorCommentsContainer/AuditorCommentsContainer';
 import { BudgetStatementForecast } from '@/components/BudgetStatement/BudgetStatementForecast/BudgetStatementForecast';
-import { TransparencyMkrVesting } from '@/components/BudgetStatement/BudgetStatementMkrVesting/BudgetStatementMkrVesting';
+import { BudgetStatementMkrVesting } from '@/components/BudgetStatement/BudgetStatementMkrVesting/BudgetStatementMkrVesting';
 import BudgetStatementPager from '@/components/BudgetStatement/BudgetStatementPager/BudgetStatementPager';
 import { TransparencyTransferRequest } from '@/components/BudgetStatement/BudgetStatementTransferRequest/BudgetStatementTransferRequest';
 import ExpenseReport from '@/components/BudgetStatement/ExpenseReport/ExpenseReport';
@@ -175,7 +175,7 @@ const CoreUnitBudgetStatementView = ({
               />
             )}
             {tabsIndex === TRANSPARENCY_IDS_ENUM.MKR_VESTING && (
-              <TransparencyMkrVesting
+              <BudgetStatementMkrVesting
                 currentMonth={currentMonth}
                 budgetStatements={coreUnit?.budgetStatements}
                 longCode={longCode}

--- a/src/views/EcosystemActorBudgetStatement/EcosystemActorBudgetStatementView.tsx
+++ b/src/views/EcosystemActorBudgetStatement/EcosystemActorBudgetStatementView.tsx
@@ -12,7 +12,7 @@ import { BudgetStatementActuals } from '@/components/BudgetStatement/BudgetState
 import { TransparencyAudit } from '@/components/BudgetStatement/BudgetStatementAudit/BudgetStatementAudit';
 import AuditorCommentsContainer from '@/components/BudgetStatement/BudgetStatementAuditorComments/AuditorCommentsContainer/AuditorCommentsContainer';
 import { BudgetStatementForecast } from '@/components/BudgetStatement/BudgetStatementForecast/BudgetStatementForecast';
-import { TransparencyMkrVesting } from '@/components/BudgetStatement/BudgetStatementMkrVesting/BudgetStatementMkrVesting';
+import { BudgetStatementMkrVesting } from '@/components/BudgetStatement/BudgetStatementMkrVesting/BudgetStatementMkrVesting';
 import BudgetStatementPager from '@/components/BudgetStatement/BudgetStatementPager/BudgetStatementPager';
 import { TransparencyTransferRequest } from '@/components/BudgetStatement/BudgetStatementTransferRequest/BudgetStatementTransferRequest';
 import ExpenseReport from '@/components/BudgetStatement/ExpenseReport/ExpenseReport';
@@ -167,7 +167,7 @@ const EcosystemActorBudgetStatementView: React.FC<EcosystemActorBudgetStatementV
               />
             )}
             {tabsIndex === TRANSPARENCY_IDS_ENUM.MKR_VESTING && (
-              <TransparencyMkrVesting
+              <BudgetStatementMkrVesting
                 currentMonth={currentMonth}
                 budgetStatements={actor?.budgetStatements}
                 longCode={actor.code}


### PR DESCRIPTION
## Ticket
https://trello.com/c/1A1BltB6/478-reskin-budget-statements-cu-ea-mkr-vesting-tab



## What solved

- [X] Should update the external link for light/dark mode. Desktop/Small resolutions.
- [X]  Should update the MKR Vesting Overview title with the info icon (status: default, hover) for light/dark mode. Desktop/Small resolutions.
- [X] Should update the tooltip for light/dark mode. Desktop/Small resolutions.
- [X] Should update the Total FTEs for light/dark mode. Desktop/Small resolutions.
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
