### PR TITLE
Add the styles for the arrow in the tab

### DIFF
--- a/src/components/BudgetStatement/ExpenseReport/ExpenseReport.tsx
+++ b/src/components/BudgetStatement/ExpenseReport/ExpenseReport.tsx
@@ -68,6 +68,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
             </TitleSpacer>
 
             <Tabs
+              showBorderBottomIconTab={true}
               tabs={actualsData.breakdownTabs.map((header, i) => ({
                 item: header,
                 id: actualsData.headerIds[i],
@@ -145,6 +146,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
             </TitleSpacer>
 
             <Tabs
+              showBorderBottomIconTab={true}
               tabs={forecastData.breakdownTabs.map((header, i) => ({
                 item: header,
                 id: forecastData.headerIds[i],

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -260,11 +260,11 @@ const Tabs: React.FC<TabsProps> = ({
           >
             {expanded ? (
               <TabPopover id={'expanded-view-popover'} title={expandToolTip?.compressed}>
-                <ArrowExpand width={24} height={24} />
+                <ArrowExpand width={24} height={24} key="expanded-view-popover" />
               </TabPopover>
             ) : (
               <TabPopover id={'compressed-view-popover'} title={expandToolTip?.default}>
-                <ArrowCollapseStyled width={24} height={24} />
+                <ArrowCollapseStyled width={24} height={24} key="compressed-view-popover" />
               </TabPopover>
             )}
           </StyledTabIcon>
@@ -330,7 +330,8 @@ const StyledTab = styled(Tab)<{ isFirst?: boolean; additionalStyles?: React.CSSP
 
 const ArrowCollapseStyled = styled(ArrowCollapse)(({ theme }) => ({
   '& path': {
-    fill: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+    // Note use important to override styles in StyledTab
+    fill: `${theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50]} !important`,
   },
 }));
 
@@ -346,6 +347,6 @@ const StyledTabIcon = styled(StyledTab)<{ expanded: boolean; showBorderBottomIco
             ? 'transparent'
             : theme.palette.colors.gray[50]
         }`
-      : 'none',
+      : 'transparent',
   })
 );

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -63,6 +63,8 @@ export interface TabsProps {
   selectedTabId?: string;
   // Customize
   className?: string;
+  // When compress the icon its the only select there is not more values
+  showBorderBottomIconTab?: boolean;
 }
 
 const Tabs: React.FC<TabsProps> = ({
@@ -79,6 +81,7 @@ const Tabs: React.FC<TabsProps> = ({
   expandToolTip,
   tabQuery = 'tab',
   viewKey = 'view',
+  showBorderBottomIconTab = false,
   viewValues = {
     default: 'default',
     compressed: 'compressed',
@@ -248,17 +251,23 @@ const Tabs: React.FC<TabsProps> = ({
           </StyledTab>
         ))}
         {expandable && (
-          <StyledTab active={false} additionalStyles={{ paddingBottom: 7 }} onClick={handleExpand}>
+          <StyledTabIcon
+            showBorderBottomIconTab={showBorderBottomIconTab}
+            expanded={expanded}
+            active={false}
+            additionalStyles={{ paddingBottom: 7 }}
+            onClick={handleExpand}
+          >
             {expanded ? (
               <TabPopover id={'expanded-view-popover'} title={expandToolTip?.compressed}>
                 <ArrowExpand width={24} height={24} />
               </TabPopover>
             ) : (
               <TabPopover id={'compressed-view-popover'} title={expandToolTip?.default}>
-                <ArrowCollapse width={24} height={24} />
+                <ArrowCollapseStyled width={24} height={24} />
               </TabPopover>
             )}
-          </StyledTab>
+          </StyledTabIcon>
         )}
       </Container>
     </Wrapper>
@@ -316,5 +325,27 @@ const StyledTab = styled(Tab)<{ isFirst?: boolean; additionalStyles?: React.CSSP
     [theme.breakpoints.up('desktop_1024')]: {
       marginRight: isFirst ? 40 : undefined,
     },
+  })
+);
+
+const ArrowCollapseStyled = styled(ArrowCollapse)(({ theme }) => ({
+  '& path': {
+    fill: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+  },
+}));
+
+const StyledTabIcon = styled(StyledTab)<{ expanded: boolean; showBorderBottomIconTab?: boolean }>(
+  ({ theme, expanded, showBorderBottomIconTab = false }) => ({
+    borderBottom: showBorderBottomIconTab
+      ? `2px solid ${
+          theme.palette.isLight
+            ? expanded
+              ? 'transparent'
+              : theme.palette.colors.gray[900]
+            : expanded
+            ? 'transparent'
+            : theme.palette.colors.gray[50]
+        }`
+      : 'none',
   })
 );


### PR DESCRIPTION
## Ticket
https://trello.com/c/64GRv7Lz/501-reskin-budget-statements-cu-ea-auditor-view

## What solved
- [X] Should update the Forecast Breakdown section (title + tabs: collapsed/expanded) for light/dark mode

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
