### PR TITLE
[Issue-477]Hidden category section when there is not one

### DIFF
--- a/src/views/CoreUnitsIndex/components/ToolTips/SummaryToolTip.tsx
+++ b/src/views/CoreUnitsIndex/components/ToolTips/SummaryToolTip.tsx
@@ -39,14 +39,17 @@ export const SummaryToolTip: React.FC<Props> = ({ imageUrl, code, name, status, 
         </StatusLastModifiedContainer>
       </InformationContainer>
     </RowContainer>
-    <CategoriesContainer>
-      <CategoriesLabel>Categories</CategoriesLabel>
-      <Categories>
-        {categories.map((category) => (
-          <CategoryChip category={category} />
-        ))}
-      </Categories>
-    </CategoriesContainer>
+    {categories && (
+      <CategoriesContainer>
+        <CategoriesLabel>Categories</CategoriesLabel>
+
+        <Categories>
+          {categories?.map((category) => (
+            <CategoryChip category={category} />
+          ))}
+        </Categories>
+      </CategoriesContainer>
+    )}
   </Container>
 );
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/R6wqimqX/477-reskin-budget-statements-cu-ea-transfer-requests-tab

## What solved
[X] Should fix issues from QC.
Fix issue when hover on CU item that don't have any category
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/8bda448c-b878-493f-af9f-d31677bd6fc0">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
