### PR TITLE
Mobile chart in the overview section

### DIFF
--- a/src/views/Finances/FinancesView.tsx
+++ b/src/views/Finances/FinancesView.tsx
@@ -94,7 +94,7 @@ const FinancesView: React.FC<Props> = ({ budgets, allBudgets, yearsRange, initia
               paymentsOnChain={cardOverViewSectionData.paymentsOnChain}
               budgetCap={cardOverViewSectionData.budgetCap}
               selectedMetric={cardOverViewSectionData.selectedMetric}
-              doughnutSeriesData={cardOverViewSectionData.doughnutSeriesData}
+              seriesData={cardOverViewSectionData.doughnutSeriesData}
               isCoreThirdLevel={levelNumber >= 3}
               changeAlignment={cardOverViewSectionData.changeAlignment}
               showSwiper={cardOverViewSectionData.showSwiper}

--- a/src/views/Finances/components/SectionPages/OverviewSection/OverviewSection.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/OverviewSection.tsx
@@ -1,13 +1,13 @@
 import { styled } from '@mui/material';
 import type { AnalyticMetric } from '@/core/models/interfaces/analytic';
 import type { DoughnutSeries } from '@/views/Finances/utils/types';
-import DoughnutChartFinances from '../CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinances';
 import BudgetUtilizationCard from './BudgetUtilizationCard/BudgetUtilizationCard';
+import UtilizationChart from './UtilizationChart/UtilizationChart';
 
 interface OverviewSectionProps {
   paymentsOnChain: number;
   budgetCap: number;
-  doughnutSeriesData: DoughnutSeries[];
+  seriesData: DoughnutSeries[];
   isCoreThirdLevel: boolean;
   changeAlignment: boolean;
   showSwiper: boolean;
@@ -18,24 +18,25 @@ interface OverviewSectionProps {
 const OverviewSection: React.FC<OverviewSectionProps> = ({
   paymentsOnChain,
   budgetCap,
-  changeAlignment,
-  doughnutSeriesData,
-  isCoreThirdLevel,
-  selectedMetric,
-  showSwiper,
-  numberSliderPerLevel,
+  seriesData,
+  // changeAlignment,
+  // isCoreThirdLevel,
+  // selectedMetric,
+  // showSwiper,
+  // numberSliderPerLevel,
 }) => (
   <MainContentSection>
     <BudgetUtilizationCard paymentsOnChain={paymentsOnChain} budgetCap={budgetCap} />
 
-    <DoughnutChartFinances
+    <UtilizationChart seriesData={seriesData} />
+    {/* <DoughnutChartFinances
       doughnutSeriesData={doughnutSeriesData}
       isCoreThirdLevel={isCoreThirdLevel}
       changeAlignment={changeAlignment}
       showSwiper={showSwiper}
       numberSliderPerLevel={numberSliderPerLevel}
       selectedMetric={selectedMetric}
-    />
+    /> */}
   </MainContentSection>
 );
 

--- a/src/views/Finances/components/SectionPages/OverviewSection/OverviewSection.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/OverviewSection.tsx
@@ -19,6 +19,8 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
   paymentsOnChain,
   budgetCap,
   seriesData,
+  // NOTICE: for reviewers, the following commented code is a WIP and it is going to be used
+  // right after the merge of the PR that is currently being reviewed.
   // changeAlignment,
   // isCoreThirdLevel,
   // selectedMetric,
@@ -27,16 +29,7 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
 }) => (
   <MainContentSection>
     <BudgetUtilizationCard paymentsOnChain={paymentsOnChain} budgetCap={budgetCap} />
-
     <UtilizationChart seriesData={seriesData} />
-    {/* <DoughnutChartFinances
-      doughnutSeriesData={doughnutSeriesData}
-      isCoreThirdLevel={isCoreThirdLevel}
-      changeAlignment={changeAlignment}
-      showSwiper={showSwiper}
-      numberSliderPerLevel={numberSliderPerLevel}
-      selectedMetric={selectedMetric}
-    /> */}
   </MainContentSection>
 );
 

--- a/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/FilterTabs/FilterTabs.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/FilterTabs/FilterTabs.tsx
@@ -1,0 +1,90 @@
+import { styled } from '@mui/material';
+
+interface FilterTabsProps {
+  tabs: string[];
+  activeTab: string;
+  onChangeTab: (tab: string) => void;
+}
+
+const FilterTabs: React.FC<FilterTabsProps> = ({ tabs, activeTab, onChangeTab }) => (
+  <Wrapper className="no-select">
+    <TabContainer>
+      {tabs.map((tab) => (
+        <Tab key={tab} onClick={() => onChangeTab(tab)} active={activeTab === tab}>
+          {tab}
+        </Tab>
+      ))}
+    </TabContainer>
+  </Wrapper>
+);
+
+export default FilterTabs;
+
+const Wrapper = styled('div')(() => ({
+  position: 'relative',
+  maxWidth: '100%',
+  boxShadow: '1px 0px 15px 0px rgba(117, 117, 117, 0.15)',
+}));
+
+const TabContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  width: '100%',
+  overflowX: 'scroll',
+  msOverflowStyle: 'none',
+  scrollbarWidth: 'none',
+
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
+
+  [theme.breakpoints.up('tablet_768')]: {
+    flexDirection: 'column',
+    gap: 8,
+    padding: '14px 0',
+    minWidth: 192,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    minWidth: 205,
+  },
+}));
+
+const Tab = styled('div')<{ active: boolean }>(({ theme, active }) => ({
+  fontSize: 12,
+  fontWeight: active ? 700 : 500,
+  lineHeight: active ? '18px' : '22px',
+  color: active
+    ? theme.palette.isLight
+      ? theme.palette.colors.gray[900]
+      : theme.palette.colors.gray[500]
+    : theme.palette.isLight
+    ? theme.palette.colors.gray[500]
+    : 'red',
+  background: active ? (theme.palette.isLight ? theme.palette.colors.slate[50] : 'red') : 'transparent',
+  whiteSpace: 'nowrap',
+  padding: `8px 8px ${active ? 8 : 4}px`,
+  cursor: 'pointer',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    padding: '2px 24px',
+    lineHeight: '22px',
+    position: 'relative',
+
+    '&:before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: 4,
+      height: '100%',
+      borderRadius: '0px 4px 4px 0px',
+      background: active ? (theme.palette.isLight ? theme.palette.colors.gray[900] : 'red') : 'transparent',
+    },
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    fontSize: 14,
+    lineHeight: '22px',
+    padding: '2px 16px 2px 24px',
+  },
+}));

