### PR TITLE
[Fix-559] Avoid redirect to core unit from the activity feed button

### DIFF
--- a/src/views/CoreUnitsIndex/useCoreUnitsTableView.tsx
+++ b/src/views/CoreUnitsIndex/useCoreUnitsTableView.tsx
@@ -39,7 +39,7 @@ export const useCoreUnitsTableView = (coreUnits: CoreUnit[]) => {
   const theme = useTheme();
   const [searchText, setSearchText] = useState('');
   const deferredSearchText = useDeferredValue(searchText);
-  const previousSearchTextRef = useRef<string | null>(null);
+  const previousSearchTextRef = useRef<string | null>('');
 
   const filteredStatuses = useMemo(() => getArrayParam('filteredStatuses', router.query), [router.query]);
   const filteredCategories = useMemo(() => getArrayParam('filteredCategories', router.query), [router.query]);
@@ -434,6 +434,7 @@ export const useCoreUnitsTableView = (coreUnits: CoreUnit[]) => {
       pathname: siteRoutes.coreUnitsOverview,
       search: stringify(newQuery),
     });
+    setSearchText('');
   };
 
   return {


### PR DESCRIPTION
## Ticket
https://trello.com/c/gpE4auII/559-fix-redirect-issue-in-core-units-activity-feed-view

## What solved

- [X] Should .make it possible to navigate to the CU Activity Feed page properly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook
