### PR TITLE
Split the card per component and merge into item

### DIFF
--- a/src/views/EcosystemActorsIndex/components/ActorItem/ActorItem.tsx
+++ b/src/views/EcosystemActorsIndex/components/ActorItem/ActorItem.tsx
@@ -1,23 +1,18 @@
 import { styled } from '@mui/material';
 import SocialMediaComponent from '@ses/components/SocialMediaComponent/SocialMediaComponent';
 import { siteRoutes } from '@ses/config/routes';
-import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
+import Link from 'next/link';
 import React from 'react';
-import SocialMediaLinksButton from '@/components/ButtonLink/SocialMediaLinksButton';
 import Card from '@/components/Card/Card';
-import CircleAvatar from '@/components/CircleAvatar/CircleAvatar';
-import InternalLinkButton from '@/components/InternalLinkButton/InternalLinkButton';
-import RoleChip from '@/components/RoleChip/RoleChip';
-import ScopeChip from '@/components/ScopeChip/ScopeChip';
-import { StatusChip } from '@/components/StatusChip/StatusChip';
-import type { TeamRole } from '@/core/enums/teamRole';
-import type { TeamStatus } from '@/core/models/interfaces/types';
 import LastModifiedActorCoreUnit from '@/views/CoreUnitsIndex/components/LastModifiedActorCoreUnit/LastModifiedActorCoreUnit';
 import { getActorLastMonthWithData } from '../../utils/utils';
-import GroupedScopes from './GroupedScopes';
+import EcosystemActorDescription from '../EcosystemActorDescription/EcosystemActorDescription';
+import RoleItem from '../RoleItem/RoleItem';
+import ScopeItem from '../ScopeItem/ScopeItem';
+
+import SocialArrowLinks from '../SocialArrowLinks/SocialArrowLinks';
 import type { SocialMediaChannels } from '@ses/core/models/interfaces/socialMedia';
 import type { Team } from '@ses/core/models/interfaces/team';