--- a/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/MobileChart/LegendItem.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/MobileChart/LegendItem.tsx
@@ -1,0 +1,75 @@
+import { styled } from '@mui/material';
+import { threeDigitsPrecisionHumanization, usLocalizedNumber } from '@/core/utils/humanization';
+
+interface LegendItemProps {
+  inline: boolean;
+  name: string;
+  code?: string;
+  color: string;
+  value: number;
+  percentage: number;
+}
+
+const LegendItem: React.FC<LegendItemProps> = ({ inline = false, name, code, color, value, percentage }) => {
+  const valueFormatted = threeDigitsPrecisionHumanization(value);
+
+  return (
+    <LegendContainer inline={inline} color={color}>
+      <Name>{inline ? code ?? name : name}</Name>
+      <Line>
+        <Percentage>({usLocalizedNumber(percentage, 0)}%)</Percentage>
+        <Value>
+          {valueFormatted.value} {valueFormatted.suffix}
+        </Value>
+      </Line>
+    </LegendContainer>
+  );
+};
+
+export default LegendItem;
+
+const LegendContainer = styled('div')<{ inline: boolean; color: string }>(({ inline, color }) => ({
+  display: 'flex',
+  flexDirection: inline ? 'row' : 'column',
+  gap: 4,
+  position: 'relative',
+  paddingLeft: 14,
+  lineHeight: inline ? '15px' : '18px',
+
+  '&::before': {
+    content: '""',
+    display: 'inline-block',
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    backgroundColor: color,
+    position: 'absolute',
+    left: 0,
+    top: inline ? 3.5 : 8,
+  },
+}));
+
+const Name = styled('div')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 600,
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : 'red',
+}));
+
+const Line = styled('div')(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  fontSize: 12,
+  fontWeight: 500,
+  lineHeight: 'normal',
+}));
+
+const Percentage = styled('span')(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.gray[500] : 'red',
+}));
+
+const Value = styled('span')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 600,
+  color: theme.palette.isLight ? theme.palette.colors.gray[600] : 'red',
+}));

--- a/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/MobileChart/MobileChart.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/MobileChart/MobileChart.tsx
@@ -1,6 +1,7 @@
 import { styled } from '@mui/material';
 import { useMemo } from 'react';
 import type { DoughnutSeries } from '@/views/Finances/utils/types';
+import LegendItem from './LegendItem';
 
 interface MobileChartProps {
   seriesData: DoughnutSeries[];
@@ -23,7 +24,21 @@ const MobileChart: React.FC<MobileChartProps> = ({ seriesData }) => {
           <Bar key={item.name} color={item.color} height={item.percentage} />
         ))}
       </BarContainer>
-      <LegendsContainer>legends</LegendsContainer>
+      <LegendsWrapper>
+        <LegendContainer>
+          {seriesData.map((item) => (
+            <LegendItem
+              key={item.name}
+              inline={seriesData.length > 4}
+              name={item.name}
+              code={item.code}
+              color={item.color}
+              value={item.value}
+              percentage={item.percent}
+            />
+          ))}
+        </LegendContainer>
+      </LegendsWrapper>
     </Wrapper>
   );
 };
