### PR TITLE
[Home-537] Add the tooltip in the line chart

### DIFF
--- a/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.tsx
+++ b/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.tsx
@@ -131,7 +131,7 @@ const FinancesBarChartContainer = styled('div')(({ theme }) => ({
 
 const AnnualProfit = styled('div')(({ theme }) => ({
   display: 'flex',
-  justifyContent: 'space-between',
+  justifyContent: 'flex-end',
 
   [theme.breakpoints.up('tablet_768')]: {
     paddingLeft: 49,

--- a/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
+++ b/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
@@ -1,6 +1,8 @@
 import { styled, useMediaQuery, useTheme } from '@mui/material';
 import ReactECharts from 'echarts-for-react';
+import { usLocalizedNumber } from '@/core/utils/humanization';
 import { replaceAllNumberLetOneBeforeDot } from '@/core/utils/string';
+import type { BarChartSeries } from '@/views/Finances/utils/types';
 import useFinancesLineChart from './useFinancesLineChart';
 import type { FormattedFinancesData, MetricKey } from '../../api/finances';
 import type { Theme } from '@mui/material';
@@ -146,6 +148,61 @@ const FinancesLineChart: FC<FinancesLineChartProps> = ({ financesData, selectedM
       right: 10,
       bottom: 20,
       left: isMobile ? 40 : 45,
+    },
+    tooltip: {
+      show: true,
+      trigger: 'axis',
+      borderRadius: 12,
+      backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
+
+      axisPointer: {
+        type: 'shadow',
+        shadowStyle: {
+          color: theme.palette.isLight ? '#D4D9E1' : '#231536',
+          opacity: 0.15,
+        },
+      },
+      padding: 0,
+      borderColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
+      formatter: function (params: BarChartSeries[]) {
+        const shortAmount = params.length > 10;
+        const flexDirection = shortAmount ? 'row' : 'column';
+        const gap = 8;
+        return `
+          <div style="background-color:${
+            theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800]
+          };box-shadow:${
+          theme.palette.isLight ? theme.fusionShadows.graphShadow : 'none'
+        };padding:8px 16px 8px 16px;min-width:194px;overflow:auto;border-radius:12px; font-family:Inter ,sans-serif">
+            <div style="margin-bottom:8px;font-size:16px;font-weight:600;color:#8391A7";line-height:24px;>${
+              params?.[0]?.name
+            }</div>
+            <div style="display:flex;flex-direction:${flexDirection};gap:${gap}px;min-width:194px;max-width:450px;flex-wrap:wrap;">
+              ${params
+                .reverse()
+                .map(
+                  (item) =>
+                    `<div style="display: flex;align-items:center;gap: 4px">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="${isMobile ? 13 : 16}" height="${
+                      isMobile ? 13 : 16
+                    }" viewBox="0 0 13 13" fill="none">
+                    <circle cx="6.5" cy="6.5" r="4" fill="${item.color}" />
+                  </svg>
+                  <span style="font-size:14px;font-weight:600;line-height:22px;color:${
+                    theme.palette.isLight ? '#9DA6B9' : '#B6BCC2'
+                  };max-width:350px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"> ${
+                      item.seriesName
+                    }:</span>
+                  <span style="font-size:14px;margin-left:4px;font-weight:600;line-height:22px;color:${
+                    theme.palette.isLight ? '#252A34' : '#EDEFFF'
+                  };">${usLocalizedNumber(item.value, 2)}</span>
+                </div>`
+                )
+                .join('')}
+            </div>
+          </div>
+          `;
+      },
     },
     xAxis: {
       data: ['Q1', 'Q2', 'Q3', 'Q4', 'Q1', 'Q2', 'Q3', 'Q4', 'Q1', 'Q2', 'Q3', 'Q4', 'Q1', 'Q2', 'Q3', 'Q4'],


### PR DESCRIPTION
## Ticket
https://trello.com/c/hvGVEox5/537-hom-12-finances-homepage-section

## What solved
- [X] Should add the tooltips (right side). [image.png]

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