-import type { PropsWithChildren } from 'react';
 
 interface Props {
   queryStrings?: string;
@@ -25,18 +20,6 @@ interface Props {
 }
 
 const ActorItem: React.FC<Props> = ({ actor, queryStrings }) => {
-  const [isEnabled] = useFlagsActive();
-  const ActorSpaceLink: React.FC<PropsWithChildren> = ({ children }) => (
-    <ContainerLinkColum>
-      <LinkColumSpace>{children}</LinkColumSpace>
-    </ContainerLinkColum>
-  );
-
-  const ActorAboutLink: React.FC<PropsWithChildren> = ({ children }) => (
-    <ContainerLinkColum>
-      <LinkColum>{children}</LinkColum>
-    </ContainerLinkColum>
-  );
   const socialIcons: SocialMediaChannels = actor.socialMediaChannels[0] ?? {};
   const keysWithNonNullValues = Object.keys(socialIcons).filter(
     (key): key is keyof SocialMediaChannels =>
@@ -46,163 +29,49 @@ const ActorItem: React.FC<Props> = ({ actor, queryStrings }) => {
 
   return (
     <CardContainer socialLength={keysWithNonNullValues.length}>
-      <ActorSpaceLink>
-        <ContainerActorType>
-          <WrapperEcosystemActor>
-            <ActorAvatar>
-              <CircleAvatarExtended name={actor.name || 'Wallet'} image={actor.image} />
-              <ContainerDescription>
-                <ContainerTitleStatus>
-                  <TitleLinks>
-                    <ContainerShortCodeName>
-                      {isEnabled('FEATURE_ECOSYSTEM_ACTORS_STATUS_AND_CODE') && (
-                        <ShortCode>{actor.shortCode}</ShortCode>
-                      )}
-                      <Name>{actor.name}</Name>
-                    </ContainerShortCodeName>
-                    {isEnabled('FEATURE_ECOSYSTEM_ACTORS_STATUS_AND_CODE') && (
-                      <StatusMobile>
-                        <StatusChip status={actor.status as TeamStatus} />
-                      </StatusMobile>
-                    )}
-                  </TitleLinks>
-                  <ScopeOnlyTable>
-                    <LabelMobile>Scope</LabelMobile>
-                    <ContainerScopeMobile>
-                      {actor.scopes?.map((item, index) => (
-                        <ScopeChip scope={item} key={index} codeOnly />
-                      ))}
-                    </ContainerScopeMobile>
-                  </ScopeOnlyTable>
-                  <RoleOnlyTable>
-                    <LabelMobile>Role</LabelMobile>
-                    <RoleChip status={(actor.category?.[0] ?? '') as TeamRole} />
-                  </RoleOnlyTable>
-                </ContainerTitleStatus>
+      <ContainerActorType>
+        <RowLink>
+          <EcosystemActorDescription actor={actor} />
+          <ShowOnlyMobile>
+            <SocialArrowLinks actor={actor} />
+          </ShowOnlyMobile>
+        </RowLink>
+        <LinkSpace href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}`} />
+        <RowScopeRole>
+          <RoleItem actor={actor} />
+          <ScopeItem actor={actor} />
+        </RowScopeRole>
+        <LinkSpace href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}`} />
 
-                <ContainerLinksArrowsMobile>
-                  <SocialMediaLinksButton socialMedia={actor.socialMediaChannels?.[0]} />
+        <DivSpace href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}`} />
+        <ContainerLastModifiedDesk>
+          <LastModifiedActorCoreUnit
+            date={getActorLastMonthWithData(actor)}
+            href={`${siteRoutes.ecosystemActorReports(actor.shortCode)}`}
+          />
+        </ContainerLastModifiedDesk>
+        <LinkSpace href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}`} />
+        <ShowOnlyTable>
+          <SocialArrowLinks actor={actor} />
+        </ShowOnlyTable>
+      </ContainerActorType>
 
-                  <InternalLinkButtonStyled
-                    href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}/${queryStrings}`}
-                    showIcon
-                  />
-                </ContainerLinksArrowsMobile>
-                <ContainerLinksArrowsTable>
-                  <SocialMediaLinksButton socialMedia={actor.socialMediaChannels?.[0]} hideLabelIn={['desktop_1024']} />
-                  <InternalLinkButtonStyled
-                    href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}/${queryStrings}`}
-                    showIcon
-                  />
-                </ContainerLinksArrowsTable>
-              </ContainerDescription>
-            </ActorAvatar>
-          </WrapperEcosystemActor>
-
-          <TypeSection>
-            <WrapperType>Role</WrapperType>
-            <WrapperHiddenOnlyMobileCategory>
-              <RoleChip status={(actor.category?.[0] ?? '') as TeamRole} />
-            </WrapperHiddenOnlyMobileCategory>
-          </TypeSection>
-          <WrapperCategoryScopeMobile>
-            <TableHiddenScope>
-              <LabelMobile>Role</LabelMobile>
-              <WrapperCategoryScopeMobileInside>
-                <RoleChip status={(actor.category?.[0] ?? '') as TeamRole} />
-              </WrapperCategoryScopeMobileInside>
-            </TableHiddenScope>
-
-            <ContainerScopeMobileOnly>
-              <LabelMobile>Scope</LabelMobile>
-              <ContainerScopeMobile>
-                {actor.scopes?.map((item, index) => (
-                  <ScopeChip scope={item} key={index} codeOnly />
-                ))}
-              </ContainerScopeMobile>
-            </ContainerScopeMobileOnly>
-          </WrapperCategoryScopeMobile>
-        </ContainerActorType>
-      </ActorSpaceLink>
-      <WrapperScopeLinks alignEnd={actor?.scopes?.length === 0}>
-        <WrapperHiddenOnlyMobileScope>
-          <ContainerScopeLastModified>
-            <ActorAboutLink>
-              <ScopeSection>
-                {actor?.scopes?.length > 2 ? (
-                  <GroupedScopes scopes={actor.scopes} />
-                ) : (
-                  actor?.scopes?.map((item, index) => <ScopeChipStyled scope={item} key={index} />)
-                )}
-              </ScopeSection>
-            </ActorAboutLink>
-
-            <ContainerLastModifiedDesk>
-              <LastModifiedActorCoreUnit
-                date={getActorLastMonthWithData(actor)}
-                href={`${siteRoutes.ecosystemActorReports(actor.shortCode)}`}
-              />
-            </ContainerLastModifiedDesk>
-          </ContainerScopeLastModified>
-          <ActorAboutLink>
-            <LinkSpace />
-          </ActorAboutLink>
-        </WrapperHiddenOnlyMobileScope>
-      </WrapperScopeLinks>
       <ContainerLastModifiedMobileTable>
         <ActorLastModifiedStyled
           date={getActorLastMonthWithData(actor)}
           href={`${siteRoutes.ecosystemActorReports(actor.shortCode)}`}
         />
       </ContainerLastModifiedMobileTable>
-      <ContainerLinksArrowsDesk>
-        <SocialMediaLinksButton socialMedia={actor.socialMediaChannels?.[0]} />
-        <VerticalLine />
-        <InternalLinkButtonStyled
-          href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}/${queryStrings}`}
-          showIcon
-        />
-      </ContainerLinksArrowsDesk>
+      <LinkSpaceDesk href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}/${queryStrings}`} />
+      <ShowOnlyDesk>
+        <SocialArrowLinks actor={actor} />
+      </ShowOnlyDesk>
     </CardContainer>
   );
 };
 
 export default ActorItem;
 
-const ContainerTitleStatus = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  justifyContent: 'space-between',
-  [theme.breakpoints.up('desktop_1024')]: {
-    width: 202,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    width: 256,
-  },
-}));
-
-const TitleLinks = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 2,
-  [theme.breakpoints.up('tablet_768')]: {
-    width: 154,
-    gap: 'revert',
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    marginTop: -4,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    width: 202,
-  },
-}));
-
-const ContainerScopeMobileOnly = styled('div')({
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-end',
-  gap: 6,
-});
 const CardContainer = styled(Card)<{ socialLength: number }>(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
@@ -210,29 +79,23 @@ const CardContainer = styled(Card)<{ socialLength: number }>(({ theme }) => ({
   fontStyle: 'normal',
   [theme.breakpoints.up('tablet_768')]: {
     padding: 0,
-    minHeight: 94,
     flexDirection: 'column',
     maxHeight: 'revert',
   },
   [theme.breakpoints.up('desktop_1024')]: {
     flexDirection: 'row',
-    minHeight: 82,
-    padding: 16,
+    padding: 0,
     justifyContent: 'space-between',
     alignItems: 'center',
     ':hover': {
       background: theme.palette.isLight ? theme.palette.colors.gray[50] : 'rgba(41, 46, 56, 1)',
     },
   },
-  [theme.breakpoints.up('desktop_1280')]: {
-    padding: '16px 16px 16px 16px',
-  },
+
   [theme.breakpoints.up('desktop_1440')]: {
     flexDirection: 'row',
     maxWidth: 1312,
-    minHeight: 82,
     alignItems: 'center',
-    padding: '16px 24px 16px 8px',
   },
 }));
 
@@ -242,188 +105,26 @@ const ContainerActorType = styled('div')(({ theme }) => ({
   gap: 4,
   [theme.breakpoints.up('tablet_768')]: {
     flexDirection: 'row',
-    flex: 1,
     justifyContent: 'space-between',
-    paddingTop: 8,
+    gap: 0,
   },
   [theme.breakpoints.up('desktop_1024')]: {
     flexDirection: 'row',
-    flex: 1,
+
     paddingTop: 'revert',
   },
 }));
 
-const WrapperEcosystemActor = styled('div')({
+const RowLink = styled('div')(({ theme }) => ({
   display: 'flex',
-  flexDirection: 'column',
-  width: '100%',
-});
 
-const ActorAvatar = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  gap: 10,
-  paddingLeft: 8,
-  paddingTop: 8,
   [theme.breakpoints.up('tablet_768')]: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 16,
-    paddingTop: 'revert',
     paddingLeft: 0,
-    marginBottom: 0,
-    paddingBottom: 0,
-    width: '100%',
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: 14,
-    paddingTop: -4,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    width: 304,
-    paddingLeft: 2,
-    gap: 20,
-    paddingTop: -6,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    width: 292,
-  },
-}));
 
-const Name = styled('div')(({ theme }) => ({
-  fontWeight: 600,
-  fontSize: 14,
-  lineHeight: '22px',
-  color: theme.palette.isLight ? theme.palette.colors.gray[900] : '#D2D4EF',
-  width: 160,
-  overflow: 'hidden',
-  whiteSpace: 'nowrap',
-  textOverflow: 'ellipsis',
-  [theme.breakpoints.up('tablet_768')]: {
-    width: 'revert',
+    paddingRight: 0,
   },
   [theme.breakpoints.up('desktop_1024')]: {
-    fontSize: '14px',
-    width: 202,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    fontSize: 14,
-    width: 159,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    width: 211,
-  },
-}));
-
-const TypeSection = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
-    display: 'none',
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginTop: -3,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
     paddingLeft: 0,
-    marginTop: -4,
-  },
-
-  [theme.breakpoints.up('desktop_1440')]: {
-    paddingLeft: 0,
-    marginTop: -10,
-    flexDirection: 'row',
-  },
-}));
-
-const WrapperType = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.up('tablet_768')]: {
-    display: 'flex',
-    fontFamily: 'Inter, sans-serif',
-    fontStyle: 'normal',
-    fontWeight: 400,
-    fontSize: 14,
-    color: theme.palette.isLight ? '#9FAFB9' : '#9FAFB9',
-
-    lineHeight: '17px',
-    alignItems: 'end',
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'none',
-  },
-}));
-const CircleAvatarExtended = styled(CircleAvatar)(({ theme }) => ({
-  boxShadow: theme.palette.isLight ? theme.fusionShadows.avatars : theme.fusionShadows.shortShadow,
-  width: 32,
-  height: 32,
-  minWidth: 32,
-  minHeight: 32,
-  border: 'none',
-}));
-
-const WrapperScopeLinks = styled('div')<{ alignEnd: boolean }>(({ alignEnd, theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: alignEnd ? 'flex-end' : 'space-between',
-  [theme.breakpoints.up('tablet_768')]: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingBottom: 'revert',
-    flex: 1,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingBottom: 'revert',
-    flex: 1.5,
-  },
-}));
-
-const ScopeSection = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  gap: 8,
-
-  justifyContent: 'center',
-  marginBottom: 8,
-  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
-    display: 'none',
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-    minWidth: 150,
-    marginLeft: 11,
-    marginTop: -4,
-    gap: 4,
-    width: 202,
-    marginBottom: 0,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    marginLeft: 6,
-    paddingTop: 6,
-  },
-
-  [theme.breakpoints.up('desktop_1440')]: {
-    minWidth: 150,
-    marginLeft: 20,
-    paddingTop: 0,
-    flexDirection: 'column',
-    gap: 4,
   },
 }));
 
@@ -454,101 +155,9 @@ export const SocialMediaComponentStyled = styled(SocialMediaComponent)(({ theme 
   },
 }));
 
-const ContainerLinkColum = styled('div')(({ theme }) => ({
-  [theme.breakpoints.up('tablet_768')]: {
-    display: 'flex',
-    flexDirection: 'row',
-    flex: 1,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-    flex: 1,
-  },
-}));
-
-const LinkColum = styled('a')(({ theme }) => ({
-  [theme.breakpoints.up('tablet_768')]: {
-    display: 'flex',
-    paddingLeft: 16,
-
-    paddingRight: 16,
-    flex: 1,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-    padding: 0,
-    flex: 1,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    display: 'flex',
-    padding: 0,
-    flex: 1,
-  },
-}));
-const LinkColumSpace = styled('div')(({ theme }) => ({
-  [theme.breakpoints.up('tablet_768')]: {
-    display: 'flex',
-    paddingLeft: 8,
-    paddingRight: 8,
-    flex: 1,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-    flex: 'revert',
-    paddingLeft: 'revert',
-    paddingRight: 'revert',
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    paddingRight: 0,
-    minWidth: 430,
-    paddingLeft: 8,
-  },
-}));
-
-const ContainerLastModifiedDesk = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    marginTop: -1,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    display: 'flex',
-    marginLeft: 'revert',
-    marginTop: 0,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    display: 'flex',
-
-    marginTop: -4,
-  },
-}));
-
-const ContainerScopeLastModified = styled('div')(({ theme }) => ({
-  marginTop: 0,
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-
-    flexDirection: 'row',
-    gap: 8,
-    marginTop: -1,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    gap: 54,
-    marginLeft: 18,
-    marginTop: -4,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    gap: 88,
-    marginLeft: 50,
-    paddingTop: 2,
-  },
-}));
-
 const ContainerLastModifiedMobileTable = styled('div')(({ theme }) => ({
   width: '100%',
-  marginTop: 6,
+  marginTop: 0,
   marginLeft: 0,
   [theme.breakpoints.up('tablet_768')]: {
     marginTop: 4,
@@ -560,192 +169,6 @@ const ContainerLastModifiedMobileTable = styled('div')(({ theme }) => ({
   },
 }));
 
-const WrapperCategoryScopeMobile = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  justifyContent: 'space-between',
-  paddingLeft: 8,
-  paddingRight: 8,
-  [theme.breakpoints.up('tablet_768')]: {
-    display: 'none',
-  },
-}));
-
-const WrapperCategoryScopeMobileInside = styled('div')({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'center',
-});
-
-const ContainerScopeMobile = styled('div')(({ theme }) => ({
-  display: 'flex',
-
-  flexDirection: 'row',
-  gap: 4,
-  '& div': {
-    width: 34,
-    padding: '0px',
-  },
-  [theme.breakpoints.up('tablet_768')]: {
-    '& div': {
-      width: 40,
-    },
-  },
-}));
-const WrapperHiddenOnlyMobileCategory = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.up('tablet_768')]: {
-    display: 'flex',
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    marginLeft: 10,
-    minWidth: 200,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    marginRight: 12,
-    marginLeft: 40,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    marginRight: 0,
-    marginLeft: 84,
-    paddingTop: 4,
-  },
-}));
-
-const WrapperHiddenOnlyMobileScope = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.up('tablet_768')]: {
-    display: 'flex',
-
-    alignItems: 'center',
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-    flex: 1,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    paddingLeft: 0,
-  },
-}));
-
-const LinkSpace = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flex: 1,
-  [theme.breakpoints.up('desktop_1024')]: {},
-}));
-
-const ShortCode = styled('div')(({ theme }) => ({
-  fontFamily: 'Inter, sans-serif',
-  fontWeight: 600,
-  fontSize: 14,
-  lineHeight: '22px',
-  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[600],
-}));
-
-const ContainerDescription = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  justifyContent: 'space-between',
-
-  flex: 1,
-  paddingRight: 8,
-  [theme.breakpoints.up('tablet_768')]: {
-    paddingRight: 0,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    gap: 8,
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-  },
-}));
-
-const StatusMobile = styled('div')(({ theme }) => ({
-  display: 'flex',
-  marginTop: -4,
-  [theme.breakpoints.up('tablet_768')]: {
-    marginTop: 1,
-  },
-}));
-const ContainerShortCodeName = styled('div')({
-  display: 'flex',
-  flexDirection: 'row',
-  gap: 4,
-});
-const ContainerLinksArrowsMobile = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  gap: 16,
-  height: 32,
-  [theme.breakpoints.up('tablet_768')]: {
-    display: 'none',
-  },
-}));
-const ContainerLinksArrowsTable = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
-    display: 'flex',
-    gap: 8,
-    paddingTop: 16,
-    height: 'revert',
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'none',
-  },
-}));
-const ContainerLinksArrowsDesk = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    minWidth: 140,
-    justifyContent: 'flex-end',
-  },
-}));
-
-const LabelMobile = styled('div')(({ theme }) => ({
-  fontSize: 12,
-  fontWeight: 500,
-  lineHeight: '18px',
-  color: theme.palette.isLight ? theme.palette.colors.charcoal[300] : theme.palette.colors.charcoal[700],
-  [theme.breakpoints.up('tablet_768')]: {
-    fontSize: 14,
-    fontWeight: 600,
-    lineHeight: '22px',
-  },
-}));
-
-const TableHiddenScope = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 3,
-  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
-    display: 'none',
-  },
-}));
-
-const ScopeOnlyTable = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
-    display: 'flex',
-    flexDirection: 'column',
-    minWidth: 195,
-    marginLeft: 8,
-    gap: 2,
-  },
-}));
-
-const RoleOnlyTable = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
-    display: 'flex',
-    flexDirection: 'column',
-    minWidth: 195,
-    marginLeft: 6,
-    gap: 1,
-  },
-}));
 const ActorLastModifiedStyled = styled(LastModifiedActorCoreUnit)(({ theme }) => ({
   [theme.breakpoints.up('tablet_768')]: {
     padding: '3px 8px 4px 8px',
@@ -753,29 +176,119 @@ const ActorLastModifiedStyled = styled(LastModifiedActorCoreUnit)(({ theme }) =>
   },
 }));
 
-const InternalLinkButtonStyled = styled(InternalLinkButton)({
-  borderRadius: 8,
-  padding: '2px 8px 2px 8px',
-  ':hover': {
-    padding: '2px 8px 2px 8px',
-  },
-});
-
-const VerticalLine = styled('div')(({ theme }) => ({
-  marginLeft: 8,
-  marginRight: 8,
-  height: 16,
+const ShowOnlyMobile = styled('div')(({ theme }) => ({
   display: 'flex',
-  alignItems: 'center',
-  border: `1px solid ${theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[800]}`,
-  [theme.breakpoints.up('desktop_1280')]: {
-    marginLeft: 16,
-    marginRight: 16,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'none',
+  },
+}));
+const ShowOnlyTable = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    selfAlign: 'end',
+
+    paddingTop: 8,
+    paddingRight: 8,
+    minWidth: 80,
   },
 }));
 
