### PR TITLE
[Reskin-49] Delete the flag target blank in the text

### DIFF
--- a/src/views/CoreUnitsIndex/components/CuTableColumnSummary/CuTableColumnSummary.tsx
+++ b/src/views/CoreUnitsIndex/components/CuTableColumnSummary/CuTableColumnSummary.tsx
@@ -97,7 +97,7 @@ export const CuTableColumnSummary = ({ hasPopup = true, ...props }: CuTableColum
           </PopupWrapper>
         </CircleContainer>
         <Content>
-          <TitleWrapper href={props.href} target="_blank">
+          <TitleWrapper href={props.href}>
             <Code>{props.code}</Code>
             <Title longCode={(props.code?.length ?? 0) > 3}>{props.title}</Title>
           </TitleWrapper>


### PR DESCRIPTION
## Ticket
https://trello.com/c/47RkwnO6/549-update-the-expenditure-section-link-in-the-core-units-index



## What solved

- [X] Should the About view be opened in the same tab instead of a new one clicking on the name and code.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
