### PR TITLE
Add styles for the auditios view

### DIFF
--- a/src/components/BudgetStatement/ExpenseReport/ExpenseReport.tsx
+++ b/src/components/BudgetStatement/ExpenseReport/ExpenseReport.tsx
@@ -55,6 +55,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
         <BudgetTable
           columns={actualsData.mainTableColumns}
           items={actualsData.mainTableItems}
+          cardSpacingSize="small"
           cardsTotalPosition="top"
           longCode={longCode}
           tablePlaceholder={<BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />}
@@ -96,17 +97,17 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                 {actualsData.breakdownTabs.map((header, index) => (
                   <L2SectionInner key={header}>
                     <BudgetSubsectionContainer isFirst={index === 0}>
-                      <SectionTitle level={2} hasIcon={false} hasExternalIcon={false} idPrefix={'actuals'}>
+                      <StyledSectionTitle level={2} hasIcon={false} hasExternalIcon={false} idPrefix={'actuals'}>
                         {header}
-                      </SectionTitle>
+                      </StyledSectionTitle>
                       <BudgetTable
                         columns={actualsData.allBreakdownColumns[header]}
                         items={actualsData.allBreakdownItems[header]}
                         longCode={longCode}
-                        style={{ marginTop: 16 }}
+                        style={{ marginTop: 8 }}
                         cardSpacingSize="small"
                         tablePlaceholder={
-                          <div style={{ marginTop: 16 }}>
+                          <div style={{ marginTop: 8 }}>
                             <BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />
                           </div>
                         }
@@ -123,12 +124,17 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
 
       <ExpenseSection title={'Forecast - Totals'}>
         <BudgetTable
+          cardSpacingSize="small"
           longCode={longCode}
           columns={forecastData.mainTableColumns}
           items={forecastData.mainTableItems}
-          style={{ marginBottom: 32 }}
+          style={{ marginBottom: 8 }}
           cardsTotalPosition={'top'}
-          tablePlaceholder={<BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />}
+          tablePlaceholder={
+            <div style={{ marginTop: 8 }}>
+              <BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />
+            </div>
+          }
         />
 
         {forecastData.mainTableItems?.length > 0 && (
@@ -167,17 +173,17 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
                 {forecastData.breakdownTabs.map((header, index) => (
                   <L2SectionInner key={header}>
                     <BudgetSubsectionContainer isFirst={index === 0}>
-                      <SectionTitle level={2} hasIcon={false} hasExternalIcon={false} idPrefix={'forecast'}>
+                      <StyledSectionTitle level={2} hasIcon={false} hasExternalIcon={false} idPrefix={'forecast'}>
                         {header}
-                      </SectionTitle>
+                      </StyledSectionTitle>
                       <BudgetTable
                         columns={forecastData.allBreakdownColumns[header]}
                         items={forecastData.allBreakdownItems[header]}
                         longCode={longCode}
-                        style={{ marginTop: 16 }}
+                        style={{ marginTop: 8 }}
                         cardSpacingSize="small"
                         tablePlaceholder={
-                          <div style={{ marginTop: 16 }}>
+                          <div style={{ marginTop: 8 }}>
                             <BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />
                           </div>
                         }
@@ -226,7 +232,7 @@ const BudgetTable = styled((props: React.ComponentProps<typeof AdvancedInnerTabl
 ))(() => ({}));
 
 const TitleSpacer = styled('div')(({ theme }) => ({
-  marginTop: 16,
+  marginTop: 32,
   marginBottom: 16,
 
   [theme.breakpoints.up('tablet_768')]: {
@@ -238,7 +244,14 @@ const BudgetSubsectionContainer = styled('div')<{ isFirst: boolean }>(({ isFirst
   marginTop: 0,
 
   [theme.breakpoints.up('tablet_768')]: {
-    ...(isFirst ? {} : { marginTop: 24 }),
+    ...(isFirst ? {} : { marginTop: 16 }),
+    borderRadius: 12,
+    padding: '8px 16px 16px',
+    background: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.background.dm,
+
+    border: `1px solid ${
+      theme.palette.isLight ? theme.palette.colors.charcoal[100] : theme.palette.colors.charcoal[800]
+    }`,
   },
 }));
 
@@ -263,3 +276,10 @@ const MkrVestingTotalFTEStyled = styled(MkrVestingTotalFTE)({
     fontWeight: 700,
   },
 });
+
+const StyledSectionTitle = styled(SectionTitle)(({ theme }) => ({
+  marginBottom: 16,
+  [theme.breakpoints.up('tablet_768')]: {
+    marginBottom: 0,
+  },
+}));

--- a/src/components/BudgetStatement/ExpenseReport/components/ExpenseSection/ExpenseSection.tsx
+++ b/src/components/BudgetStatement/ExpenseReport/components/ExpenseSection/ExpenseSection.tsx
@@ -8,14 +8,15 @@ interface ExpenseSectionProps extends React.PropsWithChildren {
   title?: string;
   level?: 1 | 2;
   hasIcon?: boolean;
+  className?: string;
 }
 
-const ExpenseSection: React.FC<ExpenseSectionProps> = ({ children, level = 1, title, hasIcon = false }) => {
+const ExpenseSection: React.FC<ExpenseSectionProps> = ({ children, level = 1, title, hasIcon = false, className }) => {
   const Wrapper = level === 1 ? WrapperL1 : WrapperL2;
   const LevelContainer = level === 1 ? L1Container : React.Fragment;
 
   return (
-    <ExpensesContainer level={level}>
+    <ExpensesContainer level={level} className={className}>
       <Wrapper>
         <LevelContainer>
           {title && (
@@ -74,7 +75,7 @@ const WrapperL1 = styled('div')(({ theme }) => ({
 }));
 
 const WrapperL2 = styled('div')(({ theme }) => ({
-  padding: '16px 8px',
+  padding: '16px 16px',
   borderRadius: 12,
   background: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.background.dm,
   marginTop: 16,
@@ -85,6 +86,8 @@ const WrapperL2 = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('tablet_768')]: {
     padding: 16,
     marginTop: 24,
+    border: 'revert',
+    background: 'revert',
   },
 
   [theme.breakpoints.up('desktop_1024')]: {
@@ -94,21 +97,12 @@ const WrapperL2 = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('desktop_1280')]: {
     padding: '16px 32px 32px',
   },
-
-  // custom style for the table header sections
-  '.advanced-table--group-section': {
-    lineHeight: '17px',
-    background: theme.palette.isLight ? 'rgba(255, 255, 255, 0.4)' : 'rgba(30, 44, 55, 0.7)',
-    padding: '8px 16px',
-    marginTop: 24,
-    marginBottom: 8,
-  },
 }));
 
 const ChildrenContainer = styled('div')<{ hasMargin: boolean }>(({ hasMargin, theme }) => ({
   marginTop: hasMargin ? 16 : 0,
 
   [theme.breakpoints.up('tablet_768')]: {
-    marginTop: hasMargin ? 24 : 0,
+    marginTop: hasMargin ? 16 : 0,
   },
 }));

--- a/src/components/BudgetStatement/ExpenseReport/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/BudgetStatement/ExpenseReport/components/SectionTitle/SectionTitle.tsx
@@ -14,16 +14,24 @@ interface SectionTitleProps extends React.PropsWithChildren {
   hasIcon?: boolean;
   hasExternalIcon?: boolean;
   idPrefix?: string;
+  className?: string;
 }
 
-const SectionTitle: React.FC<SectionTitleProps> = ({ children, level = 1, hasIcon = false, idPrefix = '' }) => (
-  <Container>
+const SectionTitle: React.FC<SectionTitleProps> = ({
+  children,
+  level = 1,
+  hasIcon = false,
+  idPrefix = '',
+  className,
+}) => (
+  <Container className={className}>
     <Title level={level} as={level === 1 ? 'h2' : 'h3'} id={`#${idPrefix}-${toKebabCase(children as string)}`}>
       {children}
     </Title>
     {hasIcon && (
       <ContainerTitle>
         <SESTooltipStyled
+          showAsModal
           content={
             <ContainerToolTip>This Overview is based on MIP40c3-SP17, SES’MKR Incentive Proposal.</ContainerToolTip>
           }
@@ -48,7 +56,6 @@ const Title = styled('h2')<{ level: number }>(({ theme, level }) => ({
   fontWeight: level === 1 ? 600 : 700,
   color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   margin: 0,
-
   [lightTheme.breakpoints.up('tablet_768')]: {
     fontSize: 18,
     lineHeight: '21.6px',
@@ -57,19 +64,12 @@ const Title = styled('h2')<{ level: number }>(({ theme, level }) => ({
   },
 }));
 
-const ContainerTitle = styled('div')<{ marginBottom?: number; responsiveMarginBottom?: number; marginTop?: number }>(
-  ({ marginBottom = 24, responsiveMarginBottom, theme, marginTop = 24 }) => ({
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12.5,
-    marginTop,
-    marginBottom: `${marginBottom}px`,
-    [theme.breakpoints.up('tablet_768')]: {
-      marginBottom: `${responsiveMarginBottom || marginBottom}px`,
-    },
-  })
-);
+const ContainerTitle = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: 12.5,
+}));
 
 const SESTooltipStyled = styled(SESTooltip)(({ theme }) => ({
   padding: 0,


### PR DESCRIPTION

## Ticket
https://trello.com/c/64GRv7Lz/501-reskin-budget-statements-cu-ea-auditor-view


## What solved

- [X] Should update the breakdown table styles (table, text, values) for light/dark mode. Small resolutions.
- [X]  Should update the Forecast Totals section for light/dark mode. Desktop resolutions. 
- [X] Should update the Forecast Totals section for light/dark mode. Small resolutions.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