-const ScopeChipStyled = styled(ScopeChip)(({ theme }) => ({
+const ShowOnlyDesk = styled('div')(({ theme }) => ({
+  display: 'none',
   [theme.breakpoints.up('desktop_1024')]: {
-    height: 24,
+    display: 'flex',
+  },
+}));
+
+const LinkSpace = styled(Link)({
+  display: 'flex',
+  flex: 1,
+});
+const LinkSpaceDesk = styled(Link)(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+    flex: 2,
+    paddingTop: 27.5,
+    paddingBottom: 27.5,
+  },
+}));
+
+const ContainerLastModifiedDesk = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    marginTop: -4,
+    marginLeft: 18,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    display: 'flex',
+    marginLeft: 6,
+    marginTop: -4,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    display: 'flex',
+    marginTop: -4,
+    marginLeft: -4,
+  },
+}));
+
+const DivSpace = styled(Link)(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+    marginLeft: -10,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    display: 'flex',
+    minWidth: 50,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    display: 'flex',
+    minWidth: 94,
+  },
+}));
+
+const RowScopeRole = styled('div')(({ theme }) => ({
+  display: 'flex',
+  paddingRight: 8,
+  paddingLeft: 8,
+
+  justifyContent: 'space-between',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    alignItems: 'flex-start',
+
+    '& #scope': {
+      order: 1,
+    },
+    '& #role': {
+      order: 2,
+    },
+    paddingRight: 0,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    marginLeft: -15,
+    marginTop: -2,
+    alignItems: 'center',
+    '& #role': {
+      order: 1,
+    },
+    '& #scope': {
+      order: 2,
+    },
+    paddingRight: 0,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    marginLeft: -20,
+    marginTop: 0,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    marginLeft: -24,
   },
 }));