@@ -38,7 +53,8 @@ const Wrapper = styled('div')(() => ({
 const BarContainer = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
-  height: 192,
+  alignSelf: 'stretch',
+  minHeight: 192,
   width: 32,
   borderRadius: 8,
   overflow: 'hidden',
@@ -50,7 +66,7 @@ const Bar = styled('div')<{ color: string; height: number }>(({ color, height })
   width: '100%',
 }));
 
-const LegendsContainer = styled('div')(({ theme }) => ({
+const LegendsWrapper = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
@@ -58,5 +74,12 @@ const LegendsContainer = styled('div')(({ theme }) => ({
   borderRadius: 12,
   background: theme.palette.isLight ? theme.palette.colors.slate[50] : 'red',
   width: '100%',
-  height: 192,
+  minHeight: 192,
+  padding: 16,
+}));
+
+const LegendContainer = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
 }));

--- a/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/MobileChart/MobileChart.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/MobileChart/MobileChart.tsx
@@ -1,0 +1,62 @@
+import { styled } from '@mui/material';
+import { useMemo } from 'react';
+import type { DoughnutSeries } from '@/views/Finances/utils/types';
+
+interface MobileChartProps {
+  seriesData: DoughnutSeries[];
+}
+
+const MobileChart: React.FC<MobileChartProps> = ({ seriesData }) => {
+  const series = useMemo(() => {
+    const total = seriesData.reduce((acc, item) => acc + item.value, 0);
+
+    return seriesData.map((item) => ({
+      ...item,
+      percentage: (item.value / total) * 100,
+    }));
+  }, [seriesData]);
+
+  return (
+    <Wrapper>
+      <BarContainer>
+        {series.map((item) => (
+          <Bar key={item.name} color={item.color} height={item.percentage} />
+        ))}
+      </BarContainer>
+      <LegendsContainer>legends</LegendsContainer>
+    </Wrapper>
+  );
+};
+
+export default MobileChart;
+
+const Wrapper = styled('div')(() => ({
+  display: 'flex',
+  gap: 16,
+}));
+
+const BarContainer = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  height: 192,
+  width: 32,
+  borderRadius: 8,
+  overflow: 'hidden',
+}));
+
+const Bar = styled('div')<{ color: string; height: number }>(({ color, height }) => ({
+  backgroundColor: color,
+  height: `${height}%`,
+  width: '100%',
+}));
+
+const LegendsContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderRadius: 12,
+  background: theme.palette.isLight ? theme.palette.colors.slate[50] : 'red',
+  width: '100%',
+  height: 192,
+}));

--- a/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/UtilizationChart.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/UtilizationChart.tsx
@@ -1,0 +1,41 @@
+import { styled, useMediaQuery } from '@mui/material';
+import { useState } from 'react';
+import Card from '@/components/Card/Card';
+import type { DoughnutSeries } from '@/views/Finances/utils/types';
+import FilterTabs from './FilterTabs/FilterTabs';
+import MobileChart from './MobileChart/MobileChart';
+import type { Theme } from '@mui/material';
+
+interface UtilizationChartProps {
+  seriesData: DoughnutSeries[];
+}
+
+const UtilizationChart: React.FC<UtilizationChartProps> = ({ seriesData }) => {
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
+  const [activeTab, setActiveTab] = useState('Budget');
+
+  return (
+    <CardContainer>
+      <FilterTabs
+        tabs={['Budget', 'Forecast', 'Net Protocol Outflow', 'Net Expenses On-chain', 'Actuals']}
+        activeTab={activeTab}
+        onChangeTab={(tab: string) => setActiveTab(tab)}
+      />
+      <Content>{isMobile ? <MobileChart seriesData={seriesData} /> : <div>Chart</div>}</Content>
+    </CardContainer>
+  );
+};
+
+export default UtilizationChart;
+
+const CardContainer = styled(Card)(({ theme }) => ({
+  overflow: 'hidden',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    flexDirection: 'row',
+  },
+}));
+
+const Content = styled('div')(() => ({
+  padding: '8px 16px 16px',
+}));


### PR DESCRIPTION
## Ticket
https://trello.com/c/lHsgd1Nv/485-reskin-finances-main-section

## Description
Implemented base for the mobile chart in the overview section

## What solved

- [X] Should update the pie chart card for light/dark mode. Desktop resolutions.
- [X] Should update the pie chart card for light/dark mode. Small resolutions.
- [X] Should update the pie chart card for light/dark mode. Small resolutions. 
- [X] Should update the metrics background and the texts (status: default, hover, selected) for light/dark mode. Desktop resolutions. 
- [X] Should update the metrics background and the texts (status: default, selected) for light/dark mode. Small resolutions.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
