### PR TITLE
[Home-537] Add correct height for the button in line chart

### DIFF
--- a/src/views/Home/components/FinancesLineChartCard/FinancesLineChartCard.tsx
+++ b/src/views/Home/components/FinancesLineChartCard/FinancesLineChartCard.tsx
@@ -75,12 +75,12 @@ const FinancesLineChartCard: FC<FinancesLineChartCardProps> = ({ financesData })
             visibility: activeTab === ExpenseBreakdownFilterOptions.REALIZED_EXPENSES ? 'visible' : 'hidden',
           }}
         >
-          <FilterButtonTab
+          <FilterButtonTabStyled
             label={'Actuals'}
             handleChange={() => setRealizedExpensesFilter('Actuals')}
             isSelect={realizedExpensesFilter === 'Actuals'}
           />
-          <FilterButtonTab
+          <FilterButtonTabStyled
             label={'Payments'}
             handleChange={() => setRealizedExpensesFilter('Payments')}
             isSelect={realizedExpensesFilter === 'Payments'}
@@ -275,3 +275,12 @@ const ExternalButtonContainer = styled('div')(({ theme }) => ({
     marginTop: 16,
   },
 }));
+
+const FilterButtonTabStyled = styled(FilterButtonTab)({
+  height: 32,
+  '& div': {
+    fontSize: 16,
+    linHeight: '24px',
+    letterSpacing: '-0.32px',
+  },
+});


### PR DESCRIPTION

## Ticket
https://trello.com/c/hvGVEox5/537-hom-12-finances-homepage-section


## What solved

- [X] Should apply the proper size for the filters.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