--- a/src/views/EcosystemActorsIndex/components/EcosystemActorDescription/EcosystemActorDescription.tsx
+++ b/src/views/EcosystemActorsIndex/components/EcosystemActorDescription/EcosystemActorDescription.tsx
@@ -1,0 +1,208 @@
+import { styled } from '@mui/material';
+import Link from 'next/link';
+import React from 'react';
+import CircleAvatar from '@/components/CircleAvatar/CircleAvatar';
+import { StatusChip } from '@/components/StatusChip/StatusChip';
+import { siteRoutes } from '@/config/routes';
+import { useFlagsActive } from '@/core/hooks/useFlagsActive';
+import type { Team } from '@/core/models/interfaces/team';
+import type { TeamStatus } from '@/core/models/interfaces/types';
+import type { FC } from 'react';
+
+interface Props {
+  actor: Team;
+  className?: string;
+}
+
+const EcosystemActorDescription: FC<Props> = ({ actor, className }) => {
+  const [isEnabled] = useFlagsActive();
+  return (
+    <Container href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}`} className={className}>
+      <ActorAvatar>
+        <CircleAvatarExtended name={actor.name || 'Wallet'} image={actor.image} />
+        <ContainerDescription>
+          <ContainerTitleStatus>
+            <TitleLinks>
+              <ContainerShortCodeName>
+                {isEnabled('FEATURE_ECOSYSTEM_ACTORS_STATUS_AND_CODE') && <ShortCode>{actor.shortCode}</ShortCode>}
+                <Name>{actor.name}</Name>
+              </ContainerShortCodeName>
+              {isEnabled('FEATURE_ECOSYSTEM_ACTORS_STATUS_AND_CODE') && (
+                <StatusMobile>
+                  <StatusChipStyled status={actor.status as TeamStatus} />
+                </StatusMobile>
+              )}
+            </TitleLinks>
+          </ContainerTitleStatus>
+        </ContainerDescription>
+      </ActorAvatar>
+    </Container>
+  );
+};
+
+export default EcosystemActorDescription;
+
+const Container = styled(Link)(({ theme }) => ({
+  display: 'flex',
+  flex: 1,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    flex: 'revert',
+    paddingLeft: 8,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    paddingLeft: 16,
+    paddingTop: 16,
+    paddingBottom: 16,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    paddingLeft: 24,
+  },
+}));
+const ContainerTitleStatus = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    width: 202,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    width: 256,
+  },
+}));
+
+const TitleLinks = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 154,
+    gap: 'revert',
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    marginTop: -4,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    width: 202,
+  },
+}));
+
+const ActorAvatar = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: 10,
+  paddingTop: 8,
+
+  paddingLeft: 8,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    paddingTop: 'revert',
+    paddingLeft: 0,
+    marginBottom: 0,
+    paddingBottom: 0,
+    width: '100%',
+    marginTop: 2,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 14,
+    paddingTop: -4,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    width: 304,
+    marginLeft: -2,
+    gap: 16,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    width: 292,
+    marginTop: 4,
+  },
+}));
+
+const Name = styled('div')(({ theme }) => ({
+  fontWeight: 600,
+  fontSize: 14,
+  lineHeight: '22px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : '#D2D4EF',
+  width: 140,
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  [theme.breakpoints.up('tablet_768')]: {
+    width: 'revert',
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontSize: '14px',
+    width: 202,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    fontSize: 14,
+    width: 159,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    width: 211,
+  },
+}));
+
+const CircleAvatarExtended = styled(CircleAvatar)(({ theme }) => ({
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.avatars : theme.fusionShadows.shortShadow,
+  width: 32,
+  height: 32,
+  minWidth: 32,
+  minHeight: 32,
+  border: 'none',
+  [theme.breakpoints.up('desktop_1024')]: {
+    marginTop: 4,
+  },
+}));
+
+const ShortCode = styled('div')(({ theme }) => ({
+  fontFamily: 'Inter, sans-serif',
+  fontWeight: 600,
+  fontSize: 14,
+  lineHeight: '22px',
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[600],
+}));
+
+const ContainerDescription = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+
+  justifyContent: 'space-between',
+
+  flex: 1,
+  paddingRight: 8,
+  [theme.breakpoints.up('tablet_768')]: {
+    paddingRight: 0,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 8,
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  },
+}));
+
+const StatusMobile = styled('div')(({ theme }) => ({
+  display: 'flex',
+  marginTop: -4,
+  [theme.breakpoints.up('tablet_768')]: {
+    marginTop: 1,
+  },
+}));
+const ContainerShortCodeName = styled('div')({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: 4,
+});
+
+const StatusChipStyled = styled(StatusChip)({
+  padding: '1px 16px 1px 16px',
+});

--- a/src/views/EcosystemActorsIndex/components/RoleItem/RoleItem.tsx
+++ b/src/views/EcosystemActorsIndex/components/RoleItem/RoleItem.tsx
@@ -71,7 +71,7 @@ const Label = styled('div')(({ theme }) => ({
   fontWeight: 500,
   fontSize: 12,
   lineHeight: '18px',
-  color: theme.palette.isLight ? theme.palette.colors.charcoal[300] : 'red',
+  color: theme.palette.isLight ? theme.palette.colors.charcoal[300] : theme.palette.colors.charcoal[700],
   [theme.breakpoints.up('tablet_768')]: {
     lineHeight: '22px',
     fontWeight: 600,

--- a/src/views/EcosystemActorsIndex/components/RoleItem/RoleItem.tsx
+++ b/src/views/EcosystemActorsIndex/components/RoleItem/RoleItem.tsx
@@ -1,0 +1,105 @@
+import { styled } from '@mui/material';
+import Link from 'next/link';
+import React from 'react';
+import RoleChip from '@/components/RoleChip/RoleChip';
+
+import { siteRoutes } from '@/config/routes';
+import type { TeamRole } from '@/core/enums/teamRole';
+import type { Team } from '@/core/models/interfaces/team';
+import type { FC } from 'react';
+
+interface Props {
+  actor: Team;
+  className?: string;
+}
+
+const RoleItem: FC<Props> = ({ actor, className }) => (
+  <Container className={className} href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}`} id="role">
+    <TypeSection>
+      <Label>Role</Label>
+      <WrapperHiddenOnlyMobileCategory>
+        <RoleChip status={(actor.category?.[0] ?? '') as TeamRole} />
+      </WrapperHiddenOnlyMobileCategory>
+    </TypeSection>
+  </Container>
+);
+export default RoleItem;
+
+const Container = styled(Link)(({ theme }) => ({
+  display: 'flex',
+  width: '100%',
+  [theme.breakpoints.up('tablet_768')]: {
+    minWidth: 190,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    paddingTop: 27.5,
+    paddingBottom: 27.5,
+  },
+}));
+const TypeSection = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    justifyContent: 'start',
+    gap: 2,
+    marginLeft: 8,
+    paddingTop: 8,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    paddingLeft: 0,
+    marginTop: -4,
+  },
+
+  [theme.breakpoints.up('desktop_1440')]: {
+    paddingLeft: 0,
+    marginTop: -10,
+    flexDirection: 'row',
+  },
+}));
+
+const Label = styled('div')(({ theme }) => ({
+  display: 'flex',
+  fontFamily: 'Inter, sans-serif',
+  fontStyle: 'normal',
+  fontWeight: 500,
+  fontSize: 12,
+  lineHeight: '18px',
+  color: theme.palette.isLight ? theme.palette.colors.charcoal[300] : 'red',
+  [theme.breakpoints.up('tablet_768')]: {
+    lineHeight: '22px',
+    fontWeight: 600,
+    fontSize: 14,
+    alignItems: 'end',
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'none',
+  },
+}));
+
+const WrapperHiddenOnlyMobileCategory = styled('div')(({ theme }) => ({
+  display: 'flex',
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    marginLeft: 10,
+    marginTop: -6,
+    minWidth: 200,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    marginRight: 12,
+    marginLeft: 40,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    marginRight: 0,
+    marginLeft: 90,
+    paddingTop: 4,
+  },
+}));

