### PR TITLE
Add the background to the auditor card comments

### DIFF
--- a/src/components/BudgetStatement/BudgetStatementAuditorComments/AuditorCommentsContainer/AuditorCommentsContainer.tsx
+++ b/src/components/BudgetStatement/BudgetStatementAuditorComments/AuditorCommentsContainer/AuditorCommentsContainer.tsx
@@ -71,7 +71,7 @@ const CommentsContainer = styled('div')(({ theme }) => ({
   },
 
   [theme.breakpoints.up('desktop_1440')]: {
-    width: 'calc(100% - 368px)',
+    width: 'calc(100% - 336px)',
   },
 }));
 
@@ -97,5 +97,8 @@ const ParticipantsColumn = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('desktop_1280')]: {
     width: 276,
     marginLeft: 32,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    width: 304,
   },
 }));

--- a/src/components/BudgetStatement/BudgetStatementAuditorComments/ParticipantRoles.tsx
+++ b/src/components/BudgetStatement/BudgetStatementAuditorComments/ParticipantRoles.tsx
@@ -93,7 +93,7 @@ const RoleSection = styled('div')(({ theme }) => ({
   gap: 16,
   borderRadius: 8,
   border: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[200] : theme.palette.colors.charcoal[800]}`,
-
+  backgroundColor: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.charcoal[900],
   '&:not(:last-child)': {
     marginBottom: 32,
   },


### PR DESCRIPTION

## Ticket
https://trello.com/c/lYYlK9W4/551-apply-background-to-the-participant-roles-in-the-comments-view

## What solved

- [X] Should apply the background in the Participant section as it is displayed on the About page.
- [X] Should increase the width of the Participant Roles section to 304px and make sure it is aligned with the above elements.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
