### PR TITLE
[Reskin-501] Add the styles for forecast

### DIFF
--- a/src/components/BudgetStatement/BudgetStatementForecast/BarWithDottedLine.tsx
+++ b/src/components/BudgetStatement/BudgetStatementForecast/BarWithDottedLine.tsx
@@ -50,7 +50,6 @@ const BarWithDottedLine: React.FC<Props> = ({ value, relativeValue, month, isTot
         <BudgetBar>{<BarPercent width={percent} color={barColor} />}</BudgetBar>
 
         <SESTooltipStyled
-          showAsModal
           borderColor={borderColor}
           content={<PopoverForecastDescription relativeValue={relativeValue} value={value} month={monthFormatted} />}
         >

--- a/src/components/BudgetStatement/ExpenseReport/ExpenseReport.tsx
+++ b/src/components/BudgetStatement/ExpenseReport/ExpenseReport.tsx
@@ -213,7 +213,7 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
         />
       </MkExpenseSection>
 
-      <ExpenseSection title={'Transfer Request'}>
+      <ExpenseSectionStyled title={'Transfer Request'}>
         <BudgetTable
           cardSpacingSize="small"
           columns={transferRequestsData.mainTableColumns}
@@ -222,16 +222,14 @@ const ExpenseReport: React.FC<ExpenseReportProps> = ({ currentMonth, budgetState
           longCode={longCode}
           tablePlaceholder={<BudgetStatementsPlaceholder longCode={longCode} shortCode={code} resource={resource} />}
         />
-      </ExpenseSection>
+      </ExpenseSectionStyled>
     </ExpenseReportWrapper>
   );
 };
 
 export default ExpenseReport;
 
-const ExpenseReportWrapper = styled('div')({
-  marginBottom: 32,
-});
+const ExpenseReportWrapper = styled('div')({});
 
 const BudgetTable = styled((props: React.ComponentProps<typeof AdvancedInnerTable>) => (
   <AdvancedInnerTable {...props} />
@@ -298,3 +296,9 @@ const MkExpenseSection = styled(ExpenseSection)({
     lineHeight: '21.6px',
   },
 });
+
+const ExpenseSectionStyled = styled(ExpenseSection)(() => ({
+  '& > div': {
+    marginBottom: 0,
+  },
+}));

--- a/src/components/BudgetStatement/ExpenseReport/components/ExpenseSection/ExpenseSection.tsx
+++ b/src/components/BudgetStatement/ExpenseReport/components/ExpenseSection/ExpenseSection.tsx
@@ -71,6 +71,7 @@ const WrapperL1 = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('tablet_768')]: {
     background: theme.palette.isLight ? theme.palette.colors.gray[100] : '#1E222A',
     padding: '8px 0 24px',
+    marginBottom: 0,
   },
 }));
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/64GRv7Lz/501-reskin-budget-statements-cu-ea-auditor-view

## What solved

- [X] Should update the breakdown table styles (table, text, values) for light/dark mode. Desktop resolutions. 
- [X]  Should update the breakdown table styles (table, text, values) for light/dark mode. Small resolutions. 
- [X] Should update the MKRVesting section for light/dark mode. Desktop resolutions.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
