### PR TITLE
[Reskin-501]Add styles for auditor view

### DIFF
--- a/src/components/BudgetStatement/BudgetStatementMkrVesting/BudgetStatementMkrVestingSection/BudgetStatementMkrVestingTableSection.tsx
+++ b/src/components/BudgetStatement/BudgetStatementMkrVesting/BudgetStatementMkrVestingSection/BudgetStatementMkrVestingTableSection.tsx
@@ -80,7 +80,7 @@ const SESTooltipStyled = styled(SESTooltip)(({ theme }) => ({
   boxShadow: theme.palette.isLight ? theme.fusionShadows.graphShadow : theme.fusionShadows.darkMode,
 }));
 
-const IconContainer = styled('div')(({ theme }) => ({
+export const IconContainer = styled('div')(({ theme }) => ({
   width: 15,
   height: 15,
   display: 'flex',
@@ -109,7 +109,7 @@ const ContainerTitle = styled('div')<{ marginBottom?: number; responsiveMarginBo
   })
 );
 
-const ContainerToolTip = styled('div')(({ theme }) => ({
+export const ContainerToolTip = styled('div')(({ theme }) => ({
   color: theme.palette.isLight ? theme.palette.colors.charcoal[900] : theme.palette.colors.charcoal[100],
   fontSize: 16,
   fontWeight: 500,

--- a/src/components/BudgetStatement/BudgetStatementMkrVesting/MkrVestingTotalFTE.tsx
+++ b/src/components/BudgetStatement/BudgetStatementMkrVesting/MkrVestingTotalFTE.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 
 interface MkrVestingTotalFTEProps {
   totalFTE: string | number;
+  className?: string;
 }
 
-const MkrVestingTotalFTE: React.FC<MkrVestingTotalFTEProps> = ({ totalFTE }) => (
-  <Container>
+const MkrVestingTotalFTE: React.FC<MkrVestingTotalFTEProps> = ({ totalFTE, className }) => (
+  <Container className={className}>
     <TotalFte>
       <span>Total FTEs</span>
       <u>{totalFTE}</u>

--- a/src/components/BudgetStatement/ExpenseReport/ExpenseReport.tsx
+++ b/src/components/BudgetStatement/ExpenseReport/ExpenseReport.tsx
@@ -1,28 +1,24 @@
-import styled from '@emotion/styled';
-import { CustomLink } from '@ses/components/CustomLink/CustomLink';
-import { ResourceType } from '@ses/core/models/interfaces/types';
-import { MAKER_BURN_LINK } from '@ses/core/utils/const';
-import lightTheme from '@ses/styles/theme/themes';
+import { styled } from '@mui/material';
+
 import React from 'react';
 import { AdvancedInnerTable } from '@/components/AdvancedInnerTable/AdvancedInnerTable';
 import CategoryModalComponent from '@/components/AdvancedInnerTable/BasicModal/CategoryModalComponent';
 import Container from '@/components/Container/Container';
-import Tabs from '@/components/Tabs/Tabs';
+import CuHeadlineText from '@/components/CuHeadlineText/CuHeadlineText';
+import BudgetStatementsPlaceholder from '@/components/PlaceHolders/BudgetStatementsPlaceholder';
 
-import { TransparencyEmptyTable } from '@/views/CoreUnitBudgetStatement/components/Placeholders/TransparencyEmptyTable';
+import Tabs from '@/components/Tabs/Tabs';
 import {
   ACTUALS_BREAKDOWN_QUERY_PARAM,
   BREAKDOWN_VIEW_QUERY_KEY,
   FORECAST_BREAKDOWN_QUERY_PARAM,
 } from '@/views/CoreUnitBudgetStatement/utils/constants';
-import { LinkDescription } from '../BudgetStatementActuals/BudgetStatementActuals';
-import MkrVestingInfo from '../BudgetStatementMkrVesting/MkrVestingInfo';
 import MkrVestingTotalFTE from '../BudgetStatementMkrVesting/MkrVestingTotalFTE';
 import ExpenseSection from './components/ExpenseSection/ExpenseSection';
 import SectionTitle from './components/SectionTitle/SectionTitle';
 import useExpenseReport from './useExpenseReport';
 import type { BudgetStatement } from '@ses/core/models/interfaces/budgetStatement';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+import type { ResourceType } from '@ses/core/models/interfaces/types';
 import type { DateTime } from 'luxon';
 
 interface ExpenseReportProps {
@@ -35,7 +31,6 @@ interface ExpenseReportProps {
 
 const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetStatements, code, longCode, resource }) => {
   const {
-    isLight,
     L2SectionInner,
     L2SectionOuter,
     actualsData,
@@ -53,33 +48,16 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
   return (
     <ExpenseReportWrapper>
       <Container>
-        <LinkDescription>
-          <span> Visit makerburn.com to view the</span>
-          <ActualViewOnChainLink
-            href={`${MAKER_BURN_LINK}/${longCode}`}
-            fontSize={16}
-            fontWeight={500}
-            iconWidth={10}
-            iconHeight={10}
-            marginLeft="7px"
-          >
-            {`${code} ${
-              resource === ResourceType.CoreUnit ? 'Core Unit' : 'Ecosystem Actor'
-            } On-Chain transaction history`}
-          </ActualViewOnChainLink>
-
-          <BudgetDateTitle isLight={isLight}>{currentMonth.toFormat('MMMM yyyy')} Expense Report</BudgetDateTitle>
-        </LinkDescription>
+        <CuHeadlineTextStyled cuLongCode={longCode} shortCode={code} />
       </Container>
 
       <ExpenseSection title={'Actuals - Totals'}>
         <BudgetTable
-          isLight={isLight}
           columns={actualsData.mainTableColumns}
           items={actualsData.mainTableItems}
           cardsTotalPosition="top"
           longCode={longCode}
-          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={code} resource={resource} />}
+          tablePlaceholder={<BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />}
         />
 
         {actualsData.mainTableItems?.length > 0 && (
@@ -104,13 +82,12 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
             {isBreakdownExpanded ? (
               <BreakdownTableWrapper>
                 <BudgetTable
-                  isLight={isLight}
                   columns={actualsData.breakdownColumnsForActiveTab}
                   items={actualsData.breakdownItemsForActiveTab}
                   longCode={longCode}
                   cardSpacingSize="small"
                   tablePlaceholder={
-                    <TransparencyEmptyTable breakdown longCode={longCode} shortCode={code} resource={resource} />
+                    <BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />
                   }
                 />
               </BreakdownTableWrapper>
@@ -119,11 +96,10 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                 {actualsData.breakdownTabs.map((header, index) => (
                   <L2SectionInner key={header}>
                     <BudgetSubsectionContainer isFirst={index === 0}>
-                      <SectionTitle level={2} hasIcon={true} hasExternalIcon={true} idPrefix={'actuals'}>
+                      <SectionTitle level={2} hasIcon={false} hasExternalIcon={false} idPrefix={'actuals'}>
                         {header}
                       </SectionTitle>
                       <BudgetTable
-                        isLight={isLight}
                         columns={actualsData.allBreakdownColumns[header]}
                         items={actualsData.allBreakdownItems[header]}
                         longCode={longCode}
@@ -131,12 +107,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                         cardSpacingSize="small"
                         tablePlaceholder={
                           <div style={{ marginTop: 16 }}>
-                            <TransparencyEmptyTable
-                              breakdown
-                              longCode={longCode}
-                              shortCode={code}
-                              resource={resource}
-                            />
+                            <BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />
                           </div>
                         }
                       />
@@ -152,13 +123,12 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
 
       <ExpenseSection title={'Forecast - Totals'}>
         <BudgetTable
-          isLight={isLight}
           longCode={longCode}
           columns={forecastData.mainTableColumns}
           items={forecastData.mainTableItems}
           style={{ marginBottom: 32 }}
           cardsTotalPosition={'top'}
-          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={code} resource={resource} />}
+          tablePlaceholder={<BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />}
         />
 
         {forecastData.mainTableItems?.length > 0 && (
@@ -183,13 +153,12 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
             {isBreakdownExpanded ? (
               <BreakdownTableWrapper>
                 <BudgetTable
-                  isLight={isLight}
                   longCode={longCode}
                   columns={forecastData.breakdownColumnsForActiveTab}
                   items={forecastData.breakdownItems}
                   cardSpacingSize="small"
                   tablePlaceholder={
-                    <TransparencyEmptyTable breakdown longCode={longCode} shortCode={code} resource={resource} />
+                    <BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />
                   }
                 />
               </BreakdownTableWrapper>
@@ -198,11 +167,10 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                 {forecastData.breakdownTabs.map((header, index) => (
                   <L2SectionInner key={header}>
                     <BudgetSubsectionContainer isFirst={index === 0}>
-                      <SectionTitle level={2} hasIcon={true} hasExternalIcon={true} idPrefix={'forecast'}>
+                      <SectionTitle level={2} hasIcon={false} hasExternalIcon={false} idPrefix={'forecast'}>
                         {header}
                       </SectionTitle>
                       <BudgetTable
-                        isLight={isLight}
                         columns={forecastData.allBreakdownColumns[header]}
                         items={forecastData.allBreakdownItems[header]}
                         longCode={longCode}
@@ -210,12 +178,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                         cardSpacingSize="small"
                         tablePlaceholder={
                           <div style={{ marginTop: 16 }}>
-                            <TransparencyEmptyTable
-                              breakdown
-                              longCode={longCode}
-                              shortCode={code}
-                              resource={resource}
-                            />
+                            <BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />
                           </div>
                         }
                       />
@@ -228,32 +191,24 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
         )}
       </ExpenseSection>
 
-      <ExpenseSection title={'MKR Vesting Overview'}>
-        <MkrVestingTotalFTE totalFTE={mkrVestingData.fTEs} />
+      <ExpenseSection title={'MKR Vesting Overview'} hasIcon>
+        <MkrVestingTotalFTEStyled totalFTE={mkrVestingData.fTEs} />
 
         <BudgetTable
-          isLight={isLight}
           columns={mkrVestingData.mainTableColumns}
           items={mkrVestingData.mainTableItems}
           longCode={longCode}
-          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={code} resource={resource} />}
+          tablePlaceholder={<BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />}
         />
-
-        {mkrVestingData.mainTableItems?.length > 0 && (
-          <MkrVestingInfoContainer>
-            <MkrVestingInfo />
-          </MkrVestingInfoContainer>
-        )}
       </ExpenseSection>
 
       <ExpenseSection title={'Transfer Request'}>
         <BudgetTable
-          isLight={isLight}
           columns={transferRequestsData.mainTableColumns}
           items={transferRequestsData.mainTableItems}
           cardsTotalPosition={'top'}
           longCode={longCode}
-          tablePlaceholder={<TransparencyEmptyTable longCode={longCode} shortCode={code} resource={resource} />}
+          tablePlaceholder={<BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />}
         />
       </ExpenseSection>
     </ExpenseReportWrapper>
@@ -262,69 +217,49 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
 
 export default ExpenseReport;
 
-const ExpenseReportWrapper = styled.div({
+const ExpenseReportWrapper = styled('div')({
   marginBottom: 32,
-});
-
-const ActualViewOnChainLink = styled(CustomLink)({
-  color: '#447AFB',
-  letterSpacing: '0.3px',
-  fontSize: 14,
-  lineHeight: '22px',
-  marginLeft: 0,
-  whiteSpace: 'break-spaces',
-  display: 'inline',
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    lineHeight: '18px',
-  },
 });
 
 const BudgetTable = styled((props: React.ComponentProps<typeof AdvancedInnerTable>) => (
   <AdvancedInnerTable {...props} />
-))<WithIsLight>(({ isLight }) => ({
-  boxShadow: isLight
-    ? '0px 20px 40px -40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
-    : '0px 20px 40px -40px rgba(7, 22, 40, 0.4), 0px 1px 3px rgba(30, 23, 23, 0.25)',
-}));
+))(() => ({}));
 
-const BudgetDateTitle = styled.h1<WithIsLight>(({ isLight }) => ({
-  fontSize: 20,
-  fontWeight: 600,
-  lineHeight: '24px',
-  letterSpacing: '0.4px',
-  color: isLight ? '#231536' : '#D2D4EF',
-  marginTop: 24,
-  marginBottom: 24,
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    fontSize: 24,
-    lineHeight: '29px',
-    marginBottom: 32,
-  },
-}));
-
-const TitleSpacer = styled.div({
+const TitleSpacer = styled('div')(({ theme }) => ({
   marginTop: 16,
   marginBottom: 16,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     marginTop: 32,
   },
-});
+}));
 
-const BudgetSubsectionContainer = styled.div<{ isFirst: boolean }>(({ isFirst }) => ({
+const BudgetSubsectionContainer = styled('div')<{ isFirst: boolean }>(({ isFirst, theme }) => ({
   marginTop: 0,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     ...(isFirst ? {} : { marginTop: 24 }),
   },
 }));
 
-const MkrVestingInfoContainer = styled.div({
-  marginTop: 32,
+const BreakdownTableWrapper = styled('div')({
+  marginTop: 16,
 });
 
-const BreakdownTableWrapper = styled.div({
-  marginTop: 16,
+const CuHeadlineTextStyled = styled(CuHeadlineText)({
+  marginTop: 24,
+  marginBottom: 25,
+});
+
+const MkrVestingTotalFTEStyled = styled(MkrVestingTotalFTE)({
+  '& span': {
+    fontSize: 16,
+    lineHeight: '24px',
+    fontWeight: 700,
+  },
+  '& u': {
+    fontSize: 18,
+    lineHeight: '21.6px',
+    fontWeight: 700,
+  },
 });

--- a/src/components/BudgetStatement/ExpenseReport/components/ExpenseSection/ExpenseSection.tsx
+++ b/src/components/BudgetStatement/ExpenseReport/components/ExpenseSection/ExpenseSection.tsx
@@ -1,26 +1,28 @@
-import styled from '@emotion/styled';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
-import lightTheme from '@ses/styles/theme/themes';
+import { styled } from '@mui/material';
+
 import React from 'react';
 import Container from '@/components/Container/Container';
 import SectionTitle from '../SectionTitle/SectionTitle';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface ExpenseSectionProps extends React.PropsWithChildren {
   title?: string;
   level?: 1 | 2;
+  hasIcon?: boolean;
 }
 
-const ExpenseSection: React.FC<ExpenseSectionProps> = ({ children, level = 1, title }) => {
-  const { isLight } = useThemeContext();
+const ExpenseSection: React.FC<ExpenseSectionProps> = ({ children, level = 1, title, hasIcon = false }) => {
   const Wrapper = level === 1 ? WrapperL1 : WrapperL2;
   const LevelContainer = level === 1 ? L1Container : React.Fragment;
 
   return (
     <ExpensesContainer level={level}>
-      <Wrapper isLight={isLight}>
+      <Wrapper>
         <LevelContainer>
-          {title && <SectionTitle hasExternalIcon={true}>{title}</SectionTitle>}
+          {title && (
+            <SectionTitle hasExternalIcon={true} hasIcon={hasIcon}>
+              {title}
+            </SectionTitle>
+          )}
 
           <ChildrenContainer hasMargin={!!title}>{children}</ChildrenContainer>
         </LevelContainer>
@@ -31,11 +33,11 @@ const ExpenseSection: React.FC<ExpenseSectionProps> = ({ children, level = 1, ti
 
 export default ExpenseSection;
 
-const ExpensesContainer = styled(Container)<{ level: 1 | 2 }>(({ level }) => ({
+const ExpensesContainer = styled('div')<{ level: 1 | 2 }>(({ level, theme }) => ({
   paddingLeft: 0,
   paddingRight: 0,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     ...(level === 2 && {
       paddingLeft: 0,
       paddingRight: 0,
@@ -43,70 +45,70 @@ const ExpensesContainer = styled(Container)<{ level: 1 | 2 }>(({ level }) => ({
   },
 }));
 
-const L1Container = styled(Container)({
-  [lightTheme.breakpoints.up('table_834')]: {
+const L1Container = styled(Container)(({ theme }) => ({
+  [theme.breakpoints.up('tablet_768')]: {
     paddingLeft: 16,
     paddingRight: 16,
   },
-
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     paddingLeft: 24,
     paddingRight: 24,
   },
-
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+  [theme.breakpoints.up('desktop_1280')]: {
     paddingLeft: 32,
     paddingRight: 32,
   },
-});
+}));
 
-const WrapperL1 = styled.div<WithIsLight>(({ isLight }) => ({
-  padding: '16px 0',
-  background: isLight ? '#F6F8F9' : '#121F27',
-  boxShadow: isLight
-    ? '0px 20px 40px -40px rgba(219, 227, 237, 0.4), 0px 1px 3px rgba(190, 190, 190, 0.25)'
-    : '0px -20px 40px -40px rgba(7, 22, 40, 0.4), 0px -1px 3px rgba(30, 23, 23, 0.25)',
+const WrapperL1 = styled('div')(({ theme }) => ({
+  padding: '8px 0',
+
+  background: theme.palette.isLight ? theme.palette.colors.charcoal[100] : '#1E222A',
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.graphShadow : theme.fusionShadows.darkMode,
   marginBottom: 24,
 
-  [lightTheme.breakpoints.up('table_834')]: {
-    padding: '16px 0 32px',
-    marginBottom: 32,
+  [theme.breakpoints.up('tablet_768')]: {
+    background: theme.palette.isLight ? theme.palette.colors.gray[100] : '#1E222A',
+    padding: '8px 0 24px',
   },
 }));
 
-const WrapperL2 = styled.div<WithIsLight>(({ isLight }) => ({
+const WrapperL2 = styled('div')(({ theme }) => ({
   padding: '16px 8px',
-  background: isLight ? '#ECF1F3' : '#0C1318',
+  borderRadius: 12,
+  background: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.background.dm,
   marginTop: 16,
-  borderRadius: 6,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  border: `1px solid ${
+    theme.palette.isLight ? theme.palette.colors.charcoal[100] : theme.palette.colors.charcoal[800]
+  }`,
+  [theme.breakpoints.up('tablet_768')]: {
     padding: 16,
-    marginTop: 32,
+    marginTop: 24,
   },
 
-  [lightTheme.breakpoints.up('desktop_1194')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     padding: '16px 24px 32px',
   },
 
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+  [theme.breakpoints.up('desktop_1280')]: {
     padding: '16px 32px 32px',
   },
 
   // custom style for the table header sections
   '.advanced-table--group-section': {
     lineHeight: '17px',
-    background: isLight ? 'rgba(255, 255, 255, 0.4)' : 'rgba(30, 44, 55, 0.7)',
+    background: theme.palette.isLight ? 'rgba(255, 255, 255, 0.4)' : 'rgba(30, 44, 55, 0.7)',
     padding: '8px 16px',
     marginTop: 24,
     marginBottom: 8,
   },
 }));
 
-const ChildrenContainer = styled.div<{ hasMargin: boolean }>(({ hasMargin }) => ({
+const ChildrenContainer = styled('div')<{ hasMargin: boolean }>(({ hasMargin, theme }) => ({
   marginTop: hasMargin ? 16 : 0,
 
-  [lightTheme.breakpoints.up('table_834')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     marginTop: hasMargin ? 24 : 0,
   },
 }));

--- a/src/components/BudgetStatement/ExpenseReport/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/BudgetStatement/ExpenseReport/components/SectionTitle/SectionTitle.tsx
@@ -1,11 +1,13 @@
-import styled from '@emotion/styled';
-import ArrowLink from '@ses/components/svg/ArrowLink';
-import Wallet from '@ses/components/svg/wallet';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { styled } from '@mui/material';
 import { toKebabCase } from '@ses/core/utils/string';
 import lightTheme from '@ses/styles/theme/themes';
+import Info from 'public/assets/svg/info_outlined.svg';
 import React from 'react';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
+import {
+  ContainerToolTip,
+  IconContainer,
+} from '@/components/BudgetStatement/BudgetStatementMkrVesting/BudgetStatementMkrVestingSection/BudgetStatementMkrVestingTableSection';
+import SESTooltip from '@/components/SESTooltip/SESTooltip';
 
 interface SectionTitleProps extends React.PropsWithChildren {
   level?: 1 | 2;
@@ -14,92 +16,72 @@ interface SectionTitleProps extends React.PropsWithChildren {
   idPrefix?: string;
 }
 
-const SectionTitle: React.FC<SectionTitleProps> = ({
-  children,
-  level = 1,
-  hasIcon = false,
-  hasExternalIcon = false,
-  idPrefix = '',
-}) => {
-  const { isLight } = useThemeContext();
-
-  return (
-    <Title
-      isLight={isLight}
-      level={level}
-      as={level === 1 ? 'h2' : 'h3'}
-      id={`#${idPrefix}-${toKebabCase(children as string)}`}
-    >
-      {hasIcon && (
-        <IconContainer>
-          <Wallet fill={isLight ? '#231536' : '#D2D4EF'} />
-        </IconContainer>
-      )}
+const SectionTitle: React.FC<SectionTitleProps> = ({ children, level = 1, hasIcon = false, idPrefix = '' }) => (
+  <Container>
+    <Title level={level} as={level === 1 ? 'h2' : 'h3'} id={`#${idPrefix}-${toKebabCase(children as string)}`}>
       {children}
-      {hasExternalIcon && (
-        <StyledArrowLink href={`#${idPrefix}-${toKebabCase(children as string)}`} target="_blank" fill={'#447AFB'} />
-      )}
     </Title>
-  );
-};
+    {hasIcon && (
+      <ContainerTitle>
+        <SESTooltipStyled
+          content={
+            <ContainerToolTip>This Overview is based on MIP40c3-SP17, SES’MKR Incentive Proposal.</ContainerToolTip>
+          }
+        >
+          <IconContainer className="advance-table--transparency-card_icon_hidden">
+            <Info />
+          </IconContainer>
+        </SESTooltipStyled>
+      </ContainerTitle>
+    )}
+  </Container>
+);
 
 export default SectionTitle;
 
-const Title = styled.h2<{ level: number } & WithIsLight>(({ isLight, level }) => ({
+const Title = styled('h2')<{ level: number }>(({ theme, level }) => ({
   display: 'flex',
   alignItems: 'center',
   fontSize: 16,
-  lineHeight: '19px',
-  letterSpacing: level === 1 ? 0 : '0.3px',
-  fontWeight: 700,
-  color: isLight ? '#231536' : '#D2D4EF',
+  lineHeight: level === 1 ? '24px' : 'normal',
+
+  fontWeight: level === 1 ? 600 : 700,
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   margin: 0,
-  fontFeatureSettings: "'tnum' on, 'lnum' on",
 
-  [lightTheme.breakpoints.up('table_834')]: {
-    fontSize: level === 1 ? 20 : 18,
-    lineHeight: level === 1 ? '24px' : '22px',
+  [lightTheme.breakpoints.up('tablet_768')]: {
+    fontSize: 18,
+    lineHeight: '21.6px',
     letterSpacing: '0.4px',
-    fontWeight: level === 1 ? 600 : 500,
-  },
-
-  [lightTheme.breakpoints.up('desktop_1194')]: {
-    fontSize: 20,
-    lineHeight: '24px',
+    fontWeight: 700,
   },
 }));
 
-const IconContainer = styled.div({
-  display: 'inline-flex',
-  marginRight: 12,
-
-  svg: {
-    width: 10,
-    height: 10,
-
-    [lightTheme.breakpoints.up('table_834')]: {
-      width: 20,
-      height: 20,
+const ContainerTitle = styled('div')<{ marginBottom?: number; responsiveMarginBottom?: number; marginTop?: number }>(
+  ({ marginBottom = 24, responsiveMarginBottom, theme, marginTop = 24 }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12.5,
+    marginTop,
+    marginBottom: `${marginBottom}px`,
+    [theme.breakpoints.up('tablet_768')]: {
+      marginBottom: `${responsiveMarginBottom || marginBottom}px`,
     },
-  },
-});
+  })
+);
 
-const StyledArrowLink = styled(ArrowLink)({
-  marginLeft: 8,
+const SESTooltipStyled = styled(SESTooltip)(({ theme }) => ({
+  padding: 0,
+  marginTop: 0,
+  width: '100%',
+  backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
+  minWidth: 327,
+  borderRadius: 12,
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.graphShadow : theme.fusionShadows.darkMode,
+}));
+
+const Container = styled('div')({
   display: 'flex',
-  alignItems: 'center',
-
-  [lightTheme.breakpoints.up('table_834')]: {
-    marginLeft: 10,
-  },
-
-  svg: {
-    width: 16,
-    height: 16,
-
-    [lightTheme.breakpoints.up('table_834')]: {
-      width: 20,
-      height: 20,
-    },
-  },
+  gap: 12.5,
 });

--- a/src/components/CuHeadlineText/CuHeadlineText.tsx
+++ b/src/components/CuHeadlineText/CuHeadlineText.tsx
@@ -12,10 +12,10 @@ interface CuHeadlineTextProps {
   isCoreUnit?: boolean;
 }
 
-const CuHeadlineText: React.FC<CuHeadlineTextProps> = ({ cuLongCode, isCoreUnit = true, shortCode }) => {
+const CuHeadlineText: React.FC<CuHeadlineTextProps> = ({ cuLongCode, isCoreUnit = true, shortCode, className }) => {
   const resource = isCoreUnit ? 'Core Unit' : 'Ecosystem Actor';
   return (
-    <LinkDescription>
+    <LinkDescription className={className}>
       <ExternalLinkButtonStyled href={`${MAKER_BURN_LINK}/${cuLongCode}`} wrapText={false}>
         {`${shortCode} ${resource} on-chain transaction history`}
       </ExternalLinkButtonStyled>


### PR DESCRIPTION
## Ticket
https://trello.com/c/64GRv7Lz/501-reskin-budget-statements-cu-ea-auditor-view


## What solved

- [X] Should update the Auditor view tabs for the light/dark mode. Desktop/Small resolutions
- [X] Should update the external link for the light/dark mode. Desktop/Small resolutions. 
- [X]  Should update the Actuals-Totals section for the light/dark mode. Desktop resolutions.
- [X]  Should update the Actuals-Totals section for the light/dark mode. Small resolutions.
- [X] Should update the Actuals-Breakdown section (title + expand/collapse icon + tabs) for light/dark mode. Desktop/Small resolutions.
- [X] Should update the breakdown table styles (table, text, values) for light/dark mode. Desktop resolutions.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
