### PR TITLE
[Fix-560] Redirect issue in core units activity feed view

### DIFF
--- a/src/views/CoreUnitsIndex/useCoreUnitsTableView.tsx
+++ b/src/views/CoreUnitsIndex/useCoreUnitsTableView.tsx
@@ -39,7 +39,7 @@ export const useCoreUnitsTableView = (coreUnits: CoreUnit[]) => {
   const theme = useTheme();
   const [searchText, setSearchText] = useState('');
   const deferredSearchText = useDeferredValue(searchText);
-  const previousSearchTextRef = useRef<string | null>(null);
+  const previousSearchTextRef = useRef<string | null>('');
 
   const filteredStatuses = useMemo(() => getArrayParam('filteredStatuses', router.query), [router.query]);
   const filteredCategories = useMemo(() => getArrayParam('filteredCategories', router.query), [router.query]);
@@ -434,6 +434,7 @@ export const useCoreUnitsTableView = (coreUnits: CoreUnit[]) => {
       pathname: siteRoutes.coreUnitsOverview,
       search: stringify(newQuery),
     });
+    setSearchText('');
   };
 
   return {

--- a/src/views/EcosystemActorsIndex/useEcosystemActorsIndexView.tsx
+++ b/src/views/EcosystemActorsIndex/useEcosystemActorsIndexView.tsx
@@ -412,6 +412,7 @@ export const useEcosystemActorsIndexView = (actors: Team[], stories = false) => 
       pathname: siteRoutes.ecosystemActors,
       search: stringify(newQuery),
     });
+    setSearchText('');
   };
 
   return {

--- a/src/views/Home/components/Contributors/TabDescriptions.tsx
+++ b/src/views/Home/components/Contributors/TabDescriptions.tsx
@@ -26,10 +26,10 @@ const Container = styled('div')<{ isLegacy?: boolean }>(({ theme, isLegacy = fal
   gap: 8,
   height: '100%',
   padding: 0,
-  paddingTop: 8,
-  paddingBottom: 8,
   backgroundColor: 'transparent',
   ...(isLegacy && {
+    paddingBottom: 8,
+    paddingTop: 8,
     borderRadius: 12,
     backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
   }),


### PR DESCRIPTION
## Ticket
https://trello.com/c/NrvjMpYJ/560-fix-reset-functionality-in-the-cu-ea-index


## What solved

- [X] Should make it possible to clean the search field when the reset option is clicked. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