--- a/src/views/EcosystemActorsIndex/components/ScopeItem/ScopeItem.tsx
+++ b/src/views/EcosystemActorsIndex/components/ScopeItem/ScopeItem.tsx
@@ -1,0 +1,171 @@
+import { styled } from '@mui/material';
+import Link from 'next/link';
+import React from 'react';
+import ScopeChip from '@/components/ScopeChip/ScopeChip';
+import { siteRoutes } from '@/config/routes';
+import type { Team } from '@/core/models/interfaces/team';
+import GroupedScopes from '../ActorItem/GroupedScopes';
+import type { FC } from 'react';
+interface Props {
+  actor: Team;
+  className?: string;
+}
+
+const ScopeItem: FC<Props> = ({ actor, className }) => (
+  <Container id="scope" className={className} href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}`}>
+    <ContainerMobileTable>
+      <LabelMobile>Scope</LabelMobile>
+      <ContainerScopeMobile>
+        {actor.scopes?.map((item, index) => (
+          <ScopeChip scope={item} key={index} codeOnly />
+        ))}
+      </ContainerScopeMobile>
+    </ContainerMobileTable>
+    <WrapperScopeLinks alignEnd={actor?.scopes?.length === 0}>
+      <ContainerDesk>
+        <ScopeSection>
+          {actor?.scopes?.length > 2 ? (
+            <GroupedScopes scopes={actor.scopes} />
+          ) : (
+            actor?.scopes?.map((item, index) => <ScopeChipStyled scope={item} key={index} />)
+          )}
+        </ScopeSection>
+      </ContainerDesk>
+    </WrapperScopeLinks>
+  </Container>
+);
+
+export default ScopeItem;
+
+const Container = styled(Link)(({ theme }) => ({
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  [theme.breakpoints.up('tablet_768')]: {
+    minWidth: 190,
+    marginLeft: -6,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {},
+}));
+const ContainerMobileTable = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  gap: 4,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    alignItems: 'flex-start',
+    paddingTop: 8,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'none',
+  },
+}));
+const ContainerScopeMobile = styled('div')(({ theme }) => ({
+  display: 'flex',
+
+  flexDirection: 'row',
+  gap: 4,
+  '& div': {
+    width: 34,
+    padding: '0px',
+  },
+  [theme.breakpoints.up('tablet_768')]: {
+    '& div': {
+      width: 40,
+    },
+  },
+}));
+const LabelMobile = styled('div')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 500,
+  lineHeight: '18px',
+  color: theme.palette.isLight ? theme.palette.colors.charcoal[300] : theme.palette.colors.charcoal[700],
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 14,
+    fontWeight: 600,
+    lineHeight: '22px',
+  },
+}));
+
+const WrapperScopeLinks = styled('div')<{ alignEnd: boolean }>(({ alignEnd, theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: alignEnd ? 'flex-end' : 'space-between',
+  [theme.breakpoints.up('tablet_768')]: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingBottom: 'revert',
+    flex: 1,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingBottom: 'revert',
+    flex: 1.5,
+  },
+}));
+
+const ContainerDesk = styled('div')(({ theme }) => ({
+  display: 'none',
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+    flex: 1,
+    marginLeft: 8,
+
+    alignItems: 'center',
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    marginLeft: 34,
+  },
+
+  [theme.breakpoints.up('desktop_1440')]: {
+    marginLeft: 60,
+    marginTop: -6,
+  },
+}));
+
+const ScopeSection = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: 8,
+  justifyContent: 'center',
+  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
+    display: 'none',
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    minWidth: 150,
+    marginLeft: 10,
+
+    gap: 4,
+    width: 202,
+    marginBottom: 0,
+    paddingTop: 14,
+    paddingBottom: 14,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    marginLeft: 8,
+  },
+
+  [theme.breakpoints.up('desktop_1440')]: {
+    minWidth: 150,
+    marginLeft: 22,
+    flexDirection: 'column',
+    gap: 4,
+  },
+}));
+
+const ScopeChipStyled = styled(ScopeChip)(({ theme }) => ({
+  [theme.breakpoints.up('desktop_1024')]: {
+    height: 24,
+  },
+}));

--- a/src/views/EcosystemActorsIndex/components/SocialArrowLinks/SocialArrowLinks.tsx
+++ b/src/views/EcosystemActorsIndex/components/SocialArrowLinks/SocialArrowLinks.tsx
@@ -1,0 +1,74 @@
+import { styled } from '@mui/material';
+import React from 'react';
+import SocialMediaLinksButton from '@/components/ButtonLink/SocialMediaLinksButton';
+import InternalLinkButton from '@/components/InternalLinkButton/InternalLinkButton';
+import { siteRoutes } from '@/config/routes';
+import type { Team } from '@/core/models/interfaces/team';
+import type { FC } from 'react';
+
+interface Props {
+  actor: Team;
+
+  className?: string;
+}
+
+const SocialArrowLinks: FC<Props> = ({ actor, className }) => (
+  <ContainerLinksArrows className={className}>
+    <SocialMediaLinksButton socialMedia={actor.socialMediaChannels?.[0]} hideLabelIn={['desktop_1024']} />
+    <VerticalLine />
+    <InternalLinkButtonStyled href={`${siteRoutes.ecosystemActorAbout(actor.shortCode)}`} showIcon />
+  </ContainerLinksArrows>
+);
+export default SocialArrowLinks;
+
+const ContainerLinksArrows = styled('div')(({ theme }) => ({
+  display: 'flex',
+  width: '100%',
+  flexDirection: 'row',
+  paddingTop: 8,
+  paddingRight: 8,
+  gap: 16,
+  height: 32,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    paddingRight: 0,
+    gap: 8,
+    height: 'revert',
+    alignItems: 'flex-end',
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    paddingRight: 16,
+    paddingTop: 0,
+    alignItems: 'center',
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    paddingRight: 24,
+  },
+}));
+
+const InternalLinkButtonStyled = styled(InternalLinkButton)({
+  borderRadius: 8,
+  padding: '2px 8px 2px 8px',
+  width: 40,
+  ':hover': {
+    padding: '2px 8px 2px 8px',
+  },
+});
+const VerticalLine = styled('div')(({ theme }) => ({
+  display: 'none',
+  [theme.breakpoints.up('desktop_1024')]: {
+    height: 16,
+    display: 'flex',
+    alignItems: 'center',
+    border: `1px solid ${theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[800]}`,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    marginLeft: 8,
+    marginRight: 8,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    marginLeft: 8,
+    marginRight: 8,
+  },
+}));


### PR DESCRIPTION
## Ticket
https://trello.com/c/ukLWiU1h/546-make-each-contributors-row-clickable


## What solved

- [X] Contributors list page reskin: we want it to behave the same was as the “Legacy” deployment. On prod (https://expenses.makerdao.network/ecosystem-actors ) a user can click on the area of the specific contributor in the list and is taken to a new page (no new tabs!) and we want this for the reskin as well.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
