### PR TITLE
Update the link and target link in core unit item

### DIFF
--- a/src/views/CoreUnitsIndex/components/CuTableColumnExpenditures/CuTableColumnExpenditures.tsx
+++ b/src/views/CoreUnitsIndex/components/CuTableColumnExpenditures/CuTableColumnExpenditures.tsx
@@ -26,7 +26,7 @@ export const CuTableColumnExpenditures = ({ isLoading = false, ...props }: CuTab
   const router = useRouter();
   const queryStrings = useMemo(() => buildQueryString(router.query), [router.query]);
   return !isLoading ? (
-    <LinkStyle href={`${siteRoutes.coreUnitAbout(props?.code || '')}/${queryStrings}`}>
+    <LinkStyle href={`${siteRoutes.coreUnitReports(props?.code || '')}/${queryStrings}`}>
       <Container>
         <Title>Latest 3 Months</Title>
         <DataWrapper>

--- a/src/views/CoreUnitsIndex/components/CuTableColumnSummary/CuTableColumnSummary.tsx
+++ b/src/views/CoreUnitsIndex/components/CuTableColumnSummary/CuTableColumnSummary.tsx
@@ -75,7 +75,7 @@ export const CuTableColumnSummary = ({ hasPopup = true, ...props }: CuTableColum
   return (
     <Container onClick={props.onClick} style={props.style}>
       <ContainerSummary>
-        <CircleContainer href={props.href} target="_blank">
+        <CircleContainer href={props.href}>
           <PopupWrapper
             hasPopup={hiddenPopOverSmallDevices}
             code={props.code}


### PR DESCRIPTION
## Ticket
https://trello.com/c/47RkwnO6/549-update-the-expenditure-section-link-in-the-core-units-index

## What solved
- [X] Should the section be direct to the Budget Statements page.
- [X] Should the About view be opened in the same tab instead of a new one.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
