### PR TITLE
[FIX-554] Avoid show tooltip for mobile

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -65,6 +65,7 @@ export interface TabsProps {
   className?: string;
   // When compress the icon its the only select there is not more values
   showBorderBottomIconTab?: boolean;
+  isDisablePopover?: boolean;
 }
 
 const Tabs: React.FC<TabsProps> = ({
@@ -89,6 +90,7 @@ const Tabs: React.FC<TabsProps> = ({
   controlled = false,
   selectedTabId,
   className,
+  isDisablePopover = false,
 }) => {
   const router = useRouter();
   const query = router.query;
@@ -259,13 +261,19 @@ const Tabs: React.FC<TabsProps> = ({
             onClick={handleExpand}
           >
             {expanded ? (
-              <TabPopover id={'expanded-view-popover'} title={expandToolTip?.compressed}>
+              !isDisablePopover ? (
+                <TabPopover id="expanded-view-popover" title={expandToolTip?.compressed}>
+                  <ArrowExpand width={24} height={24} key="expanded-view-popover" />
+                </TabPopover>
+              ) : (
                 <ArrowExpand width={24} height={24} key="expanded-view-popover" />
-              </TabPopover>
-            ) : (
-              <TabPopover id={'compressed-view-popover'} title={expandToolTip?.default}>
+              )
+            ) : !isDisablePopover ? (
+              <TabPopover id="compressed-view-popover" title={expandToolTip?.default}>
                 <ArrowCollapseStyled width={24} height={24} key="compressed-view-popover" />
               </TabPopover>
+            ) : (
+              <ArrowCollapseStyled width={24} height={24} key="compressed-view-popover" />
             )}
           </StyledTabIcon>
         )}

--- a/src/views/CoreUnitBudgetStatement/CoreUnitBudgetStatementView.tsx
+++ b/src/views/CoreUnitBudgetStatement/CoreUnitBudgetStatementView.tsx
@@ -69,6 +69,7 @@ const CoreUnitBudgetStatementView = ({
     compressedTabItems,
     setSnapshotCreated,
     pager,
+    isDisablePopoverForMobile,
   } = useCoreUnitBudgetStatementView(coreUnit, coreUnits, snapshotLimitPeriods);
 
   const headline = <CuHeadlineText cuLongCode={longCode} shortCode={coreUnit.shortCode} />;
@@ -134,6 +135,7 @@ const CoreUnitBudgetStatementView = ({
 
           <TabsContainer>
             <TabsStyled
+              isDisablePopover={isDisablePopoverForMobile}
               tabs={tabItems}
               expandable
               compressedTabs={compressedTabItems}

--- a/src/views/CoreUnitBudgetStatement/useCoreUnitBudgetStatementView.tsx
+++ b/src/views/CoreUnitBudgetStatement/useCoreUnitBudgetStatementView.tsx
@@ -1,9 +1,11 @@
+import { useMediaQuery } from '@mui/material';
 import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
 import useTransparencyReporting from '@ses/core/hooks/useTransparencyReporting';
 import useTransparencyReportingTabs from '@ses/core/hooks/useTransparencyReportingTabs';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useState } from 'react';
 import { useBreadcrumbCoreUnitPager } from '../CoreUnitAbout/hooks';
+import type { Theme } from '@mui/material';
 import type { SnapshotLimitPeriods } from '@ses/core/hooks/useBudgetStatementPager';
 import type { CoreUnit } from '@ses/core/models/interfaces/coreUnit';
 import type { DateTime } from 'luxon';
@@ -27,6 +29,8 @@ export const useCoreUnitBudgetStatementView = (
   const router = useRouter();
   const query = router.query;
   const [isEnabled] = useFlagsActive();
+
+  const isDisablePopoverForMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
 
   const initTabIndex = useCallback(() => {
     // initialize quickly the correct tab to avoid tab flickering
@@ -133,5 +137,6 @@ export const useCoreUnitBudgetStatementView = (
     longCode: coreUnit.code,
     setSnapshotCreated,
     pager,
+    isDisablePopoverForMobile,
   };
 };

--- a/src/views/EcosystemActorBudgetStatement/EcosystemActorBudgetStatementView.tsx
+++ b/src/views/EcosystemActorBudgetStatement/EcosystemActorBudgetStatementView.tsx
@@ -62,6 +62,7 @@ const EcosystemActorBudgetStatementView: React.FC<EcosystemActorBudgetStatementV
     comments,
     setSnapshotCreated,
     pager,
+    isDisablePopoverForMobile,
   } = useEcosystemActorBudgetStatementView(actor, actors, snapshotLimitPeriods);
 
   const headline = <CuHeadlineText cuLongCode={actor.code} isCoreUnit={false} shortCode={actor.shortCode} />;
@@ -126,6 +127,7 @@ const EcosystemActorBudgetStatementView: React.FC<EcosystemActorBudgetStatementV
 
           <TabsContainer>
             <Tabs
+              isDisablePopover={isDisablePopoverForMobile}
               tabs={tabItems}
               expandable
               compressedTabs={compressedTabItems}

--- a/src/views/EcosystemActorBudgetStatement/useEcosystemActorBudgetStatementView.tsx
+++ b/src/views/EcosystemActorBudgetStatement/useEcosystemActorBudgetStatementView.tsx
@@ -1,3 +1,4 @@
+import { useMediaQuery } from '@mui/material';
 import { useFlagsActive } from '@ses/core/hooks/useFlagsActive';
 import useTransparencyReporting from '@ses/core/hooks/useTransparencyReporting';
 import useTransparencyReportingTabs from '@ses/core/hooks/useTransparencyReportingTabs';
@@ -5,6 +6,7 @@ import { useRouter } from 'next/router';
 import { useCallback, useEffect, useState } from 'react';
 import { TRANSPARENCY_IDS_ENUM } from '../CoreUnitBudgetStatement/useCoreUnitBudgetStatementView';
 import { useBreadcrumbTeamPager } from '../EcosystemActorAbout/hooks';
+import type { Theme } from '@mui/material';
 import type { SnapshotLimitPeriods } from '@ses/core/hooks/useBudgetStatementPager';
 import type { Team } from '@ses/core/models/interfaces/team';
 import type { DateTime } from 'luxon';
@@ -17,6 +19,8 @@ const useEcosystemActorBudgetStatementView = (
   const router = useRouter();
   const query = router.query;
   const [isEnabled] = useFlagsActive();
+
+  const isDisablePopoverForMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
 
   const initTabIndex = useCallback(() => {
     // initialize quickly the correct tab to avoid tab flickering
@@ -121,6 +125,7 @@ const useEcosystemActorBudgetStatementView = (
     comments,
     setSnapshotCreated,
     pager,
+    isDisablePopoverForMobile,
   };
 };
 


### PR DESCRIPTION


## Ticket
https://trello.com/c/7g6oATpI/554-fix-general-issues-in-cu-ea-contributors-endgame-views



## What solved

- [X] Remove the tooltip in when is mobile for Auditor View
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
